### PR TITLE
Improve ROS setup error handling

### DIFF
--- a/oasis_perception_cpp/src/pose/PoseLandmarker.cpp
+++ b/oasis_perception_cpp/src/pose/PoseLandmarker.cpp
@@ -27,6 +27,8 @@ bool PoseLandmarker::Initialize(const std::string& loggingName)
 
   // Full verbosity
   FLAGS_v = 3;
+
+  return true;
 }
 
 std::shared_ptr<sensor_msgs::msg::Image> PoseLandmarker::OnImage(

--- a/oasis_tooling/scripts/env_kodi.sh
+++ b/oasis_tooling/scripts/env_kodi.sh
@@ -39,7 +39,7 @@ source "${SCRIPT_DIR}/env_oasis.sh"
 #
 
 # Version
-KODI_VERSION="24daf8c689945f234b1b8382aa935f56498f169f"
+KODI_VERSION="17ed756d9550f23635ffa0bfb95fb60863390a2d"
 
 # URL
 KODI_URL="https://github.com/garbear/xbmc/archive/${KODI_VERSION}.tar.gz"

--- a/oasis_tooling/scripts/setup_ros2_desktop.sh
+++ b/oasis_tooling/scripts/setup_ros2_desktop.sh
@@ -46,9 +46,15 @@ if ! dpkg -s ros2-apt-source >/dev/null 2>&1; then
     curl \
     gnupg2
 
-  export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F"\"" '{print $4}')
+  ROS_APT_SOURCE_VERSION=$(curl -fs https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | \
+    grep -F "tag_name" | awk -F"\"" '{print $4}')
+  if [ -z "${ROS_APT_SOURCE_VERSION}" ]; then
+    echo "Failed to determine ros2-apt-source version" >&2
+    exit 1
+  fi
+
   TMP_DEB=$(mktemp --suffix .deb)
-  curl -L -o "${TMP_DEB}" "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb"
+  curl -fL -o "${TMP_DEB}" "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb"
   sudo dpkg -i "${TMP_DEB}"
   rm -f "${TMP_DEB}"
 fi

--- a/oasis_tooling/scripts/setup_ros2_desktop.sh
+++ b/oasis_tooling/scripts/setup_ros2_desktop.sh
@@ -28,24 +28,29 @@ source "${SCRIPT_DIR}/env_common.sh"
 # Setup ROS 2 sources
 ################################################################################
 
-KEY_URL="https://raw.githubusercontent.com/ros/rosdistro/master/ros.key"
-PKG_URL="http://packages.ros.org/ros2/ubuntu"
-SIGNED_BY="/usr/share/keyrings/ros-archive-keyring.gpg"
-SOURCES_LIST="/etc/apt/sources.list.d/ros2.list"
+# Remove any existing ROS apt sources added by older instructions
+sudo rm -f \
+  /etc/apt/sources.list.d/ros2-latest.list \
+  /etc/apt/sources.list.d/ros2.list
+sudo sed -i '/packages\.ros\.org\/ros2/d' /etc/apt/sources.list 2>/dev/null || true
+sudo find /etc/apt/sources.list.d -name '*.list' -exec \
+  sed -i '/packages\.ros\.org\/ros2/d' {} \; 2>/dev/null || true
+sudo rm -f \
+  /usr/share/keyrings/ros-archive-keyring.gpg \
+  /etc/apt/trusted.gpg.d/ros-archive-keyring.gpg
 
-# Add the ROS 2 repository
-if [ ! -f "${SIGNED_BY}" ] || [ ! -f ${SOURCES_LIST} ]; then
+# Add the ROS 2 repository using the ros2-apt-source package
+if ! dpkg -s ros2-apt-source >/dev/null 2>&1; then
   # Install required dependencies
   sudo apt install -y \
     curl \
     gnupg2
 
-  # Authorize the ROS 2 GPG key with apt
-  sudo curl -sSL "${KEY_URL}" -o "${SIGNED_BY}"
-
-  # Add the ROS 2 repository to our sources list
-  echo "deb [arch=${ARCH} signed-by=${SIGNED_BY}] ${PKG_URL} ${CODENAME} main" | \
-    sudo tee "${SOURCES_LIST}"
-
-  sudo apt update
+  export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F"\"" '{print $4}')
+  TMP_DEB=$(mktemp --suffix .deb)
+  curl -L -o "${TMP_DEB}" "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb"
+  sudo dpkg -i "${TMP_DEB}"
+  rm -f "${TMP_DEB}"
 fi
+
+sudo apt update


### PR DESCRIPTION
## Summary
- fix `setup_ros2_desktop.sh` so network errors stop the script

## Testing
- `tox -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688920be6f8c83268925372584760a30