### PR TITLE
Delay perception service start until 20s uptime

### DIFF
--- a/oasis_perception_py/config/systemd/oasis_perception.service
+++ b/oasis_perception_py/config/systemd/oasis_perception.service
@@ -39,6 +39,8 @@ Environment=OASIS_ENV=/home/${USER}/Documents/ros-ws/src/oasis/ros-ws/oasis-${RO
 # Service definition
 #
 
+# Ensure the system has been up for at least 20 seconds before launching perception
+ExecStartPre=/bin/bash -c 'while [ $(cut -d. -f1 /proc/uptime) -lt 20 ]; do sleep 1; done'
 # Need to run from oasis_perception_cpp for background subtractor to find configs
 ExecStart=/bin/bash -c 'set +o nounset && source `eval echo "${OASIS_ENV}"` && cd `eval echo "${OASIS_SRC}/oasis_perception_cpp"` && ros2 launch oasis_perception_py perception_launch.py'
 Restart=on-failure


### PR DESCRIPTION
## Summary
- add an ExecStartPre command that waits until system uptime reaches 20 seconds before launching perception

## Testing
- not run (service change only)


------
https://chatgpt.com/codex/tasks/task_b_68ca12363220832eb718ed8511b1943c