### PR TITLE
Ensure oasis_perception_cpp uses bundled OpenCV 4.12

### DIFF
--- a/oasis_perception_cpp/CMakeLists.txt
+++ b/oasis_perception_cpp/CMakeLists.txt
@@ -68,7 +68,12 @@ set(BGS_LIBRARIES
 )
 
 # TODO: Required by bgslibrary
-find_package(OpenCV REQUIRED)
+if(NOT DEFINED OpenCV_DIR AND DEFINED ENV{OpenCV_DIR})
+  # Allow the build to use the custom OpenCV toolchain that is bundled with OASIS
+  set(OpenCV_DIR $ENV{OpenCV_DIR})
+endif()
+
+find_package(OpenCV 4.12 REQUIRED)
 list(APPEND BGS_LIBRARIES ${OpenCV_LIBS})
 
 # Sources needed for MediaPipe

--- a/oasis_tooling/scripts/build_oasis.sh
+++ b/oasis_tooling/scripts/build_oasis.sh
@@ -27,6 +27,9 @@ source "${SCRIPT_DIR}/env_cmake.sh"
 # Import MediaPipe paths and config
 source "${SCRIPT_DIR}/env_mediapipe.sh"
 
+# Import OpenCV paths and config
+source "${SCRIPT_DIR}/env_opencv.sh"
+
 # Import OASIS paths and config
 source "${SCRIPT_DIR}/env_oasis.sh"
 
@@ -52,8 +55,22 @@ COLCON_FLAGS+=" \
     -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
 "
 
-# Expose the MediaPipe install directorie to CMake
-export CMAKE_PREFIX_PATH="${MEDIAPIPE_INSTALL_DIR}:${CMAKE_PREFIX_PATH}"
+# Expose the custom OpenCV build to CMake and downstream packages
+export OpenCV_DIR="${OPENCV_INSTALL_DIR}/lib/cmake/opencv4"
+export OpenCV_ROOT="${OPENCV_INSTALL_DIR}"
+
+if [ -n "${CMAKE_PREFIX_PATH:-}" ]; then
+  export CMAKE_PREFIX_PATH="${OPENCV_INSTALL_DIR}:${CMAKE_PREFIX_PATH}"
+else
+  export CMAKE_PREFIX_PATH="${OPENCV_INSTALL_DIR}"
+fi
+
+# Expose the MediaPipe install directories to CMake
+if [ -n "${CMAKE_PREFIX_PATH:-}" ]; then
+  export CMAKE_PREFIX_PATH="${MEDIAPIPE_INSTALL_DIR}:${CMAKE_PREFIX_PATH}"
+else
+  export CMAKE_PREFIX_PATH="${MEDIAPIPE_INSTALL_DIR}"
+fi
 
 # Uncomment these to force building in serial
 #MAKE_FLAGS+=" -j1 -l1"

--- a/oasis_tooling/scripts/build_oasis_deps.sh
+++ b/oasis_tooling/scripts/build_oasis_deps.sh
@@ -27,6 +27,9 @@ source "${SCRIPT_DIR}/env_cmake.sh"
 # Import OASIS dependency paths and config
 source "${SCRIPT_DIR}/env_oasis_deps.sh"
 
+# Import OpenCV paths and config
+source "${SCRIPT_DIR}/env_opencv.sh"
+
 #
 # Load ROS 2 environment
 #
@@ -56,6 +59,16 @@ COLCON_FLAGS+=" \
     -DCMAKE_C_COMPILER_LAUNCHER=ccache \
     -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
 "
+
+# Expose the custom OpenCV build to CMake
+export OpenCV_DIR="${OPENCV_INSTALL_DIR}/lib/cmake/opencv4"
+export OpenCV_ROOT="${OPENCV_INSTALL_DIR}"
+
+if [ -n "${CMAKE_PREFIX_PATH:-}" ]; then
+  export CMAKE_PREFIX_PATH="${OPENCV_INSTALL_DIR}:${CMAKE_PREFIX_PATH}"
+else
+  export CMAKE_PREFIX_PATH="${OPENCV_INSTALL_DIR}"
+fi
 
 # Uncomment these to force building in serial
 #MAKE_FLAGS+=" -j1 -l1"


### PR DESCRIPTION
## Summary
- require OpenCV 4.12 when building oasis_perception_cpp and honour the environment hint for the bundled toolchain
- expose the custom OpenCV installation to CMake during dependency and workspace builds so colcon picks up the new toolchain

## Testing
- bash -n oasis_tooling/scripts/build_oasis.sh
- bash -n oasis_tooling/scripts/build_oasis_deps.sh

------
https://chatgpt.com/codex/tasks/task_b_68d37f2ea470832ebf0e519f763977b4