### PR TITLE
Fix namespace definitions for optical flow kernels

### DIFF
--- a/oasis_perception_cpp/src/api/ImageProc.cpp
+++ b/oasis_perception_cpp/src/api/ImageProc.cpp
@@ -10,8 +10,8 @@
 
 #include <opencv2/gapi/imgproc.hpp>
 
-using namespace OASIS;
-using namespace IMAGE;
+namespace OASIS::IMAGE
+{
 
 cv::GMat RGBA2Gray(const cv::GMat& rgbaImage)
 {
@@ -30,3 +30,5 @@ cv::GArray<cv::Point2f> GoodFeaturesToTrack(const cv::GMat& grayscaleImage,
   return GGoodFeatures::on(grayscaleImage, maxFeatures, qualityLevel, minDistance, mask, blockSize,
                            useHarrisDetector, k);
 }
+
+} // namespace OASIS::IMAGE

--- a/oasis_perception_cpp/src/api/Video.cpp
+++ b/oasis_perception_cpp/src/api/Video.cpp
@@ -10,8 +10,8 @@
 
 #include <opencv2/video/tracking.hpp>
 
-using namespace OASIS;
-using namespace VIDEO;
+namespace OASIS::VIDEO
+{
 
 cv::GArray<cv::Point2f> PredictPoints(const cv::GArray<std::vector<cv::Point2f>>& pointHistory)
 {
@@ -88,3 +88,5 @@ cv::gapi::video::GOptFlowLKOutput CalcOpticalFlow(const cv::GMat& prevImg,
   return cv::gapi::calcOpticalFlowPyrLK(prevImg, nextImg, prevPts, predPts, winSize, maxLevel,
                                         criteria, flags, minEigThresh);
 }
+
+} // namespace OASIS::VIDEO

--- a/oasis_perception_cpp/src/kernels/cpu/CPUImageProc.cpp
+++ b/oasis_perception_cpp/src/kernels/cpu/CPUImageProc.cpp
@@ -13,8 +13,8 @@
 #include <opencv2/gapi/cpu/gcpukernel.hpp>
 #include <opencv2/imgproc.hpp>
 
-using namespace OASIS;
-using namespace IMAGE;
+namespace OASIS::IMAGE
+{
 
 // Find good features
 // clang-format off
@@ -49,3 +49,5 @@ cv::gapi::GKernelPackage kernels()
 
   return pkg;
 }
+
+} // namespace OASIS::IMAGE

--- a/oasis_perception_cpp/src/kernels/cpu/CPUVideo.cpp
+++ b/oasis_perception_cpp/src/kernels/cpu/CPUVideo.cpp
@@ -13,8 +13,8 @@
 #include <opencv2/gapi/cpu/gcpukernel.hpp>
 #include <opencv2/gapi/cpu/imgproc.hpp>
 
-using namespace OASIS;
-using namespace VIDEO;
+namespace OASIS::VIDEO
+{
 
 // Predict points for optical flow
 // clang-format off
@@ -37,3 +37,5 @@ cv::gapi::GKernelPackage kernels()
 
   return pkg;
 }
+
+} // namespace OASIS::VIDEO


### PR DESCRIPTION
## Summary
- wrap optical flow image API functions in the OASIS::IMAGE namespace
- place optical flow video API functions and CPU kernel builders in their namespaces to avoid duplicate symbols

## Testing
- colcon build --packages-select oasis_perception_cpp *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68d390c4f1a0832eb004b652e0912cd5