### PR TITLE
Configure MediaPipe build to use bundled OpenCV

### DIFF
--- a/oasis_tooling/scripts/depinstall_mediapipe.sh
+++ b/oasis_tooling/scripts/depinstall_mediapipe.sh
@@ -38,16 +38,6 @@ sudo apt install -y \
 sudo apt install -y \
   libgoogle-glog-dev \
 
-# TODO: Needed until we can point MediaPipe at our OpenCV install
-sudo apt install -y \
-  libopencv-calib3d-dev \
-  libopencv-contrib-dev \
-  libopencv-core-dev \
-  libopencv-features2d-dev \
-  libopencv-highgui-dev \
-  libopencv-imgproc-dev \
-  libopencv-video-dev \
-
 # Install NVM
 curl -o- "https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_VERSION}/install.sh" | bash
 

--- a/oasis_tooling/scripts/env_cv.sh
+++ b/oasis_tooling/scripts/env_cv.sh
@@ -77,3 +77,9 @@ if [ -n "${LD_LIBRARY_PATH:-}" ]; then
 else
   export LD_LIBRARY_PATH="${OPENCV_LIBRARY_DIR}"
 fi
+
+if [ -n "${LIBRARY_PATH:-}" ]; then
+  export LIBRARY_PATH="${OPENCV_LIBRARY_DIR}:${LIBRARY_PATH}"
+else
+  export LIBRARY_PATH="${OPENCV_LIBRARY_DIR}"
+fi


### PR DESCRIPTION
## Summary
- teach the MediaPipe build helper to inject the bundled OpenCV install path into the Bazel workspace and link flags
- expose the custom OpenCV lib directory through LIBRARY_PATH alongside LD_LIBRARY_PATH
- drop the fallback apt installs for OpenCV packages now that MediaPipe uses the bundled build

## Testing
- bash -n oasis_tooling/scripts/build_mediapipe.sh
- bash -n oasis_tooling/scripts/depinstall_mediapipe.sh
- bash -n oasis_tooling/scripts/env_cv.sh

------
https://chatgpt.com/codex/tasks/task_b_68d59e77167c832e89a26f6820b9f323