### PR TITLE
Publish optical flow visualization

### DIFF
--- a/oasis_perception_cpp/src/nodes/OpticalFlowNode.h
+++ b/oasis_perception_cpp/src/nodes/OpticalFlowNode.h
@@ -9,6 +9,7 @@
 
 #include <memory>
 
+#include <image_transport/publisher.hpp>
 #include <image_transport/subscriber.hpp>
 #include <sensor_msgs/msg/image.hpp>
 
@@ -43,6 +44,7 @@ private:
 
   // ROS parameters
   rclcpp::Logger m_logger;
+  std::unique_ptr<image_transport::Publisher> m_flowPublisher;
   std::unique_ptr<image_transport::Subscriber> m_imgSubscriber;
 
   // Video parameters


### PR DESCRIPTION
## Summary
- add a flow topic publisher to the optical flow node
- draw tracked points on incoming images and publish the visualization

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d9cddcd974832ea69d384c1aede4ac