### PR TITLE
Prevent NUT services from auto-starting without UPS hardware

### DIFF
--- a/oasis_drivers_py/config/systemd/oasis_ups@.service
+++ b/oasis_drivers_py/config/systemd/oasis_ups@.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=OASIS UPS ROS driver (%i)
+Requires=nut-server.service
+After=nut-server.service
+BindsTo=nut-driver@%i.service
+PartOf=nut-driver@%i.service
+
+[Service]
+User=ubuntu
+Environment=ROS2_DISTRO=kilted
+Environment=RMW_IMPLEMENTATION=rmw_fastrtps_dynamic_cpp
+Environment=OASIS_ENV=/home/${USER}/Documents/ros-ws/src/oasis/ros-ws/oasis-${ROS2_DISTRO}/install/setup.bash
+ExecStart=/bin/bash -c 'set +o nounset && source `eval echo "${OASIS_ENV}"` && ros2 launch oasis_drivers_py ups_launch.py'
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/oasis_drivers_py/launch/drivers_launch.py
+++ b/oasis_drivers_py/launch/drivers_launch.py
@@ -307,28 +307,6 @@ def add_system_monitor(ld: LaunchDescription, host_id: str) -> None:
 
 
 #
-# UPS server
-#
-
-
-def add_ups_server(ld: LaunchDescription, zone_id: str) -> None:
-    ups_server_node = Node(
-        namespace=ROS_NAMESPACE,
-        package=PYTHON_PACKAGE_NAME,
-        executable="ups_server",
-        name=f"ups_server_{zone_id}",
-        output="screen",
-        remappings=[
-            # Topics
-            ("ups_status", f"{zone_id}/ups_status"),
-            # Services
-            ("ups_command", f"{zone_id}/ups_command"),
-        ],
-    )
-    ld.add_action(ups_server_node)
-
-
-#
 # V4L2 camera
 #
 
@@ -407,17 +385,14 @@ def generate_launch_description() -> LaunchDescription:
         add_ros2_camera(ld, "entryway")
     elif HOST_ID == HOME_ASSISTANT_ID:
         add_home_assistant(ld)
-        add_ups_server(ld, ZONE_ID)
     elif HOST_ID == "kitchen":
         add_v4l2_camera(ld, ZONE_ID)
     elif HOST_ID == "nas":
         add_kinect_v2(ld, KINECT_V2_ZONE_ID)
-        add_ups_server(ld, ZONE_ID)
 
     # LEGO hosts
     if HOST_ID == "station":
         add_ros2_camera(ld, ZONE_ID)
-        add_ups_server(ld, ZONE_ID)
 
     #
     # TODO: Microcontroller drivers

--- a/oasis_drivers_py/launch/ups_launch.py
+++ b/oasis_drivers_py/launch/ups_launch.py
@@ -1,0 +1,52 @@
+################################################################################
+#
+#  Copyright (C) 2025 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See the file LICENSE.txt for more information.
+#
+################################################################################
+
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+from oasis_hass.utils.smarthome_config import SmarthomeConfig
+
+
+################################################################################
+# Smarthome parameters
+################################################################################
+
+
+CONFIG: SmarthomeConfig = SmarthomeConfig()
+
+ZONE_ID: str = CONFIG.ZONE_ID
+
+ROS_NAMESPACE: str = "oasis"
+PYTHON_PACKAGE_NAME: str = "oasis_drivers_py"
+
+
+################################################################################
+# Launch description
+################################################################################
+
+
+def generate_launch_description() -> LaunchDescription:
+    ld = LaunchDescription()
+
+    ups_server_node = Node(
+        namespace=ROS_NAMESPACE,
+        package=PYTHON_PACKAGE_NAME,
+        executable="ups_server",
+        name=f"ups_server_{ZONE_ID}",
+        output="screen",
+        remappings=[
+            ("ups_status", f"{ZONE_ID}/ups_status"),
+            ("ups_command", f"{ZONE_ID}/ups_command"),
+        ],
+    )
+
+    ld.add_action(ups_server_node)
+
+    return ld

--- a/oasis_drivers_py/setup.py
+++ b/oasis_drivers_py/setup.py
@@ -63,13 +63,20 @@ setuptools.setup(
             ],
         ),
         # Launch files
-        (os.path.join("share", PACKAGE_NAME), ["launch/drivers_launch.py"]),
+        (
+            os.path.join("share", PACKAGE_NAME),
+            [
+                "launch/drivers_launch.py",
+                "launch/ups_launch.py",
+            ],
+        ),
         # Systemd services
         (
             os.path.join("share", PACKAGE_NAME, "systemd"),
             [
                 "config/systemd/display_fixes.service",
                 "config/systemd/oasis_drivers.service",
+                "config/systemd/oasis_ups@.service",
             ],
         ),
         # udev rules

--- a/oasis_tooling/scripts/rdepinstall_oasis.sh
+++ b/oasis_tooling/scripts/rdepinstall_oasis.sh
@@ -33,7 +33,7 @@ source "${OASIS_DEPENDS_INSTALL_DIRECTORY}/setup.bash"
 set -o nounset
 
 #
-# Install runtime dependencies
+# Install OASIS runtime dependencies
 #
 
 # Install display controllers
@@ -64,53 +64,3 @@ sudo apt install -y --no-install-recommends \
 # Needed for communicating with UPS devices
 sudo apt install -y --no-install-recommends \
   nut \
-
-# Config files
-NUT_CONF="/etc/nut/nut.conf"
-UPS_CONF="/etc/nut/ups.conf"
-UPSD_CONF="/etc/nut/upsd.conf"
-UPSD_USERS="/etc/nut/upsd.users"
-sudo touch "$NUT_CONF" "$UPS_CONF" "$UPSD_CONF" "$UPSD_USERS"
-
-# Set mode to standalone (idempotent)
-if sudo grep -q "^MODE=" "$NUT_CONF"; then
-  sudo sed -i 's/^MODE=.*/MODE=standalone/' "$NUT_CONF"
-else
-  echo "MODE=standalone" | sudo tee -a "$NUT_CONF" > /dev/null
-fi
-
-# Basic UPS config (CyberPower via USB)
-if ! sudo grep -q "^\#[ups\]" "$UPS_CONF" 2>/dev/null; then
-  cat <<EOF | sudo tee -a "$UPS_CONF" > /dev/null
-#[ups]
-#  driver = usbhid-ups
-#  port = auto
-#  desc = "Generic USB UPS"
-EOF
-fi
-
-# Enable network access for Home Assistant in upsd.conf
-if ! sudo grep -q "^LISTEN 0.0.0.0 3493" "$UPSD_CONF" 2>/dev/null; then
-  echo "LISTEN 0.0.0.0 3493" | sudo tee -a "$UPSD_CONF" > /dev/null
-fi
-
-# Create local NUT user
-if ! sudo grep -q "^\[admin\]" "$UPSD_USERS" 2>/dev/null; then
-  cat <<EOF | sudo tee -a "$UPSD_USERS" > /dev/null
-[admin]
-password = adminpass
-actions = SET
-instcmds = ALL
-EOF
-  sudo chown root:nut "$UPSD_USERS"
-  sudo chmod 640 "$UPSD_USERS"
-fi
-
-# Restart services for changes to take effect
-sudo systemctl restart nut-server.service
-
-# Enable and start driver and server
-sudo systemctl enable --now nut-server.service
-
-# Disable the monitor unless you're using upsmon for shutdown
-sudo systemctl disable --now nut-monitor.service || true

--- a/oasis_tooling/scripts/setup_nut.sh
+++ b/oasis_tooling/scripts/setup_nut.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+################################################################################
+#
+#  Copyright (C) 2025 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See the file LICENSE.txt for more information.
+#
+################################################################################
+
+# Enable strict mode
+set -o errexit
+set -o pipefail
+set -o nounset
+
+#
+# NUT setup script for Debian-based systems
+#
+
+UPS_NAME="ups"
+UPS_DRIVER="usbhid-ups"
+UPS_PORT="auto"
+UPS_DESC="Generic USB UPS"
+UPS_VENDOR_ID="0764" # CyberPower default
+UPS_PRODUCT_ID="0601" # CyberPower default
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+UPS_SERVICE_TEMPLATE_SOURCE="${SCRIPT_DIR}/../../oasis_drivers_py/config/systemd/oasis_ups@.service"
+UPS_SERVICE_TEMPLATE="/etc/systemd/system/oasis-ups@.service"
+UPS_SERVICE_NAME="oasis-ups@${UPS_NAME}.service"
+
+# Config files
+NUT_CONF="/etc/nut/nut.conf"
+UPS_CONF="/etc/nut/ups.conf"
+UPSD_CONF="/etc/nut/upsd.conf"
+UPSD_USERS="/etc/nut/upsd.users"
+UDEV_RULE="/etc/udev/rules.d/90-nut-${UPS_NAME}.rules"
+DRIVER_OVERRIDE_DIR="/etc/systemd/system/nut-driver@.service.d"
+SERVER_OVERRIDE_DIR="/etc/systemd/system/nut-server.service.d"
+
+sudo touch "${NUT_CONF}" "${UPS_CONF}" "${UPSD_CONF}" "${UPSD_USERS}"
+
+# Install optional OASIS companion service
+if [[ -f "${UPS_SERVICE_TEMPLATE_SOURCE}" ]]; then
+  echo "Installing $(basename "${UPS_SERVICE_TEMPLATE_SOURCE}")"
+  sudo install -m 0644 "${UPS_SERVICE_TEMPLATE_SOURCE}" "${UPS_SERVICE_TEMPLATE}"
+else
+  echo "Error: UPS systemd service template not found at ${UPS_SERVICE_TEMPLATE_SOURCE}"
+  exit 1
+fi
+
+# Update the User= in the templated unit (underscore or hyphen)
+sudo sed -i "s|^[[:space:]]*User=.*|User=$(id -un)|" "${UPS_SERVICE_TEMPLATE}"
+
+# Set mode to standalone (idempotent)
+echo "Configuring NUT for standalone mode"
+if sudo grep -q "^MODE=" "${NUT_CONF}" 2>/dev/null; then
+  sudo sed -i 's/^MODE=.*/MODE=standalone/' "${NUT_CONF}"
+else
+  echo "MODE=standalone" | sudo tee -a "${NUT_CONF}" > /dev/null
+fi
+
+# Configure the UPS entry (idempotent overwrite)
+echo "Configuring ups.conf for ${UPS_NAME}"
+sudo tee "${UPS_CONF}" > /dev/null <<EOF_CONF
+[${UPS_NAME}]
+  driver = ${UPS_DRIVER}
+  port = ${UPS_PORT}
+  desc = "${UPS_DESC}"
+EOF_CONF
+
+# Enable network access for Home Assistant in upsd.conf
+echo "Enabling network access in upsd.conf"
+if ! sudo grep -q "^LISTEN 0.0.0.0 3493" "${UPSD_CONF}" 2>/dev/null; then
+  echo "LISTEN 0.0.0.0 3493" | sudo tee -a "${UPSD_CONF}" > /dev/null
+fi
+
+# Create local NUT users if missing
+echo "Configuring upsd.users"
+if ! sudo grep -q "^\[admin\]" "${UPSD_USERS}" 2>/dev/null; then
+  cat <<EOF_USERS | sudo tee -a "${UPSD_USERS}" > /dev/null
+[admin]
+password = adminpass
+actions = SET
+instcmds = ALL
+EOF_USERS
+fi
+
+sudo chown root:nut "${UPSD_USERS}"
+sudo chmod 640 "${UPSD_USERS}"
+
+###############################################################################
+# Systemd policy: disable auto-start from enumerator; rely on udev events
+###############################################################################
+
+# Stop anything running now
+echo "Disabling existing NUT services"
+sudo systemctl stop "nut-driver@${UPS_NAME}.service" nut-server.service nut-driver-enumerator.service 2>/dev/null || true
+
+# Disable enumerator path (prevents auto-instances from ups.conf when device absent)
+echo "Disabling nut-driver-enumerator.path"
+sudo systemctl disable --now nut-driver-enumerator.path 2>/dev/null || true
+# Also ensure enumerator service is stopped
+echo "Stopping nut-driver-enumerator.service"
+sudo systemctl stop nut-driver-enumerator.service 2>/dev/null || true
+
+# Remove any auto-enable symlink created earlier
+echo  "Removing any existing nut-driver@${UPS_NAME}.service symlink"
+sudo rm -f "/etc/systemd/system/nut-driver.target.wants/nut-driver@${UPS_NAME}.service" 2>/dev/null || true
+
+# Disable always-on server; we'll have udev start it only when the UPS is present
+echo "Disabling nut-server.service"
+sudo systemctl disable --now nut-server.service 2>/dev/null || true
+
+# nut-monitor.service is not shipped on some distros; ignore errors
+echo "Disabling nut-monitor.service"
+sudo systemctl stop nut-monitor.service 2>/dev/null || true || true
+
+###############################################################################
+# Overrides
+###############################################################################
+
+# Ensure the driver instance behaves like a device-bound service
+echo "Creating systemd overrides"
+sudo install -d -m 0755 "${DRIVER_OVERRIDE_DIR}"
+sudo tee "${DRIVER_OVERRIDE_DIR}/override.conf" > /dev/null <<'EOF_DRIVER'
+[Service]
+Restart=on-failure
+RestartSec=10s
+EOF_DRIVER
+
+# Bind the server lifecycle to the driver so it follows the hardware
+echo "Binding nut-server.service lifecycle to nut-driver@${UPS_NAME}.service"
+sudo install -d -m 0755 "${SERVER_OVERRIDE_DIR}"
+sudo tee "${SERVER_OVERRIDE_DIR}/override.conf" > /dev/null <<EOF_SERVER
+[Unit]
+BindsTo=nut-driver@${UPS_NAME}.service
+After=nut-driver@${UPS_NAME}.service
+PartOf=nut-driver@${UPS_NAME}.service
+EOF_SERVER
+
+###############################################################################
+# udev: start/stop services on device add/remove + set permissions
+###############################################################################
+
+# udev: start/stop services on device add/remove + set permissions
+echo "Creating udev rule at ${UDEV_RULE}"
+sudo tee "${UDEV_RULE}" > /dev/null <<EOF_UDEV
+# Network UPS Tools event-driven driver for ${UPS_NAME}
+
+# 1) Match the USB device to tag add/remove events for the UPS
+ACTION=="add", SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", \
+  ATTR{idVendor}=="${UPS_VENDOR_ID}", ATTR{idProduct}=="${UPS_PRODUCT_ID}", \
+  TAG+="systemd"
+
+ACTION=="remove", SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", \
+  ATTR{idVendor}=="${UPS_VENDOR_ID}", ATTR{idProduct}=="${UPS_PRODUCT_ID}", \
+  RUN+="/bin/systemctl stop nut-driver@${UPS_NAME}.service", \
+  RUN+="/bin/systemctl stop nut-server.service", \
+  RUN+="/bin/systemctl stop ${UPS_SERVICE_NAME}"
+
+# 2) Match the HID character device to grant access and start services
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="${UPS_VENDOR_ID}", ATTRS{idProduct}=="${UPS_PRODUCT_ID}", \
+  GROUP="nut", MODE="0660", \
+  TAG+="systemd", \
+  ENV{SYSTEMD_WANTS}+="nut-driver@${UPS_NAME}.service", \
+  ENV{SYSTEMD_WANTS}+="nut-server.service", \
+  ENV{SYSTEMD_WANTS}+="${UPS_SERVICE_NAME}"
+EOF_UDEV
+
+# Apply rules and units
+echo "Reloading udev rules and systemd daemon"
+sudo udevadm control --reload-rules || true
+sudo systemctl daemon-reload
+
+# If the UPS is already plugged in, trigger udev so the driver/server start now
+sudo udevadm trigger --subsystem-match=usb \
+  --attr-match=idVendor="${UPS_VENDOR_ID}" \
+  --attr-match=idProduct="${UPS_PRODUCT_ID}" || true

--- a/oasis_tooling/scripts/setup_nut.sh
+++ b/oasis_tooling/scripts/setup_nut.sh
@@ -101,9 +101,12 @@ sudo systemctl stop "nut-driver@${UPS_NAME}.service" nut-server.service nut-driv
 # Disable enumerator path (prevents auto-instances from ups.conf when device absent)
 echo "Disabling nut-driver-enumerator.path"
 sudo systemctl disable --now nut-driver-enumerator.path 2>/dev/null || true
-# Also ensure enumerator service is stopped
+# Also ensure enumerator service is stopped and permanently masked so it cannot
+# auto-start the driver instance during boot when no UPS is connected.
 echo "Stopping nut-driver-enumerator.service"
 sudo systemctl stop nut-driver-enumerator.service 2>/dev/null || true
+echo "Masking nut-driver-enumerator.service"
+sudo systemctl mask nut-driver-enumerator.service 2>/dev/null || true
 
 # Remove any auto-enable symlink created earlier
 echo  "Removing any existing nut-driver@${UPS_NAME}.service symlink"
@@ -116,6 +119,13 @@ sudo systemctl disable --now nut-server.service 2>/dev/null || true
 # nut-monitor.service is not shipped on some distros; ignore errors
 echo "Disabling nut-monitor.service"
 sudo systemctl stop nut-monitor.service 2>/dev/null || true || true
+
+# The legacy LSB nut-client.service (a SysV wrapper around upsmon) is still
+# enabled by default on many distributions and will repeatedly attempt to start
+# even when no UPS is connected. Disable it so that service activation becomes
+# fully event-driven via the udev rules below.
+echo "Disabling nut-client.service"
+sudo systemctl disable --now nut-client.service 2>/dev/null || true
 
 ###############################################################################
 # Overrides

--- a/oasis_tooling/scripts/setup_nut.sh
+++ b/oasis_tooling/scripts/setup_nut.sh
@@ -97,6 +97,8 @@ sudo chmod 640 "${UPSD_USERS}"
 # Stop anything running now
 echo "Disabling existing NUT services"
 sudo systemctl stop "nut-driver@${UPS_NAME}.service" nut-server.service nut-driver-enumerator.service 2>/dev/null || true
+echo "Disabling nut-driver@${UPS_NAME}.service"
+sudo systemctl disable --now "nut-driver@${UPS_NAME}.service" 2>/dev/null || true
 
 # Disable enumerator path (prevents auto-instances from ups.conf when device absent)
 echo "Disabling nut-driver-enumerator.path"


### PR DESCRIPTION
## Summary
- mask the nut-driver enumerator service so it can no longer start UPS drivers during boot without hardware present
- disable the legacy nut-client SysV service to keep the stack fully event-driven

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68dc5dd75e64832eafa11543ad4b635e