### PR TITLE
Switch Firmata cooperative tasks to TaskScheduler

### DIFF
--- a/oasis_avr/src/firmata/firmata_analog.cpp
+++ b/oasis_avr/src/firmata/firmata_analog.cpp
@@ -13,9 +13,9 @@
 
 #include "firmata_analog.hpp"
 
+#include <Arduino.h>
 #include <Boards.h>
 #include <FirmataExpress.h>
-#include <Scheduler.h>
 
 using namespace OASIS;
 

--- a/oasis_avr/src/firmata/firmata_bluefruit.cpp
+++ b/oasis_avr/src/firmata/firmata_bluefruit.cpp
@@ -15,7 +15,7 @@
 #include <string.h>
 
 //#include <FirmataExpress.h>
-#include <Scheduler.h>
+#include <Arduino.h>
 
 using namespace OASIS;
 

--- a/oasis_avr/src/firmata/firmata_cpu_fan.cpp
+++ b/oasis_avr/src/firmata/firmata_cpu_fan.cpp
@@ -10,8 +10,8 @@
 
 #include "firmata_extra.hpp"
 
+#include <Arduino.h>
 #include <FirmataExpress.h>
-#include <Scheduler.h>
 #include <avr/io.h>
 
 using namespace OASIS;

--- a/oasis_avr/src/firmata/firmata_dht.cpp
+++ b/oasis_avr/src/firmata/firmata_dht.cpp
@@ -10,8 +10,8 @@
 
 #include "firmata_callbacks.hpp"
 
+#include <Arduino.h>
 #include <FirmataExpress.h>
-#include <Scheduler.h>
 
 using namespace OASIS;
 

--- a/oasis_avr/src/firmata/firmata_digital.cpp
+++ b/oasis_avr/src/firmata/firmata_digital.cpp
@@ -15,7 +15,6 @@
 
 #include <Arduino.h>
 #include <FirmataExpress.h>
-#include <Scheduler.h>
 
 using namespace OASIS;
 

--- a/oasis_avr/src/firmata/firmata_i2c.cpp
+++ b/oasis_avr/src/firmata/firmata_i2c.cpp
@@ -17,8 +17,8 @@
 
 #include <stddef.h>
 
+#include <Arduino.h>
 #include <FirmataExpress.h>
-#include <Scheduler.h>
 #include <Wire.h>
 
 using namespace OASIS;

--- a/oasis_avr/src/firmata/firmata_scheduler.cpp
+++ b/oasis_avr/src/firmata/firmata_scheduler.cpp
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (C) 2025 Garrett Brown
+ *  This file is part of OASIS - https://github.com/eigendude/OASIS
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *  See DOCS/LICENSING.md for more information.
+ */
+
+#include "firmata_scheduler.hpp"
+
+namespace OASIS
+{
+namespace
+{
+TsScheduler g_scheduler;
+bool g_initialized{false};
+}
+
+void InitializeTaskScheduler()
+{
+  if (!g_initialized)
+  {
+    g_scheduler.init();
+    g_initialized = true;
+  }
+}
+
+TsScheduler& GetTaskScheduler()
+{
+  InitializeTaskScheduler();
+  return g_scheduler;
+}
+
+void RunTaskScheduler()
+{
+  InitializeTaskScheduler();
+  g_scheduler.execute();
+}
+
+} // namespace OASIS

--- a/oasis_avr/src/firmata/firmata_scheduler.hpp
+++ b/oasis_avr/src/firmata/firmata_scheduler.hpp
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (C) 2025 Garrett Brown
+ *  This file is part of OASIS - https://github.com/eigendude/OASIS
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *  See DOCS/LICENSING.md for more information.
+ */
+#pragma once
+
+#include <TScheduler.hpp>
+
+namespace OASIS
+{
+
+// Initialize the shared TaskScheduler instance.
+void InitializeTaskScheduler();
+
+// Retrieve the shared TaskScheduler instance.
+TsScheduler& GetTaskScheduler();
+
+// Execute one scheduler pass. Call from the Arduino loop().
+void RunTaskScheduler();
+
+} // namespace OASIS

--- a/oasis_avr/src/firmata/firmata_servo.cpp
+++ b/oasis_avr/src/firmata/firmata_servo.cpp
@@ -13,8 +13,8 @@
 
 #include "firmata_servo.hpp"
 
+#include <Arduino.h>
 #include <FirmataExpress.h>
-#include <Scheduler.h>
 
 using namespace OASIS;
 

--- a/oasis_avr/src/firmata/firmata_spi.cpp
+++ b/oasis_avr/src/firmata/firmata_spi.cpp
@@ -17,10 +17,10 @@
 
 #include "firmata_extra.hpp"
 
+#include <Arduino.h>
 #include <Boards.h>
 #include <FirmataExpress.h>
 #include <SPI.h>
-#include <Scheduler.h>
 
 using namespace OASIS;
 

--- a/oasis_avr/src/leds/heartbeat_thread.cpp
+++ b/oasis_avr/src/leds/heartbeat_thread.cpp
@@ -9,15 +9,13 @@
 #include "heartbeat_thread.hpp"
 
 #include <Arduino.h>
-#include <Scheduler.h>
+
+#include "firmata/firmata_scheduler.hpp"
 
 using namespace OASIS;
 
 namespace OASIS
 {
-
-// Threading constants
-constexpr size_t HEARTBEAT_STACK_SIZE = 32; // Default is 128
 
 // LED parameters
 constexpr unsigned int HEARTBEAT_LED = LED_BUILTIN;
@@ -37,8 +35,11 @@ void HeartbeatThread::Setup()
   // Setup to blink the inbuilt LED
   pinMode(HEARTBEAT_LED, OUTPUT);
 
-  // Start heartbeat thread
-  Scheduler.startLoop(HeartbeatLoop, HEARTBEAT_STACK_SIZE);
+  InitializeTaskScheduler();
+
+  static TsTask heartbeatTask(TASK_IMMEDIATE, TASK_FOREVER, HeartbeatLoop);
+  GetTaskScheduler().addTask(heartbeatTask);
+  heartbeatTask.enable();
 }
 
 void HeartbeatThread::Loop()

--- a/oasis_avr/src/ros/firmata_node.cpp
+++ b/oasis_avr/src/ros/firmata_node.cpp
@@ -10,7 +10,8 @@
 #include "leds/heartbeat_thread.hpp"
 
 #include <Arduino.h>
-#include <Scheduler.h>
+
+#include "firmata/firmata_scheduler.hpp"
 
 using namespace OASIS;
 
@@ -22,6 +23,5 @@ void setup()
 
 void loop()
 {
-  // TODO: Delay forever
-  delay(1000);
+  RunTaskScheduler();
 }


### PR DESCRIPTION
## Summary
- add a shared TaskScheduler wrapper for Firmata targets
- replace Scheduler.startLoop usage in Firmata and heartbeat threads with TaskScheduler tasks
- drive the scheduler from the Arduino loop and update includes to drop the old Scheduler dependency

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68ddeeb0a438832ea4f0afd5fcc6e765