### PR TITLE
Fix TaskScheduler multiple definition errors

### DIFF
--- a/oasis_avr/src/leds/heartbeat_thread.cpp
+++ b/oasis_avr/src/leds/heartbeat_thread.cpp
@@ -11,7 +11,6 @@
 #include "scheduler/task_scheduler.hpp"
 
 #include <Arduino.h>
-#include <TScheduler.hpp>
 
 using namespace OASIS;
 

--- a/oasis_avr/src/scheduler/task_scheduler.cpp
+++ b/oasis_avr/src/scheduler/task_scheduler.cpp
@@ -8,7 +8,6 @@
 
 #include "task_scheduler.hpp"
 
-#include <TScheduler.hpp>
 
 namespace OASIS
 {

--- a/oasis_avr/src/telemetrix/telemetrix_thread.cpp
+++ b/oasis_avr/src/telemetrix/telemetrix_thread.cpp
@@ -12,7 +12,6 @@
 #include "telemetrix/telemetrix_server.hpp"
 
 #include <Arduino.h>
-#include <TScheduler.hpp>
 
 using namespace OASIS;
 


### PR DESCRIPTION
## Summary
- stop including the TaskScheduler implementation header from AVR sources that only need declarations
- ensure only the shared scheduler translation unit is responsible for interacting with the linked library

## Testing
- `oasis_tooling/scripts/build_oasis.sh` *(fails: missing /workspace/OASIS/ros-ws/oasis-depends-kilted/install setup script in CI environment)*

------
https://chatgpt.com/codex/tasks/task_b_68df6ca69498832e81acac5d76acf697