### PR TITLE
Fix lab manager warning format

### DIFF
--- a/oasis_control/oasis_control/nodes/lab_manager_telemetrix_node.py
+++ b/oasis_control/oasis_control/nodes/lab_manager_telemetrix_node.py
@@ -264,9 +264,8 @@ class LabManagerNode(rclpy.node.Node):
         # Translate analog value
         if not 0.0 <= analog_value <= 1.0:
             self.get_logger().warning(
-                "Analog reading %.2f for pin %d out of range, clamping to [0.0, 1.0]",
-                analog_value,
-                analog_pin,
+                f"Analog reading {analog_value:.2f} for pin {analog_pin} out of "
+                "range, clamping to [0.0, 1.0]"
             )
         normalized_value = max(0.0, min(analog_value, 1.0))
         analog_voltage: float = normalized_value * reference_voltage


### PR DESCRIPTION
## Summary
- avoid passing multiple positional arguments to the lab manager warning log by preformatting the message

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68e0c134feac832eb5e5de01cffe3919