### PR TITLE
Type FirmataBridge logger as RcutilsLogger

### DIFF
--- a/oasis_drivers_py/oasis_drivers/nodes/firmata_bridge_node.py
+++ b/oasis_drivers_py/oasis_drivers/nodes/firmata_bridge_node.py
@@ -93,7 +93,7 @@ class FirmataBridgeNode(rclpy.node.Node, FirmataCallback):
 
         # Initialize members
         com_port: str = str(self.get_parameter(PARAM_COM_PORT).value)
-        self._bridge = FirmataBridge(self, com_port)
+        self._bridge = FirmataBridge(self, com_port, logger=self.get_logger())
 
         # Guard condition and queue for dispatching callbacks onto the ROS thread
         self._dispatch_queue: "queue.Queue[Callable[[], None]]" = queue.Queue()


### PR DESCRIPTION
## Summary
- type annotate the FirmataBridge logger parameter with the RcutilsLogger returned by ROS nodes
- cast the default module logger to the same type so logging continues to function when no ROS logger is injected

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e1bee83688832e97e33fc61463524a