### PR TITLE
Improve Telemetrix reconnect behavior (persistent worker, reduced retries)

### DIFF
--- a/oasis_drivers_py/oasis_drivers/telemetrix/telemetrix_bridge.py
+++ b/oasis_drivers_py/oasis_drivers/telemetrix/telemetrix_bridge.py
@@ -54,7 +54,7 @@ class TelemetrixBridge:
     BAUD_RATE = 115200
     ARDUINO_INSTANCE_ID = 1
     ARDUINO_WAIT_SECS = 4  # Wait time changed from 2s in Firmata to 4s in Telemetrix
-    HANDSHAKE_ATTEMPTS = 5
+    HANDSHAKE_ATTEMPTS = 3
     HANDSHAKE_RETRY_DELAY_S = 1.0
     SHUTDOWN_TIMEOUT_S = 2.0
 
@@ -113,22 +113,6 @@ class TelemetrixBridge:
             {TelemetrixConstants.UPTIME_REPORT: self._on_uptime_report}
         )
         return board
-
-    def initialize(self) -> bool:
-        """Initialize the bridge and start communicating via Telemetrix"""
-        self._thread.start()
-
-        try:
-            asyncio.run_coroutine_threadsafe(
-                self._board.start_aio(), self._loop
-            ).result()
-        except Exception as e:
-            self.deinitialize()
-            raise e
-
-        self._log_reported_features()
-
-        return True
 
     def initialize_with_retries(self) -> bool:
         """Initialize the bridge with retry logic for USB reconnects"""


### PR DESCRIPTION
### Motivation
- Prevent double-retrying and noisy reconnect behavior by moving retry policy into the bridge and making the node own a single persistent reconnect worker.
- Make reconnects persistent until success and reduce heavy recreation of event loops/threads and TelemetrixAIO objects to reduce banner spam.
- Keep bridge-level handshake retries but avoid recreating the event loop/thread repeatedly from higher layers.

### Description
- Node: removed the node-level `reconnect_attempts` loop and parameter, added `rclpy` import, and simplified ping/timer logic so the timer returns when `_reconnecting` and starts a single background reconnect worker when needed.
- Node: added `_reconnect_worker(reason: str)` which creates one `TelemetrixBridge` per reconnect cycle, calls `initialize_with_retries()` once, verifies link with `ping_uptime_ms(...)`, and only then swaps in the new bridge and marks the node initialized/connected.
- Node: reduced logging spam by logging a single WARN when reconnect starts, WARN per failed reconnect cycle, and INFO on successful reconnect, and removed the per-attempt and "Uptime ping recovered" noisy log.
- Bridge: reduced handshake chatter by lowering `HANDSHAKE_ATTEMPTS` from `5` to `3` and keeping `initialize_with_retries()` as the single retry loop; removed the separate `initialize()` path so the node no longer calls `initialize()` directly.
- Bridge: ensured the event loop/thread is started once in `__init__` and reused across handshake attempts while `_create_board()` only creates `TelemetrixAIO` and installs handlers.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696c4a4568e4832ea1b6cad9aa20cf08)