### PR TITLE
Cache and replay Telemetrix configuration on reconnect

### DIFF
--- a/oasis_drivers_py/oasis_drivers/nodes/telemetrix_bridge_node.py
+++ b/oasis_drivers_py/oasis_drivers/nodes/telemetrix_bridge_node.py
@@ -29,6 +29,7 @@ from std_msgs.msg import Header as HeaderMsg
 from oasis_drivers.ros.ros_translator import RosTranslator
 from oasis_drivers.telemetrix.telemetrix_bridge import TelemetrixBridge
 from oasis_drivers.telemetrix.telemetrix_callback import TelemetrixCallback
+from oasis_drivers.telemetrix.telemetrix_config_cache import TelemetrixConfigCache
 from oasis_drivers.telemetrix.telemetrix_types import AnalogMode
 from oasis_drivers.telemetrix.telemetrix_types import DigitalMode
 from oasis_msgs.msg import AirQuality as AirQualityMsg
@@ -139,6 +140,7 @@ class TelemetrixBridgeNode(rclpy.node.Node, TelemetrixCallback):
             self.get_parameter(PARAM_RECONNECT_DELAY_S).value
         )
         self._bridge = TelemetrixBridge(self, self._com_port)
+        self._config_cache = TelemetrixConfigCache()
         self._initialized: bool = self._bridge.initialize_with_retries()
         self._ping_failed: bool = False
         self._connected: bool = self._initialized
@@ -363,11 +365,27 @@ class TelemetrixBridgeNode(rclpy.node.Node, TelemetrixCallback):
                         continue
 
                     bridge.ping_uptime_ms(timeout_s=self._ping_timeout_s)
+                    self.get_logger().info(
+                        "Replaying Telemetrix config after reconnect"
+                    )
+                    try:
+                        self._config_cache.replay(bridge, self.get_logger())
+                    except RuntimeError as exc:
+                        self.get_logger().warning(
+                            f"Config replay failed; restarting reconnect loop: {exc!r}"
+                        )
+                        try:
+                            bridge.deinitialize()
+                        except Exception:
+                            pass
+                        time.sleep(self._reconnect_delay_s)
+                        continue
+
                     self._bridge = bridge
                     self._initialized = True
                     self._ping_failed = False
                     self._connected = True
-                    self.get_logger().info("Telemetrix reconnected")
+                    self.get_logger().info("Telemetrix reconnected and config restored")
                     return
                 except Exception as exc:
                     self.get_logger().warning(f"Reconnect cycle failed: {exc!r}")
@@ -379,6 +397,15 @@ class TelemetrixBridgeNode(rclpy.node.Node, TelemetrixCallback):
                     time.sleep(self._reconnect_delay_s)
         finally:
             self._reconnecting = False
+
+    def _config_apply_allowed(self) -> bool:
+        if not self._initialized or self._reconnecting:
+            self.get_logger().warning(
+                "Telemetrix bridge not ready; cached configuration only"
+            )
+            return False
+
+        return True
 
     def stop(self) -> None:
         """Stop the bridge and cleanup ROS resources"""
@@ -719,6 +746,19 @@ class TelemetrixBridgeNode(rclpy.node.Node, TelemetrixCallback):
         i2c_port: int = request.i2c_port
         i2c_devices: List[I2CDeviceMsg] = request.i2c_devices
 
+        self._config_cache.record_i2c_begin(i2c_port)
+        for i2c_device in i2c_devices:
+            i2c_device_type: int = i2c_device.i2c_device_type
+            i2c_address: int = i2c_device.i2c_address
+
+            if i2c_device_type == I2CDeviceTypeMsg.CCS811:
+                self._config_cache.record_ccs811_begin(i2c_port, i2c_address)
+            elif i2c_device_type == I2CDeviceTypeMsg.MPU6050:
+                self._config_cache.record_mpu6050_begin(i2c_port, i2c_address)
+
+        if not self._config_apply_allowed():
+            return response
+
         # Debug logging
         self.get_logger().info(f"Beginning I2C on port {i2c_port}")
 
@@ -747,6 +787,18 @@ class TelemetrixBridgeNode(rclpy.node.Node, TelemetrixCallback):
         # Translate parameters
         i2c_port: int = request.i2c_port
         i2c_devices: List[I2CDeviceMsg] = request.i2c_devices
+
+        for i2c_device in i2c_devices:
+            i2c_device_type: int = i2c_device.i2c_device_type
+            i2c_address: int = i2c_device.i2c_address
+
+            if i2c_device_type == I2CDeviceTypeMsg.CCS811:
+                self._config_cache.record_ccs811_end(i2c_port, i2c_address)
+            elif i2c_device_type == I2CDeviceTypeMsg.MPU6050:
+                self._config_cache.record_mpu6050_end(i2c_port, i2c_address)
+
+        if not self._config_apply_allowed():
+            return response
 
         # Debug logging
         self.get_logger().info(f"Ending I2C on port {i2c_port}")
@@ -790,6 +842,10 @@ class TelemetrixBridgeNode(rclpy.node.Node, TelemetrixCallback):
         """Handle request to enable/disable MCU memory reporting"""
         # Translate parameters
         reporting_period_ms: int = request.reporting_period_ms
+
+        self._config_cache.record_memory_reporting_interval(reporting_period_ms)
+        if not self._config_apply_allowed():
+            return response
 
         # Debug logging
         if reporting_period_ms != 0:
@@ -836,6 +892,10 @@ class TelemetrixBridgeNode(rclpy.node.Node, TelemetrixCallback):
             )
             analog_mode = AnalogMode.DISABLED
 
+        self._config_cache.record_analog_mode(analog_pin, analog_mode)
+        if not self._config_apply_allowed():
+            return response
+
         # Debug logging
         self.get_logger().info(f"Setting analog pin {analog_pin} to mode {analog_mode}")
 
@@ -852,6 +912,10 @@ class TelemetrixBridgeNode(rclpy.node.Node, TelemetrixCallback):
         """Handle ROS 2 CPU fan sampling interval changes"""
         # Translate parameters
         sampling_interval_ms: int = request.sampling_interval_ms
+
+        self._config_cache.record_cpu_fan_sampling_interval(sampling_interval_ms)
+        if not self._config_apply_allowed():
+            return response
 
         # Debug logging
         self.get_logger().info(
@@ -881,6 +945,10 @@ class TelemetrixBridgeNode(rclpy.node.Node, TelemetrixCallback):
             )
             digital_mode = DigitalMode.DISABLED
 
+        self._config_cache.record_digital_mode(digital_pin, digital_mode)
+        if not self._config_apply_allowed():
+            return response
+
         # Debug logging
         self.get_logger().info(
             f"Setting digital pin {digital_pin} to mode {digital_mode}"
@@ -899,6 +967,10 @@ class TelemetrixBridgeNode(rclpy.node.Node, TelemetrixCallback):
         """Handle ROS 2 sampling interval changes"""
         # Translate parameters
         sampling_interval_ms: int = request.sampling_interval_ms
+
+        self._config_cache.record_sampling_interval(sampling_interval_ms)
+        if not self._config_apply_allowed():
+            return response
 
         # Debug logging
         self.get_logger().info(

--- a/oasis_drivers_py/oasis_drivers/telemetrix/telemetrix_config_cache.py
+++ b/oasis_drivers_py/oasis_drivers/telemetrix/telemetrix_config_cache.py
@@ -1,0 +1,201 @@
+################################################################################
+#
+#  Copyright (C) 2025 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+from __future__ import annotations
+
+import threading
+from typing import Dict
+from typing import Optional
+from typing import Protocol
+from typing import Set
+from typing import Tuple
+
+from oasis_drivers.telemetrix.telemetrix_bridge import TelemetrixBridge
+from oasis_drivers.telemetrix.telemetrix_types import AnalogMode
+from oasis_drivers.telemetrix.telemetrix_types import DigitalMode
+
+
+class Logger(Protocol):
+    def info(self, message: str) -> None: ...
+
+    def warning(self, message: str) -> None: ...
+
+
+class TelemetrixConfigCache:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._sampling_interval_ms: Optional[int] = None
+        self._memory_reporting_interval_ms: Optional[int] = None
+        self._cpu_fan_sampling_interval_ms: Optional[int] = None
+        self._digital_modes: Dict[int, DigitalMode] = {}
+        self._analog_modes: Dict[int, AnalogMode] = {}
+        self._i2c_ports_started: Set[int] = set()
+        self._ccs811_devices: Set[Tuple[int, int]] = set()
+        self._mpu6050_devices: Set[Tuple[int, int]] = set()
+
+    def record_sampling_interval(self, ms: int) -> None:
+        with self._lock:
+            self._sampling_interval_ms = ms
+
+    def record_memory_reporting_interval(self, ms: int) -> None:
+        with self._lock:
+            self._memory_reporting_interval_ms = ms
+
+    def record_cpu_fan_sampling_interval(self, ms: int) -> None:
+        with self._lock:
+            self._cpu_fan_sampling_interval_ms = ms
+
+    def record_digital_mode(self, pin: int, mode: DigitalMode) -> None:
+        with self._lock:
+            self._digital_modes[pin] = mode
+
+    def record_analog_mode(self, pin: int, mode: AnalogMode) -> None:
+        with self._lock:
+            self._analog_modes[pin] = mode
+
+    def record_i2c_begin(self, port: int) -> None:
+        with self._lock:
+            self._i2c_ports_started.add(port)
+
+    def record_ccs811_begin(self, port: int, address: int) -> None:
+        with self._lock:
+            self._ccs811_devices.add((port, address))
+
+    def record_ccs811_end(self, port: int, address: int) -> None:
+        with self._lock:
+            self._ccs811_devices.discard((port, address))
+
+    def record_mpu6050_begin(self, port: int, address: int) -> None:
+        with self._lock:
+            self._mpu6050_devices.add((port, address))
+
+    def record_mpu6050_end(self, port: int, address: int) -> None:
+        with self._lock:
+            self._mpu6050_devices.discard((port, address))
+
+    def replay(self, bridge: TelemetrixBridge, logger: Logger) -> None:
+        with self._lock:
+            memory_reporting_interval_ms = self._memory_reporting_interval_ms
+            sampling_interval_ms = self._sampling_interval_ms
+            cpu_fan_sampling_interval_ms = self._cpu_fan_sampling_interval_ms
+            digital_modes = dict(self._digital_modes)
+            analog_modes = dict(self._analog_modes)
+            i2c_ports_started = set(self._i2c_ports_started)
+            ccs811_devices = set(self._ccs811_devices)
+            mpu6050_devices = set(self._mpu6050_devices)
+
+        failures = 0
+
+        logger.info(f"Replaying Telemetrix config: {self.summary()}")
+
+        if memory_reporting_interval_ms is not None:
+            try:
+                bridge.set_memory_reporting_interval(memory_reporting_interval_ms)
+            except Exception as exc:
+                failures += 1
+                logger.warning(
+                    "Failed to replay memory reporting interval "
+                    f"{memory_reporting_interval_ms}: {exc!r}"
+                )
+
+        if sampling_interval_ms is not None:
+            try:
+                bridge.set_sampling_interval(sampling_interval_ms)
+            except Exception as exc:
+                failures += 1
+                logger.warning(
+                    f"Failed to replay sampling interval {sampling_interval_ms}: {exc!r}"
+                )
+
+        if cpu_fan_sampling_interval_ms is not None:
+            try:
+                bridge.set_cpu_fan_sampling_interval(cpu_fan_sampling_interval_ms)
+            except Exception as exc:
+                failures += 1
+                logger.warning(
+                    "Failed to replay CPU fan sampling interval "
+                    f"{cpu_fan_sampling_interval_ms}: {exc!r}"
+                )
+
+        for port in sorted(i2c_ports_started):
+            try:
+                bridge.i2c_begin(port)
+            except Exception as exc:
+                failures += 1
+                logger.warning(f"Failed to replay I2C begin on port {port}: {exc!r}")
+
+        for pin, mode in sorted(digital_modes.items()):
+            try:
+                bridge.set_digital_mode(pin, mode)
+            except Exception as exc:
+                failures += 1
+                logger.warning(
+                    f"Failed to replay digital mode for pin {pin} ({mode}): {exc!r}"
+                )
+
+        for pin, mode in sorted(analog_modes.items()):
+            try:
+                bridge.set_analog_mode(pin, mode)
+            except Exception as exc:
+                failures += 1
+                logger.warning(
+                    f"Failed to replay analog mode for pin {pin} ({mode}): {exc!r}"
+                )
+
+        for port, address in sorted(ccs811_devices):
+            try:
+                bridge.i2c_ccs811_begin(port, address)
+            except Exception as exc:
+                failures += 1
+                logger.warning(
+                    "Failed to replay CCS811 begin on port "
+                    f"{port} addr {hex(address)}: {exc!r}"
+                )
+
+        for port, address in sorted(mpu6050_devices):
+            try:
+                bridge.i2c_mpu6050_begin(port, address)
+            except Exception as exc:
+                failures += 1
+                logger.warning(
+                    "Failed to replay MPU6050 begin on port "
+                    f"{port} addr {hex(address)}: {exc!r}"
+                )
+
+        logger.info("Telemetrix config replay complete")
+
+        if failures:
+            raise RuntimeError("Telemetrix config replay had failures")
+
+    def summary(self) -> str:
+        with self._lock:
+            sampling_interval_ms = self._sampling_interval_ms
+            memory_reporting_interval_ms = self._memory_reporting_interval_ms
+            cpu_fan_sampling_interval_ms = self._cpu_fan_sampling_interval_ms
+            digital_count = len(self._digital_modes)
+            analog_count = len(self._analog_modes)
+            i2c_ports = len(self._i2c_ports_started)
+            ccs811_count = len(self._ccs811_devices)
+            mpu6050_count = len(self._mpu6050_devices)
+
+        return (
+            "intervals="
+            f"(memory={memory_reporting_interval_ms}, "
+            f"sampling={sampling_interval_ms}, "
+            f"cpu_fan={cpu_fan_sampling_interval_ms}), "
+            f"digital_pins={digital_count}, "
+            f"analog_pins={analog_count}, "
+            f"i2c_ports={i2c_ports}, "
+            f"ccs811_devices={ccs811_count}, "
+            f"mpu6050_devices={mpu6050_count}"
+        )
+
+    def __repr__(self) -> str:
+        return f"TelemetrixConfigCache({self.summary()})"


### PR DESCRIPTION
### Motivation
- Ensure MCU configuration (pin modes, sampling intervals, I2C device begins) is preserved across Telemetrix reconnects so higher-level nodes do not need to reapply settings.
- Make restore best-effort and deterministic while allowing the reconnect loop to retry if critical replay failures occur.
- Keep cached desired state separate from applied results and avoid blocking ROS executor threads during replay.

### Description
- Add a new thread-safe cache class `TelemetrixConfigCache` in `oasis_drivers_py/oasis_drivers/telemetrix/telemetrix_config_cache.py` to record desired intervals, pin modes, I2C ports, and device begins/ends, and provide a `replay(bridge, logger)` method that applies cached state in a deterministic order and raises `RuntimeError` if any replayed operation failed.
- Wire the cache into `TelemetrixBridgeNode` by instantiating `self._config_cache = TelemetrixConfigCache()` and recording configuration changes (using methods such as `record_sampling_interval`, `record_memory_reporting_interval`, `record_digital_mode`, `record_analog_mode`, `record_i2c_begin`, `record_ccs811_begin/end`, `record_mpu6050_begin/end`) before attempting to apply them to the bridge.
- Replay cached config immediately after a successful reconnect in `_reconnect_worker` (calls `self._config_cache.replay(...)`), log progress, and on replay failure deinitialize the bridge and restart the reconnect loop (so restore is retried). Do not set `self._initialized` True until replay completes successfully.
- Prevent bridge calls while disconnected/reconnecting by adding `_config_apply_allowed()` which logs a warning and returns False; service handlers still record the desired config so the desired state is preserved while offline.
- Provide a compact `summary()`/`__repr__()` on the cache used in INFO logs to make the replay operation auditable without spamming logs.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c4dc475148326b15c14b78eff8cfe)