### PR TITLE
AHRS: add event topic/frame_id and sequence IDs; fix extrinsic/diagnostics docs

### DIFF
--- a/docs/AHRS.md
+++ b/docs/AHRS.md
@@ -1,0 +1,610 @@
+# AHRS Design Document
+
+This document defines the **state-space model** and **time-handling policy** for an AHRS that uses:
+
+- a continuous-time **process model**: kinematic evolution + slow parameter drift (priors), and
+- discrete-time **measurement models**:
+  - IMU gyro + accel measurements (`imu_raw`) and
+  - magnetometer measurements (`magnetic_field`),
+
+all applied on a common time axis with deterministic fixed-lag replay.
+
+---
+
+## World / Odom frame contract
+
+The AHRS publishes the standard TF chain:
+
+`world -> odom -> base_link`
+
+Policy (no teleports, no global correction):
+
+- `world` is initialized at startup to the origin (continuous).
+- `odom` is continuous and **drifts locally**.
+- There are no discontinuities because no global constraints exist.
+
+Recommended implementation contract:
+
+- Publish `TF: world -> odom` as identity for the entire session:
+  - `T_WO := I`
+- Publish `TF: odom -> base_link` as the AHRS estimate:
+  - `T_OB := T_WB` (since `world == odom` under the identity `T_WO`)
+
+This keeps the TF tree compatible with a future localization EKF that may later produce non-identity `T_WO`.
+
+---
+
+## 1. ROS Inputs
+
+### 1.1 Streams
+
+- Single `message_filters` combination (ExactTime) producing an **IMU packet**:
+  - `imu_raw` (`sensor_msgs/Imu`): inertial sample stream (time-stamped)
+  - `imu_calibration` (`oasis_msgs/ImuCalibration`): calibration priors + uncertainty
+    - **Semantic rule:** used **only once** to initialize in-state calibration parameters (initial prior).
+    - After initialization, `imu_calibration` contents are ignored (except diagnostics / consistency checks).
+- `magnetic_field` (`sensor_msgs/MagneticField`): magnetometer samples (time-stamped)
+
+---
+
+### 1.2 `imu_raw` — `sensor_msgs/Imu`
+
+Used fields:
+
+- `header.stamp` (`t_meas`)
+- `header.frame_id` → IMU frame `{I}`
+- `angular_velocity` `ω_raw` and **full** `angular_velocity_covariance` `Σ_ω_raw` (3×3)
+- `linear_acceleration` `a_raw` and **full** `linear_acceleration_covariance` `Σ_a_raw` (3×3)
+
+Ignored:
+
+- `orientation`, `orientation_covariance`
+
+Requirements:
+
+- Covariances are interpreted as **per-sample measurement noise**.
+- `ω_raw`, `a_raw` are expressed in `{I}`.
+- Do not diagonalize any provided covariance.
+
+---
+
+### 1.3 `imu_calibration` — `oasis_msgs/ImuCalibration`
+
+Role: **one-shot initialization prior** for systematic parameters that live in the shared state.
+
+Validity:
+
+- If `valid == false`, ignore.
+
+Frame:
+
+- `header.frame_id` must match `imu_raw.header.frame_id` (calibration is defined in `{I}`).
+
+Models (parameter meaning):
+
+- Accel: `a_corr = A_a (a_raw − b_a)` where `b_a, A_a` are **in-state**
+- Gyro: `ω_corr = ω_raw − b_g` where `b_g` is **in-state**
+
+Requirements:
+
+- Consume **only while uninitialized**:
+  - The **first** valid calibration observed is applied as an initial prior on `(b_a, A_a, b_g)` with its covariance.
+  - After initialization, ignore subsequent calibration messages (except diagnostics).
+- Calibration uncertainty is **systematic parameter uncertainty**, not per-sample noise.
+- Always use full covariance matrices when provided (do not diagonalize).
+
+---
+
+### 1.4 `magnetic_field` — `sensor_msgs/MagneticField`
+
+Used fields:
+
+- `header.stamp` (`t_meas`)
+- `header.frame_id` → mag frame `{M}`
+- `magnetic_field` `m_raw`
+- **full** `magnetic_field_covariance` `Σ_m_raw` (3×3)
+
+Measurement convention:
+
+- Form magnetometer residual in `{M}` (do not rotate the raw measurement into `{B}`):
+  - `z := m_raw` in `{M}`
+  - `z_hat := m̂_M` in `{M}`
+  - `ν := z - z_hat` in `{M}`
+
+Noise interpretation:
+
+- `Σ_m_raw` is the driver’s estimate of measurement noise covariance and is used as a prior / input to the
+  internally maintained `R_m(t)` (but not treated as per-sample truth).
+- Do not diagonalize any provided covariance.
+
+Adaptive noise policy (covariance matching):
+
+- Initialize `R_m0` from first valid `Σ_m_raw`, else default:
+  - `R_m0 = diag([4e-10, 4e-10, 4e-10])` (tesla²) (20 µT RMS per axis)
+- Maintain adaptive `R_m(t)` bounded SPD:
+  - `R_min = diag([1e-12, 1e-12, 1e-12])` (tesla²)
+  - `R_max = diag([2.5e-9, 2.5e-9, 2.5e-9])` (tesla²)
+- Update:
+  - Let innovation be `ν_k`, predicted innovation covariance excluding R be `Ŝ_k = HPHᵀ`
+  - `R_m ← clamp_SPD( (1-α) R_m + α (ν_k ν_kᵀ - Ŝ_k), R_min, R_max )`
+  - default `α = 0.01`
+
+---
+
+## 2. Frames and Extrinsics
+
+Frames:
+
+- `{W}`: world frame, ROS frame_id = `world`
+- `{O}`: odom frame, ROS frame_id = `odom`
+- `{B}`: body frame, ROS child_frame_id = `base_link`
+- `{I}`: IMU measurement frame (`imu_raw.header.frame_id`)
+- `{M}`: magnetometer frame (`magnetic_field.header.frame_id`)
+
+Estimated extrinsics (in-state):
+
+- `T_BI` (IMU → body)
+- `T_BM` (mag → body)
+
+Parameterization:
+
+- Poses in SE(3): quaternion rotation + 3-vector translation
+- Uncertainty: 6D tangent (δρ, δθ) for SE(3) quantities
+
+Initialization priors (broad but finite; full covariances allowed and recommended):
+
+- `T_BI` prior:
+  - mean: identity
+  - rotation stddev: `π` rad per axis (tangent)
+  - translation stddev: `1.0 m` per axis
+- `T_BM` prior:
+  - mean: identity
+  - rotation stddev: `π` rad per axis (tangent)
+  - translation stddev: `1.0 m` per axis
+
+---
+
+## 3. State, Process Model, and Measurement Models
+
+This AHRS is a **single optimizer** over a **shared state** with multiple models.
+
+### 3.1 State (full model)
+
+The AHRS maintains a full navigation + calibration + extrinsic state:
+
+Navigation (in `{W}` unless noted):
+
+- Position: `p_WB ∈ ℝ³`
+- Velocity: `v_WB ∈ ℝ³`
+- Attitude: `q_WB` (unit quaternion, world → body rotation)
+
+IMU systematic parameters:
+
+- Gyro bias: `b_g ∈ ℝ³`
+- Accel bias: `b_a ∈ ℝ³`
+- Accel scale/misalignment: `A_a ∈ ℝ^{3×3}` (full matrix)
+
+Extrinsics (sensor-to-body in SE(3)):
+
+- `T_BI ∈ SE(3)` (IMU → body)
+- `T_BM ∈ SE(3)` (mag → body)
+
+Environment / reference vectors (kept in-state, full covariance):
+
+- Gravity vector in world: `g_W ∈ ℝ³`
+- Earth magnetic field vector in world: `m_W ∈ ℝ³`
+
+Full covariance policy:
+
+- The AHRS maintains a single covariance `P` over its internal error-state.
+- Do not diagonalize:
+  - any incoming sensor covariance (`Σ_ω_raw`, `Σ_a_raw`, `Σ_m_raw`),
+  - any priors / initialization covariances,
+  - or internal state covariance blocks.
+
+---
+
+### 3.2 Error-state definition (for covariance)
+
+The AHRS uses an error-state EKF.
+
+Representative error coordinates:
+
+- `δp, δv ∈ ℝ³`
+- `δθ ∈ ℝ³` small-angle attitude error s.t. `q_WB ≈ Exp(δθ) ⊗ q̂_WB`
+- `δb_g, δb_a ∈ ℝ³`
+- `δA_a ∈ ℝ⁹` (row-major perturbation of `A_a`) or an equivalent minimal parameterization
+- `δξ_BI ∈ ℝ⁶`, `δξ_BM ∈ ℝ⁶` (SE(3) tangent: translation + rotation)
+- `δg_W, δm_W ∈ ℝ³`
+
+`P` is the covariance over the stacked error-state vector above (full matrix).
+
+---
+
+### 3.3 Continuous-time process model (kinematic prior + slow drift)
+
+The process model provides time evolution between measurements. Sensor data does **not** drive propagation in this option;
+IMU and mag are measurement updates.
+
+Define continuous-time dynamics:
+
+Navigation kinematics:
+
+- `ṗ_WB = v_WB`
+- `v̇_WB = g_W + w_v`
+- `q̇_WB = 1/2 * Ω(ω_WB) * q_WB`
+
+where:
+- `ω_WB` is the body angular rate (world → body) treated as **latent** (not directly measured in the process model),
+  modeled as:
+  - `ω_WB = w_ω`
+- `w_v`, `w_ω` are zero-mean white noises (continuous-time) representing smoothness priors.
+
+Systematic parameter drift (random walks):
+
+- `ḃ_g = w_bg`
+- `ḃ_a = w_ba`
+- `Ȧ_a = W_A` (element-wise random walk; `vec(Ȧ_a) = w_A`)
+- `Ṫ_BI = W_BI` (SE(3) random walk in tangent; `δξ̇_BI = w_BI`)
+- `Ṫ_BM = W_BM` (SE(3) random walk in tangent; `δξ̇_BM = w_BM`)
+
+Reference vector drift (slow):
+
+- `ġ_W = w_g`
+- `ṁ_W = w_m`
+
+Notes:
+
+- This process is intentionally **weak**: it encodes “motion is smooth” and “parameters drift slowly”.
+- The IMU measurements will strongly constrain the state at high rate.
+
+Process noise covariance:
+
+- Continuous-time noise intensities:
+  - `Q_c = cov([w_v, w_ω, w_bg, w_ba, w_A, w_BI, w_BM, w_g, w_m])`
+- `Q_c` may be block-diagonal by default, but the **state covariance P is full** and will develop cross-terms through
+  Jacobians and updates.
+- If you have known cross-correlations (e.g., coupled accel axes), you may encode them in `Q_c` (full blocks permitted).
+
+Discretization:
+
+- Over interval `Δt`, compute discrete `F_k` and `Q_k` using a standard EKF discretization
+  (e.g., first-order: `Q_k ≈ G Q_c Gᵀ Δt`, with `F_k ≈ I + AΔt`),
+  keeping full matrices.
+
+---
+
+### 3.4 IMU measurement model (discrete-time)
+
+At each `imu_raw` timestamp `t_k`, treat IMU outputs as measurements.
+
+#### 3.4.1 Frame handling for IMU
+
+- IMU raw signals are in `{I}`.
+- Use the estimated extrinsic `T_BI` to relate `{I}` and `{B}`:
+  - Let `R_BI` be the rotation from IMU to body from `T_BI`.
+  - Then body-to-IMU rotation is `R_IB = R_BIᵀ`.
+
+#### 3.4.2 Gyro measurement
+
+Measurement:
+
+- `z_ω := ω_raw` in `{I}` with covariance `R_ω := Σ_ω_raw` (full 3×3)
+
+Prediction:
+
+- Predict IMU-frame angular rate as:
+  - `ω̂_I = R_IB * ω_WB + b_g`
+
+Residual:
+
+- `ν_ω = z_ω - ω̂_I` (in `{I}`)
+
+#### 3.4.3 Accelerometer measurement
+
+Measurement:
+
+- `z_a := a_raw` in `{I}` with covariance `R_a := Σ_a_raw` (full 3×3)
+
+Specific-force prediction:
+
+- Compute world-frame acceleration of the body origin from kinematics:
+  - `a_WB := v̇_WB` (from process state; in the mean model, `v̇_WB ≈ g_W`, but this is refined by measurements)
+- Specific force in body frame is:
+  - `f_B = R_BW * (a_WB - g_W)` where `R_BW` is world → body rotation from `q_WB`
+- Convert to IMU frame:
+  - `f_I = R_IB * f_B`
+
+Apply accel systematic model (as defined by calibration semantics):
+
+- The measurement model uses:
+  - `a_corr = A_a (a_raw − b_a)`
+- Equivalently, the predicted raw measurement is:
+  - `â_raw = A_a^{-1} * f_I + b_a`
+
+Prediction:
+
+- `â_I = A_a^{-1} * f_I + b_a`
+
+Residual:
+
+- `ν_a = z_a - â_I` (in `{I}`)
+
+Notes:
+
+- The above uses a full 3×3 `A_a`. If `A_a` is near-singular, the state/prior must prevent it (bounded parameterization
+  recommended). The covariance remains full regardless of parameterization.
+- `R_a` is always taken as the provided full covariance (or a configured fallback if invalid).
+
+---
+
+### 3.5 Magnetometer measurement model (discrete-time)
+
+At each `magnetic_field` timestamp `t_k`:
+
+- Measurement: `z_m := m_raw` in `{M}`
+- Covariance input: `Σ_m_raw` (full 3×3), used to initialize / inform the adaptive `R_m(t)`.
+
+Prediction (in `{M}`; residual always formed in `{M}`):
+
+- Let `R_BM` be the rotation of `T_BM` (mag → body), so body→mag is `R_MB = R_BMᵀ`.
+- Let `R_BW` be world → body rotation from `q_WB`.
+- Predict:
+  - `m̂_M = R_MB * R_BW * m_W`
+
+Residual:
+
+- `ν_m = z_m - m̂_M` in `{M}`
+
+Measurement noise used:
+
+- `R_m(t)` (adaptive, bounded SPD; full 3×3)
+
+---
+
+## 4. Time Axis, Buffer, and Deterministic Replay (Fixed-lag)
+
+This AHRS uses the same deterministic fixed-lag design as the EKF spec.
+
+### 4.1 Time definitions
+
+- `t_meas`: `header.stamp` from the incoming message (authoritative event time)
+- `t_now`: receipt time (diagnostics only)
+- `t_filter`: max `t_meas` among **accepted** messages (frontier)
+
+Event-driven: each accepted message attaches at `t_meas`. Out-of-order messages are supported via fixed-lag replay.
+
+### 4.2 Message roles
+
+- **Measurement updates (high-rate):** `imu_raw` (gyro + accel updates)
+- **Initialization prior (one-shot):** `imu_calibration`
+- **Measurement updates:** `magnetic_field`
+- **Process model:** runs continuously between time nodes as the kinematic prior and slow parameter drift.
+
+### 4.3 IMU packet synchronization contract
+
+The AHRS consumes IMU as a synchronized pair:
+
+- `imu_pkt = (imu_raw, imu_calibration)` produced by `message_filters` using **ExactTime**.
+
+Timestamp policy:
+
+- Packet time: `t_meas := imu_raw.header.stamp`
+- Require `imu_calibration.header.stamp == imu_raw.header.stamp`; reject packet if not.
+
+Semantic policy:
+
+- `imu_calibration` is used **only before initialization** to set priors on `(b_a, A_a, b_g)` with full covariance.
+- After initialization, `imu_calibration` is ignored (except diagnostics).
+- `imu_raw` always produces measurement updates (gyro + accel) when accepted.
+
+### 4.4 Buffer model
+
+Maintain a time-ordered ring buffer of time nodes over fixed lag `T_buffer_sec`.
+
+Each node at `t_k` stores:
+
+- state mean `x_k`, covariance `P_k`
+- messages attached at `t_k` (IMU packet, mag)
+- sufficient metadata to re-run deterministic replay
+
+Node rules:
+
+- One node per distinct timestamp.
+- Multiple messages may attach to the same node.
+- Evict nodes older than `t_filter - T_buffer_sec` (with diagnostics).
+
+### 4.5 Propagation convention
+
+Between time nodes, propagate with the continuous-time process model (Section 3.3), discretized over each interval.
+
+Strict coverage rule:
+
+- For deterministic replay, the AHRS must be able to propagate across any interval used in replay.
+- If there is a timestamp gap larger than `Δt_imu_max` between consecutive nodes required to cover replay,
+  reject replay across that gap and emit diagnostics.
+
+### 4.6 Insertion + replay (deterministic)
+
+On message arrival:
+
+1. Validate timestamp
+   - reject missing/invalid
+   - reject `t_meas > t_now + ε_wall_future`
+
+2. Fixed-lag window
+   - if `t_filter` exists and `t_meas < t_filter - T_buffer_sec`, reject as too old
+
+3. Attach
+   - insert/attach message to node `t_meas` (create node if needed)
+
+4. Update frontier / replay
+   - if `t_meas > t_filter`: advance `t_filter` and propagate forward
+   - else: apply update at `t_meas`, then replay forward to `t_filter`
+
+Per-node application order (stable):
+
+1. Apply any priors/parameter constraints at `t_k` (including one-shot calibration prior if first valid)
+2. Apply measurement updates at `t_k` in stable tie-break order:
+   - lexicographic `(message_type, topic, frame_id)`
+   - Within IMU: apply gyro update then accel update (fixed order)
+
+Replay must never depend on arrival order.
+
+### 4.7 Drop / reset rules
+
+Reject and emit diagnostics if:
+
+- missing timestamp
+- required covariance contains NaN/Inf
+- message outside fixed-lag window
+- propagation coverage insufficient (`Δt_imu_max` violated)
+- clock discontinuity detected: reset filter + buffer if `|t_meas - t_filter| > Δt_clock_jump_max`
+  - Reset effects (explicit):
+    - clear the time buffer and set `t_filter` to unset
+    - set `initialized = false`
+    - allow consumption of the next valid `imu_calibration` as a new initialization prior
+    - reset adaptive `R_m(t)` to `R_m0`
+
+---
+
+### 4.8 Output publish trigger (explicit)
+
+The AHRS publishes "current estimate" outputs **only when the frontier advances**.
+
+- Let `t_filter_prev` be the frontier before processing an incoming message.
+- After processing a message:
+  - If `t_meas > t_filter_prev` (frontier advance), the filter propagates to `t_meas`, applies updates at `t_meas`,
+    sets `t_filter := t_meas`, and **publishes**:
+      - TF (`world -> odom`, `odom -> base_link`) stamped `t_filter`
+      - odometry outputs stamped `t_filter`
+      - `oasis_msgs/AhrsState` stamped `t_filter`
+      - `oasis_msgs/AhrsDiagnostics` stamped `t_filter`
+  - If `t_meas <= t_filter_prev` (out-of-order insertion), the filter may replay internally to maintain consistency at
+    `t_filter`, but **does not republish** TF/odometry/state/diagnostics (to avoid emitting past timestamps).
+
+Per-measurement update reports (`oasis_msgs/EkfUpdateReport`) are published at the measurement timestamp `t_meas` for
+every accepted/rejected update, regardless of whether the frontier advanced.
+
+---
+
+## 5. Outputs (poses + covariances + measurement stats)
+
+The AHRS publishes:
+
+1. state estimates in ROS-standard frames (`world`, `odom`, `base_link`)
+2. full covariances for those estimates (not diagonalized)
+3. per-measurement innovation / gating statistics (so “all measurements” have covariances too)
+
+### 5.1 TF
+
+- Broadcast `TF: odom -> base_link` from `T_OB` (`stamp = t_filter`)
+- Broadcast `TF: world -> odom` as identity (`stamp = t_filter`)
+
+TF is published on `/tf` (standard tf2 broadcaster).
+
+### 5.2 Odometry messages
+
+**(A) `nav_msgs/Odometry` in `odom`**
+
+- Topic: `ahrs/odom`
+- `header.stamp = t_filter`
+- `header.frame_id = "odom"`
+- `child_frame_id = "base_link"`
+- Pose: `T_OB` (translation from `p_WB`, rotation from `q_WB`)
+- Twist: derived from state (e.g., linear from `v_WB`, angular from `ω_WB` estimate as implied by IMU updates)
+- Covariance: derived from `P` (full covariance propagation, mapped into ROS odom convention)
+
+**(B) `nav_msgs/Odometry` in `world`**
+
+- Topic: `ahrs/world_odom`
+- Same values as (A) under `T_WO = I` contract; covariances derived from the same `P`.
+
+### 5.3 Extrinsic outputs
+
+- `geometry_msgs/PoseWithCovarianceStamped`:
+  - Topic: `ahrs/extrinsics/t_bi` for `T_BI`
+  - Topic: `ahrs/extrinsics/t_bm` for `T_BM`
+  - `header.stamp = t_filter`
+  - `header.frame_id = "base_link"`
+  - Covariance derived from `P` (full 6×6, not diagonalized)
+  - Publish: **on frontier advance** (Section 4.8)
+
+### 5.4 Covariance transformation rules
+
+The AHRS maintains a single covariance `P` over its internal error-state. Published covariances are obtained by:
+
+`Σ_y = J * P * Jᵀ`, with `J = ∂g/∂x` evaluated at `x̂`.
+
+For SE(3) pose errors in tangent (δρ, δθ), use the adjoint:
+
+`Σ_A = Ad_{T_AB} * Σ_B * Ad_{T_AB}ᵀ`
+
+All covariance matrices are full and must remain symmetric positive definite (or PSD as appropriate).
+
+### 5.5 Per-measurement reports
+
+Publish one report entry for every accepted/rejected update:
+
+- `ahrs/updates/accel`
+- `ahrs/updates/gyro`
+- `ahrs/updates/mag`
+
+Contents (recommended):
+
+- `header.stamp = t_meas`
+- `z`, `z_hat`, innovation `ν`
+- measurement noise used `R` (full)
+- predicted innovation covariance excluding R: `Ŝ = HPHᵀ`
+- total innovation covariance `S = Ŝ + R`
+- Mahalanobis distance `d² = νᵀ S^{-1} ν`
+- gating threshold + accept/reject flag
+
+Each per-measurement topic publishes `oasis_msgs/EkfUpdateReport` stamped at `t_meas` for every accepted/rejected update.
+
+### 5.6 `oasis_msgs/AhrsState` (full state + full covariance)
+
+- Topic: `ahrs/state`
+- Publish: **on frontier advance** (Section 4.8)
+- `header.stamp = t_filter`
+- Contents: full mean state (navigation + calibration + extrinsics + `g_W`, `m_W`) and full error-state covariance `P`
+  with explicit ordering (`error_state_names`). No diagonalization.
+
+### 5.7 `oasis_msgs/AhrsDiagnostics` (buffer + drop/replay stats)
+
+- Topic: `ahrs/diag`
+- Publish: **on frontier advance** (Section 4.8)
+- `header.stamp = t_filter`
+- Contents: buffer size/span, replay flag, and monotonic drop/reset counters.
+
+---
+
+## 6. Config Parameters
+
+Frames:
+
+- `world_frame_id` (default `"world"`)
+- `odom_frame_id` (default `"odom"`)
+- `body_frame_id` (default `"base_link"`)
+
+Time / buffering:
+
+- `T_buffer_sec`
+- `ε_wall_future`
+- `Δt_clock_jump_max`
+- `Δt_imu_max`
+
+Process noise intensities (continuous-time):
+
+- `Q_v` (for `w_v`)
+- `Q_ω` (for `w_ω`)
+- `Q_bg`, `Q_ba`
+- `Q_A` (for `vec(A_a)` drift)
+- `Q_BI`, `Q_BM` (for extrinsic drift in SE(3) tangent)
+- `Q_g`, `Q_m` (for `g_W`, `m_W` drift)
+
+Magnetometer adaptive noise:
+
+- `α`
+- `R_min`, `R_max`
+- default `R_m0` (if no valid `Σ_m_raw` observed)

--- a/oasis_control/launch/control_launch.py
+++ b/oasis_control/launch/control_launch.py
@@ -69,6 +69,7 @@ def generate_launch_description() -> LaunchDescription:
     # Navigation
     if HOST_ID == "falcon":
         # ControlDescriptions.add_ekf_localizer(ld, HOST_ID, apriltag_resolution="hd")
+        ControlDescriptions.add_ahrs(ld, HOST_ID)
         ControlDescriptions.add_imu_fuser(ld, HOST_ID)
         ControlDescriptions.add_speedometer(ld, HOST_ID)
         ControlDescriptions.add_tilt_sensor(ld, HOST_ID)

--- a/oasis_control/oasis_control/cli/ahrs_cli.py
+++ b/oasis_control/oasis_control/cli/ahrs_cli.py
@@ -1,0 +1,38 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""
+ROS entry point for the AHRS node
+"""
+
+from typing import Optional
+
+import rclpy
+
+from oasis_control.nodes.ahrs_node import AhrsNode
+
+
+################################################################################
+# ROS entry point
+################################################################################
+
+
+def main(args: Optional[list[str]] = None) -> None:
+    rclpy.init(args=args)
+
+    node: AhrsNode = AhrsNode()
+
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.stop()
+        rclpy.shutdown()

--- a/oasis_control/oasis_control/launch/control_descriptions.py
+++ b/oasis_control/oasis_control/launch/control_descriptions.py
@@ -29,6 +29,31 @@ CONTROL_PACKAGE_NAME: str = "oasis_control"
 
 class ControlDescriptions:
     #
+    # AHRS
+    #
+
+    @staticmethod
+    def add_ahrs(ld: LaunchDescription, host_id: str) -> None:
+        ahrs_node: Node = Node(
+            namespace=ROS_NAMESPACE,
+            package=CONTROL_PACKAGE_NAME,
+            executable="ahrs",
+            name=f"ahrs_{host_id}",
+            output="screen",
+            remappings=[
+                ("ahrs/extrinsics/t_bi", f"{host_id}/ahrs/extrinsics/t_bi"),
+                ("ahrs/extrinsics/t_bm", f"{host_id}/ahrs/extrinsics/t_bm"),
+                ("ahrs/updates/accel", f"{host_id}/ahrs/updates/accel"),
+                ("ahrs/updates/gyro", f"{host_id}/ahrs/updates/gyro"),
+                ("ahrs/updates/mag", f"{host_id}/ahrs/updates/mag"),
+                ("imu_calibration", f"{host_id}/imu_calibration"),
+                ("imu_raw", f"{host_id}/imu_raw"),
+                ("magnetic_field", f"{host_id}/magnetic_field"),
+            ],
+        )
+        ld.add_action(ahrs_node)
+
+    #
     # EKF localizer
     #
 

--- a/oasis_control/oasis_control/localization/ahrs/ahrs_types.py
+++ b/oasis_control/oasis_control/localization/ahrs/ahrs_types.py
@@ -198,11 +198,15 @@ class AhrsEvent:
 
     Fields:
         t_meas: Measurement timestamp
+        topic: Topic name that produced the event
+        frame_id: Frame identifier from the event header
         event_type: Event category for dispatching updates
         payload: Event data payload for the selected type
     """
 
     t_meas: AhrsTime
+    topic: str
+    frame_id: str
     event_type: AhrsEventType
     payload: AhrsEventPayload
 
@@ -266,6 +270,7 @@ class AhrsStateData:
 
     Fields:
         t_filter: Filter frontier timestamp for this state
+        state_seq: Monotonic state sequence identifier
         initialized: True when the filter has a valid initial state
         world_frame_id: World frame identifier for the state
         odom_frame_id: Odometry frame identifier for the state
@@ -276,8 +281,8 @@ class AhrsStateData:
         b_g_rps: Gyro bias in rad/s, XYZ order
         b_a_mps2: Accel bias in m/s^2, XYZ order
         a_a: Accel scale/misalignment matrix, 3x3 row-major
-        t_bi: Body to IMU transform
-        t_bm: Body to magnetometer transform
+        t_bi: IMU -> body transform (T_BI)
+        t_bm: Magnetometer -> body transform (T_BM)
         g_w_mps2: Gravity vector in world in m/s^2, XYZ order
         m_w_t: Magnetic field vector in world in tesla, XYZ order
         error_state_names: Names of error-state entries in the covariance
@@ -285,6 +290,7 @@ class AhrsStateData:
     """
 
     t_filter: AhrsTime
+    state_seq: int
     initialized: bool
     world_frame_id: str
     odom_frame_id: str
@@ -310,7 +316,8 @@ class AhrsDiagnosticsData:
 
     Fields:
         t_filter: Filter frontier timestamp if an output was published
-        buffer_node_count: Number of events currently buffered
+        diag_seq: Monotonic diagnostics sequence identifier
+        buffer_node_count: Number of time nodes currently buffered
         buffer_span_sec: Time span of buffered events in seconds
         replay_happened: True when a replay was triggered
         dropped_missing_stamp: Count of updates dropped for missing stamps
@@ -324,6 +331,7 @@ class AhrsDiagnosticsData:
     """
 
     t_filter: Optional[AhrsTime]
+    diag_seq: int
     buffer_node_count: int
     buffer_span_sec: float
     replay_happened: bool

--- a/oasis_control/oasis_control/localization/ahrs/ahrs_types.py
+++ b/oasis_control/oasis_control/localization/ahrs/ahrs_types.py
@@ -1,0 +1,363 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""
+Types and helpers for AHRS localization
+"""
+
+import enum
+from dataclasses import dataclass
+from typing import Literal
+from typing import Optional
+from typing import Union
+
+
+@dataclass(frozen=True)
+class AhrsTime:
+    """
+    AHRS timestamp stored as seconds and nanoseconds
+
+    Fields:
+        sec: Whole seconds since the AHRS time reference
+        nanosec: Sub-second remainder in nanoseconds [0, 1e9)
+    """
+
+    sec: int
+    nanosec: int
+
+
+AhrsFrameId = Literal["world", "odom", "base_link"]
+
+
+@dataclass(frozen=True)
+class AhrsFrameTransform:
+    """
+    Rigid transform between semantic frames
+
+    Fields:
+        parent_frame: Semantic parent frame
+        child_frame: Semantic child frame
+        translation_m: Translation in meters, XYZ order
+        rotation_wxyz: Quaternion rotation in wxyz order, unit length
+    """
+
+    parent_frame: AhrsFrameId
+    child_frame: AhrsFrameId
+    translation_m: list[float]
+    rotation_wxyz: list[float]
+
+
+@dataclass(frozen=True)
+class AhrsSe3Transform:
+    """
+    Rigid transform between arbitrary frames
+
+    Fields:
+        parent_frame: Parent frame name for the transform
+        child_frame: Child frame name for the transform
+        translation_m: Translation in meters, XYZ order
+        rotation_wxyz: Quaternion rotation in wxyz order, unit length
+    """
+
+    parent_frame: str
+    child_frame: str
+    translation_m: list[float]
+    rotation_wxyz: list[float]
+
+
+@dataclass(frozen=True)
+class AhrsFrameOutputs:
+    """
+    Frame outputs derived from the canonical odom state
+
+    Fields:
+        t_odom_base: Transform from odom to base
+        t_world_odom: Transform from world to odom
+        t_world_base: Transform from world to base derived by composition
+    """
+
+    t_odom_base: AhrsFrameTransform
+    t_world_odom: AhrsFrameTransform
+    t_world_base: AhrsFrameTransform
+
+
+class AhrsEventType(enum.Enum):
+    """
+    Enumerates the kinds of time-ordered AHRS events
+
+    Attributes:
+        IMU: Inertial sample or IMU packet event
+        MAG: Magnetometer measurement event
+    """
+
+    IMU = "imu"
+    MAG = "mag"
+
+
+@dataclass(frozen=True)
+class ImuCalibrationData:
+    """
+    Calibration prior data for IMU bias and scale parameters
+
+    Fields:
+        valid: True when the calibration payload is safe to apply
+        frame_id: IMU frame identifier expected to match the IMU sample frame
+        accel_bias_mps2: Accelerometer bias in m/s^2, XYZ order
+        accel_a: 3x3 accel scale/misalignment matrix, row-major
+        accel_param_cov: 12x12 covariance of accel calibration params
+        gyro_bias_rps: Gyroscope bias in rad/s, XYZ order
+        gyro_bias_cov: 3x3 covariance of gyro bias params, row-major
+        gravity_mps2: Gravity magnitude assumed during calibration in m/s^2
+        fit_sample_count: Number of samples used in the calibration fit
+        rms_residual_mps2: RMS gravity residual of the calibration in m/s^2
+        temperature_c: Mean calibration temperature in deg C
+        temperature_var_c2: Temperature variance in (deg C)^2
+    """
+
+    valid: bool
+    frame_id: str
+    accel_bias_mps2: list[float]
+    accel_a: list[float]
+    accel_param_cov: list[float]
+    gyro_bias_rps: list[float]
+    gyro_bias_cov: list[float]
+    gravity_mps2: float
+    fit_sample_count: int
+    rms_residual_mps2: float
+    temperature_c: float
+    temperature_var_c2: float
+
+
+@dataclass(frozen=True)
+class ImuSample:
+    """
+    IMU sample with raw motion data
+
+    Fields:
+        frame_id: IMU frame identifier for this sample
+        angular_velocity_rps: Angular velocity in rad/s, XYZ order
+        linear_acceleration_mps2: Linear acceleration in m/s^2, XYZ order
+        angular_velocity_cov: 3x3 gyro covariance, row-major
+        linear_acceleration_cov: 3x3 accel covariance, row-major
+    """
+
+    frame_id: str
+    angular_velocity_rps: list[float]
+    linear_acceleration_mps2: list[float]
+    angular_velocity_cov: list[float]
+    linear_acceleration_cov: list[float]
+
+
+@dataclass(frozen=True)
+class AhrsImuPacket:
+    """
+    IMU packet event payload
+
+    Fields:
+        imu: Raw IMU measurement sample
+        calibration: IMU calibration prior tied to the IMU frame
+    """
+
+    imu: ImuSample
+    calibration: ImuCalibrationData
+
+
+@dataclass(frozen=True)
+class MagSample:
+    """
+    Magnetometer sample data
+
+    Fields:
+        frame_id: Magnetometer frame identifier
+        magnetic_field_t: Magnetic field vector in tesla, XYZ order
+        magnetic_field_cov: 3x3 covariance in tesla^2, row-major
+    """
+
+    frame_id: str
+    magnetic_field_t: list[float]
+    magnetic_field_cov: list[float]
+
+
+AhrsEventPayload = Union[
+    AhrsImuPacket,
+    MagSample,
+]
+
+
+@dataclass(frozen=True)
+class AhrsEvent:
+    """
+    Time-stamped AHRS event in the common filter timeline
+
+    Fields:
+        t_meas: Measurement timestamp
+        event_type: Event category for dispatching updates
+        payload: Event data payload for the selected type
+    """
+
+    t_meas: AhrsTime
+    event_type: AhrsEventType
+    payload: AhrsEventPayload
+
+
+@dataclass(frozen=True)
+class AhrsMatrix:
+    """
+    Row-major matrix data used by update reporting
+
+    Fields:
+        rows: Number of rows in the matrix
+        cols: Number of columns in the matrix
+        data: Row-major matrix entries
+    """
+
+    rows: int
+    cols: int
+    data: list[float]
+
+
+@dataclass(frozen=True)
+class AhrsUpdateData:
+    """
+    Generic update report payload
+
+    Fields:
+        sensor: Sensor name such as gyro, accel, or mag
+        frame_id: Measurement frame identifier
+        t_meas: Measurement timestamp
+        accepted: True when the update was accepted by the filter
+        reject_reason: Optional reason string when the update is rejected
+        z: Measurement vector in sensor units, as received
+        z_hat: Predicted measurement vector in sensor units
+        nu: Innovation vector (z - z_hat) in sensor units
+        r: Measurement covariance in sensor units, row-major
+        s_hat: Predicted innovation covariance, row-major
+        s: Innovation covariance after conditioning, row-major
+        maha_d2: Mahalanobis distance squared for gating
+        gate_threshold: Gate threshold for the Mahalanobis distance
+    """
+
+    sensor: str
+    frame_id: str
+    t_meas: AhrsTime
+    accepted: bool
+    reject_reason: Optional[str]
+    z: list[float]
+    z_hat: list[float]
+    nu: list[float]
+    r: AhrsMatrix
+    s_hat: AhrsMatrix
+    s: AhrsMatrix
+    maha_d2: float
+    gate_threshold: float
+
+
+@dataclass(frozen=True)
+class AhrsStateData:
+    """
+    Filter state output payload for AhrsState publication
+
+    Fields:
+        t_filter: Filter frontier timestamp for this state
+        initialized: True when the filter has a valid initial state
+        world_frame_id: World frame identifier for the state
+        odom_frame_id: Odometry frame identifier for the state
+        body_frame_id: Body frame identifier for the state
+        p_wb_m: Position of the body in world in meters, XYZ order
+        v_wb_mps: Velocity of the body in world in m/s, XYZ order
+        q_wb_wxyz: Orientation of the body in world, quaternion wxyz order
+        b_g_rps: Gyro bias in rad/s, XYZ order
+        b_a_mps2: Accel bias in m/s^2, XYZ order
+        a_a: Accel scale/misalignment matrix, 3x3 row-major
+        t_bi: Body to IMU transform
+        t_bm: Body to magnetometer transform
+        g_w_mps2: Gravity vector in world in m/s^2, XYZ order
+        m_w_t: Magnetic field vector in world in tesla, XYZ order
+        error_state_names: Names of error-state entries in the covariance
+        p_cov: Full error-state covariance, row-major
+    """
+
+    t_filter: AhrsTime
+    initialized: bool
+    world_frame_id: str
+    odom_frame_id: str
+    body_frame_id: str
+    p_wb_m: list[float]
+    v_wb_mps: list[float]
+    q_wb_wxyz: list[float]
+    b_g_rps: list[float]
+    b_a_mps2: list[float]
+    a_a: list[float]
+    t_bi: AhrsSe3Transform
+    t_bm: AhrsSe3Transform
+    g_w_mps2: list[float]
+    m_w_t: list[float]
+    error_state_names: list[str]
+    p_cov: AhrsMatrix
+
+
+@dataclass(frozen=True)
+class AhrsDiagnosticsData:
+    """
+    Diagnostics output payload for AhrsDiagnostics publication
+
+    Fields:
+        t_filter: Filter frontier timestamp if an output was published
+        buffer_node_count: Number of events currently buffered
+        buffer_span_sec: Time span of buffered events in seconds
+        replay_happened: True when a replay was triggered
+        dropped_missing_stamp: Count of updates dropped for missing stamps
+        dropped_future_stamp: Count of updates dropped for future stamps
+        dropped_too_old: Count of updates dropped for being too old
+        dropped_nan_cov: Count of updates dropped for NaN covariance entries
+        dropped_imu_gap: Count of updates dropped for IMU gap detection
+        dropped_clock_jump_reset: Count of updates dropped for clock jump reset
+        reset_count: Number of filter resets performed
+        last_reset_reason: Latest reset reason description
+    """
+
+    t_filter: Optional[AhrsTime]
+    buffer_node_count: int
+    buffer_span_sec: float
+    replay_happened: bool
+    dropped_missing_stamp: int
+    dropped_future_stamp: int
+    dropped_too_old: int
+    dropped_nan_cov: int
+    dropped_imu_gap: int
+    dropped_clock_jump_reset: int
+    reset_count: int
+    last_reset_reason: str
+
+
+@dataclass(frozen=True)
+class AhrsOutputs:
+    """
+    Outputs produced by AHRS event processing
+
+    Fields:
+        frontier_advanced: True when the filter frontier advanced on this event
+        t_filter: Frontier timestamp for the current estimate outputs
+        frame_transforms: Frame transforms derived from the AHRS state
+        state: State output payload for AhrsState publication
+        diagnostics: Diagnostics output payload for AhrsDiagnostics publication
+        gyro_update: Update report payload for gyro updates
+        accel_update: Update report payload for accel updates
+        mag_update: Update report payload for magnetometer updates
+    """
+
+    frontier_advanced: bool
+    t_filter: Optional[AhrsTime]
+    frame_transforms: Optional[AhrsFrameOutputs]
+    state: Optional[AhrsStateData]
+    diagnostics: Optional[AhrsDiagnosticsData]
+    gyro_update: Optional[AhrsUpdateData]
+    accel_update: Optional[AhrsUpdateData]
+    mag_update: Optional[AhrsUpdateData]

--- a/oasis_msgs/CMakeLists.txt
+++ b/oasis_msgs/CMakeLists.txt
@@ -31,6 +31,8 @@ ament_export_dependencies(rosidl_default_runtime)
 rosidl_generate_interfaces(
   ${PROJECT_NAME}
     msg/Accelerometer.msg
+    msg/AhrsDiagnostics.msg
+    msg/AhrsState.msg
     msg/AirQuality.msg
     msg/AnalogButton.msg
     msg/AnalogReading.msg

--- a/oasis_msgs/msg/AhrsDiagnostics.msg
+++ b/oasis_msgs/msg/AhrsDiagnostics.msg
@@ -1,0 +1,55 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+#
+# Health / replay / drop diagnostics for the AHRS node.
+#
+# Conventions
+# - header.stamp = t_filter (frontier)
+# - header.frame_id = world frame_id
+#
+
+# Frontier timestamp and world frame_id
+std_msgs/Header header
+
+# Monotonic diagnostic sequence index
+uint64 diag_seq
+
+# The filter's current frontier timestamp in seconds (for convenience)
+float64 t_filter_sec
+
+#
+# Buffer / replay stats
+#
+
+# Number of time nodes currently retained
+uint32 buffer_node_count
+
+# Approximate time span covered by the buffer (s)
+float32 buffer_span_sec
+
+# True if an out-of-order message triggered replay on the most recent callback
+bool replay_happened
+
+#
+# Drop counters (monotonic since node start)
+#
+
+uint64 dropped_missing_stamp
+uint64 dropped_future_stamp
+uint64 dropped_too_old
+uint64 dropped_nan_cov
+uint64 dropped_imu_coverage_gap
+uint64 dropped_clock_jump_reset
+
+#
+# Most recent reset reason (empty if no reset yet)
+#
+string last_reset_reason

--- a/oasis_msgs/msg/AhrsState.msg
+++ b/oasis_msgs/msg/AhrsState.msg
@@ -1,0 +1,124 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+#
+# Full AHRS filter state snapshot at the current frontier time t_filter.
+#
+# This message exists so consumers can inspect ALL in-state parameters and
+# their FULL (non-diagonalized) covariance in a single place.
+#
+# Conventions
+# - header.stamp = t_filter (frontier)
+# - header.frame_id = world frame ("world") for all world-expressed vectors
+#
+# Frames
+# - {W}: world
+# - {B}: base_link (body)
+# - {I}: IMU frame
+# - {M}: magnetometer frame
+#
+
+# Frontier timestamp and world frame_id
+std_msgs/Header header
+
+#
+# Frame ids in use by the node (published contract)
+#
+string world_frame_id
+string odom_frame_id
+string body_frame_id
+
+#
+# Monotonic sequence index for state publications
+#
+uint64 state_seq
+
+#
+# True when the filter has consumed its initial priors and is running
+#
+bool initialized
+
+#
+# Navigation state
+#
+
+# Position of B expressed in W (m)
+geometry_msgs/Point position_wb_m
+
+# Velocity of B expressed in W (m/s)
+geometry_msgs/Vector3 velocity_wb_mps
+
+# Attitude (world -> body), unit quaternion
+geometry_msgs/Quaternion orientation_wb
+
+#
+# IMU systematic parameters (in-state)
+#
+
+# Gyroscope bias b_g (rad/s), expressed in IMU frame {I} unless otherwise specified by the node
+geometry_msgs/Vector3 gyro_bias
+
+# Accelerometer bias b_a (m/s^2), expressed in IMU frame {I} unless otherwise specified by the node
+geometry_msgs/Vector3 accel_bias
+
+# Accelerometer scale/misalignment matrix A_a
+# Units: unitless
+# Layout: 3x3 row-major
+float64[9] accel_a
+
+#
+# Extrinsics (sensor -> body)
+#
+
+# IMU -> body transform T_BI
+geometry_msgs/Pose t_bi
+
+# Magnetometer -> body transform T_BM
+geometry_msgs/Pose t_bm
+
+#
+# Environment / reference vectors (in-state)
+#
+
+# Gravity vector expressed in world (m/s^2)
+geometry_msgs/Vector3 gravity_w_mps2
+
+# Earth magnetic field vector expressed in world (tesla)
+geometry_msgs/Vector3 magnetic_field_w_t
+
+#
+# FULL covariance over the AHRS internal error-state.
+#
+# This is the single source of truth for "not diagonalized" covariance reporting.
+#
+# Matrix is row-major with dimensions error_dim x error_dim.
+#
+# IMPORTANT: error_state_names defines the exact ordering of this covariance.
+#
+
+# Error-state dimension (must match p.rows == p.cols == error_dim)
+uint32 error_dim
+
+# Names of each scalar error-state element, length = error_dim.
+# Example entries:
+# - "dp.x", "dp.y", "dp.z"
+# - "dv.x", "dv.y", "dv.z"
+# - "dtheta.x", "dtheta.y", "dtheta.z"
+# - "dbg.x", ...
+# - "dba.x", ...
+# - "dAa.0", ..., "dAa.8"
+# - "dT_BI.rho.x", ..., "dT_BI.theta.z"
+# - "dT_BM.rho.x", ..., "dT_BM.theta.z"
+# - "dg.x", ...
+# - "dm.x", ...
+string[] error_state_names
+
+# Full error-state covariance P
+oasis_msgs/Matrix p


### PR DESCRIPTION
### Motivation
- Align the Python AHRS types with the AHRS.md spec and add metadata needed for deterministic replay and tracing.
- Provide monotonic sequence identifiers on published state/diagnostics to enable stable consumer sequencing and monitoring.

### Description
- Added `topic: str` and `frame_id: str` to `AhrsEvent` to record the ROS topic and message header frame for deterministic ordering and replay, keeping `t_meas`, `event_type`, and `payload` unchanged.
- Added `state_seq: int` to `AhrsStateData` and placed it after `t_filter` as a required monotonic state sequence identifier.
- Added `diag_seq: int` to `AhrsDiagnosticsData` and placed it after `t_filter` as a required monotonic diagnostics sequence identifier.
- Fixed extrinsic transform docstrings in `AhrsStateData` to match the spec: updated `t_bi` to `IMU -> body transform (T_BI)` and `t_bm` to `Magnetometer -> body transform (T_BM)`.
- Updated diagnostics docstring line to `buffer_node_count: Number of time nodes currently buffered` to reflect the fixed‑lag node model.
- Changes are minimal and localized to `oasis_control/oasis_control/localization/ahrs/ahrs_types.py`, preserving `@dataclass(frozen=True)`, existing type hints (Python 3.10+), module header, and use of stdlib-only types.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696c9419f0f0832eba16b32197eca5a4)