### PR TITLE
Refactor AHRS core conversions for ROS-free tests

### DIFF
--- a/docs/AHRS.md
+++ b/docs/AHRS.md
@@ -1,0 +1,610 @@
+# AHRS Design Document
+
+This document defines the **state-space model** and **time-handling policy** for an AHRS that uses:
+
+- a continuous-time **process model**: kinematic evolution + slow parameter drift (priors), and
+- discrete-time **measurement models**:
+  - IMU gyro + accel measurements (`imu_raw`) and
+  - magnetometer measurements (`magnetic_field`),
+
+all applied on a common time axis with deterministic fixed-lag replay.
+
+---
+
+## World / Odom frame contract
+
+The AHRS publishes the standard TF chain:
+
+`world -> odom -> base_link`
+
+Policy (no teleports, no global correction):
+
+- `world` is initialized at startup to the origin (continuous).
+- `odom` is continuous and **drifts locally**.
+- There are no discontinuities because no global constraints exist.
+
+Recommended implementation contract:
+
+- Publish `TF: world -> odom` as identity for the entire session:
+  - `T_WO := I`
+- Publish `TF: odom -> base_link` as the AHRS estimate:
+  - `T_OB := T_WB` (since `world == odom` under the identity `T_WO`)
+
+This keeps the TF tree compatible with a future localization EKF that may later produce non-identity `T_WO`.
+
+---
+
+## 1. ROS Inputs
+
+### 1.1 Streams
+
+- Single `message_filters` combination (ExactTime) producing an **IMU packet**:
+  - `imu_raw` (`sensor_msgs/Imu`): inertial sample stream (time-stamped)
+  - `imu_calibration` (`oasis_msgs/ImuCalibration`): calibration priors + uncertainty
+    - **Semantic rule:** used **only once** to initialize in-state calibration parameters (initial prior).
+    - After initialization, `imu_calibration` contents are ignored (except diagnostics / consistency checks).
+- `magnetic_field` (`sensor_msgs/MagneticField`): magnetometer samples (time-stamped)
+
+---
+
+### 1.2 `imu_raw` — `sensor_msgs/Imu`
+
+Used fields:
+
+- `header.stamp` (`t_meas`)
+- `header.frame_id` → IMU frame `{I}`
+- `angular_velocity` `ω_raw` and **full** `angular_velocity_covariance` `Σ_ω_raw` (3×3)
+- `linear_acceleration` `a_raw` and **full** `linear_acceleration_covariance` `Σ_a_raw` (3×3)
+
+Ignored:
+
+- `orientation`, `orientation_covariance`
+
+Requirements:
+
+- Covariances are interpreted as **per-sample measurement noise**.
+- `ω_raw`, `a_raw` are expressed in `{I}`.
+- Do not diagonalize any provided covariance.
+
+---
+
+### 1.3 `imu_calibration` — `oasis_msgs/ImuCalibration`
+
+Role: **one-shot initialization prior** for systematic parameters that live in the shared state.
+
+Validity:
+
+- If `valid == false`, ignore.
+
+Frame:
+
+- `header.frame_id` must match `imu_raw.header.frame_id` (calibration is defined in `{I}`).
+
+Models (parameter meaning):
+
+- Accel: `a_corr = A_a (a_raw − b_a)` where `b_a, A_a` are **in-state**
+- Gyro: `ω_corr = ω_raw − b_g` where `b_g` is **in-state**
+
+Requirements:
+
+- Consume **only while uninitialized**:
+  - The **first** valid calibration observed is applied as an initial prior on `(b_a, A_a, b_g)` with its covariance.
+  - After initialization, ignore subsequent calibration messages (except diagnostics).
+- Calibration uncertainty is **systematic parameter uncertainty**, not per-sample noise.
+- Always use full covariance matrices when provided (do not diagonalize).
+
+---
+
+### 1.4 `magnetic_field` — `sensor_msgs/MagneticField`
+
+Used fields:
+
+- `header.stamp` (`t_meas`)
+- `header.frame_id` → mag frame `{M}`
+- `magnetic_field` `m_raw`
+- **full** `magnetic_field_covariance` `Σ_m_raw` (3×3)
+
+Measurement convention:
+
+- Form magnetometer residual in `{M}` (do not rotate the raw measurement into `{B}`):
+  - `z := m_raw` in `{M}`
+  - `z_hat := m̂_M` in `{M}`
+  - `ν := z - z_hat` in `{M}`
+
+Noise interpretation:
+
+- `Σ_m_raw` is the driver’s estimate of measurement noise covariance and is used as a prior / input to the
+  internally maintained `R_m(t)` (but not treated as per-sample truth).
+- Do not diagonalize any provided covariance.
+
+Adaptive noise policy (covariance matching):
+
+- Initialize `R_m0` from first valid `Σ_m_raw`, else default:
+  - `R_m0 = diag([4e-10, 4e-10, 4e-10])` (tesla²) (20 µT RMS per axis)
+- Maintain adaptive `R_m(t)` bounded SPD:
+  - `R_min = diag([1e-12, 1e-12, 1e-12])` (tesla²)
+  - `R_max = diag([2.5e-9, 2.5e-9, 2.5e-9])` (tesla²)
+- Update:
+  - Let innovation be `ν_k`, predicted innovation covariance excluding R be `Ŝ_k = HPHᵀ`
+  - `R_m ← clamp_SPD( (1-α) R_m + α (ν_k ν_kᵀ - Ŝ_k), R_min, R_max )`
+  - default `α = 0.01`
+
+---
+
+## 2. Frames and Extrinsics
+
+Frames:
+
+- `{W}`: world frame, ROS frame_id = `world`
+- `{O}`: odom frame, ROS frame_id = `odom`
+- `{B}`: body frame, ROS child_frame_id = `base_link`
+- `{I}`: IMU measurement frame (`imu_raw.header.frame_id`)
+- `{M}`: magnetometer frame (`magnetic_field.header.frame_id`)
+
+Estimated extrinsics (in-state):
+
+- `T_BI` (IMU → body)
+- `T_BM` (mag → body)
+
+Parameterization:
+
+- Poses in SE(3): quaternion rotation + 3-vector translation
+- Uncertainty: 6D tangent (δρ, δθ) for SE(3) quantities
+
+Initialization priors (broad but finite; full covariances allowed and recommended):
+
+- `T_BI` prior:
+  - mean: identity
+  - rotation stddev: `π` rad per axis (tangent)
+  - translation stddev: `1.0 m` per axis
+- `T_BM` prior:
+  - mean: identity
+  - rotation stddev: `π` rad per axis (tangent)
+  - translation stddev: `1.0 m` per axis
+
+---
+
+## 3. State, Process Model, and Measurement Models
+
+This AHRS is a **single optimizer** over a **shared state** with multiple models.
+
+### 3.1 State (full model)
+
+The AHRS maintains a full navigation + calibration + extrinsic state:
+
+Navigation (in `{W}` unless noted):
+
+- Position: `p_WB ∈ ℝ³`
+- Velocity: `v_WB ∈ ℝ³`
+- Attitude: `q_WB` (unit quaternion, world → body rotation)
+
+IMU systematic parameters:
+
+- Gyro bias: `b_g ∈ ℝ³`
+- Accel bias: `b_a ∈ ℝ³`
+- Accel scale/misalignment: `A_a ∈ ℝ^{3×3}` (full matrix)
+
+Extrinsics (sensor-to-body in SE(3)):
+
+- `T_BI ∈ SE(3)` (IMU → body)
+- `T_BM ∈ SE(3)` (mag → body)
+
+Environment / reference vectors (kept in-state, full covariance):
+
+- Gravity vector in world: `g_W ∈ ℝ³`
+- Earth magnetic field vector in world: `m_W ∈ ℝ³`
+
+Full covariance policy:
+
+- The AHRS maintains a single covariance `P` over its internal error-state.
+- Do not diagonalize:
+  - any incoming sensor covariance (`Σ_ω_raw`, `Σ_a_raw`, `Σ_m_raw`),
+  - any priors / initialization covariances,
+  - or internal state covariance blocks.
+
+---
+
+### 3.2 Error-state definition (for covariance)
+
+The AHRS uses an error-state EKF.
+
+Representative error coordinates:
+
+- `δp, δv ∈ ℝ³`
+- `δθ ∈ ℝ³` small-angle attitude error s.t. `q_WB ≈ Exp(δθ) ⊗ q̂_WB`
+- `δb_g, δb_a ∈ ℝ³`
+- `δA_a ∈ ℝ⁹` (row-major perturbation of `A_a`) or an equivalent minimal parameterization
+- `δξ_BI ∈ ℝ⁶`, `δξ_BM ∈ ℝ⁶` (SE(3) tangent: translation + rotation)
+- `δg_W, δm_W ∈ ℝ³`
+
+`P` is the covariance over the stacked error-state vector above (full matrix).
+
+---
+
+### 3.3 Continuous-time process model (kinematic prior + slow drift)
+
+The process model provides time evolution between measurements. Sensor data does **not** drive propagation in this option;
+IMU and mag are measurement updates.
+
+Define continuous-time dynamics:
+
+Navigation kinematics:
+
+- `ṗ_WB = v_WB`
+- `v̇_WB = g_W + w_v`
+- `q̇_WB = 1/2 * Ω(ω_WB) * q_WB`
+
+where:
+- `ω_WB` is the body angular rate (world → body) treated as **latent** (not directly measured in the process model),
+  modeled as:
+  - `ω_WB = w_ω`
+- `w_v`, `w_ω` are zero-mean white noises (continuous-time) representing smoothness priors.
+
+Systematic parameter drift (random walks):
+
+- `ḃ_g = w_bg`
+- `ḃ_a = w_ba`
+- `Ȧ_a = W_A` (element-wise random walk; `vec(Ȧ_a) = w_A`)
+- `Ṫ_BI = W_BI` (SE(3) random walk in tangent; `δξ̇_BI = w_BI`)
+- `Ṫ_BM = W_BM` (SE(3) random walk in tangent; `δξ̇_BM = w_BM`)
+
+Reference vector drift (slow):
+
+- `ġ_W = w_g`
+- `ṁ_W = w_m`
+
+Notes:
+
+- This process is intentionally **weak**: it encodes “motion is smooth” and “parameters drift slowly”.
+- The IMU measurements will strongly constrain the state at high rate.
+
+Process noise covariance:
+
+- Continuous-time noise intensities:
+  - `Q_c = cov([w_v, w_ω, w_bg, w_ba, w_A, w_BI, w_BM, w_g, w_m])`
+- `Q_c` may be block-diagonal by default, but the **state covariance P is full** and will develop cross-terms through
+  Jacobians and updates.
+- If you have known cross-correlations (e.g., coupled accel axes), you may encode them in `Q_c` (full blocks permitted).
+
+Discretization:
+
+- Over interval `Δt`, compute discrete `F_k` and `Q_k` using a standard EKF discretization
+  (e.g., first-order: `Q_k ≈ G Q_c Gᵀ Δt`, with `F_k ≈ I + AΔt`),
+  keeping full matrices.
+
+---
+
+### 3.4 IMU measurement model (discrete-time)
+
+At each `imu_raw` timestamp `t_k`, treat IMU outputs as measurements.
+
+#### 3.4.1 Frame handling for IMU
+
+- IMU raw signals are in `{I}`.
+- Use the estimated extrinsic `T_BI` to relate `{I}` and `{B}`:
+  - Let `R_BI` be the rotation from IMU to body from `T_BI`.
+  - Then body-to-IMU rotation is `R_IB = R_BIᵀ`.
+
+#### 3.4.2 Gyro measurement
+
+Measurement:
+
+- `z_ω := ω_raw` in `{I}` with covariance `R_ω := Σ_ω_raw` (full 3×3)
+
+Prediction:
+
+- Predict IMU-frame angular rate as:
+  - `ω̂_I = R_IB * ω_WB + b_g`
+
+Residual:
+
+- `ν_ω = z_ω - ω̂_I` (in `{I}`)
+
+#### 3.4.3 Accelerometer measurement
+
+Measurement:
+
+- `z_a := a_raw` in `{I}` with covariance `R_a := Σ_a_raw` (full 3×3)
+
+Specific-force prediction:
+
+- Compute world-frame acceleration of the body origin from kinematics:
+  - `a_WB := v̇_WB` (from process state; in the mean model, `v̇_WB ≈ g_W`, but this is refined by measurements)
+- Specific force in body frame is:
+  - `f_B = R_BW * (a_WB - g_W)` where `R_BW` is world → body rotation from `q_WB`
+- Convert to IMU frame:
+  - `f_I = R_IB * f_B`
+
+Apply accel systematic model (as defined by calibration semantics):
+
+- The measurement model uses:
+  - `a_corr = A_a (a_raw − b_a)`
+- Equivalently, the predicted raw measurement is:
+  - `â_raw = A_a^{-1} * f_I + b_a`
+
+Prediction:
+
+- `â_I = A_a^{-1} * f_I + b_a`
+
+Residual:
+
+- `ν_a = z_a - â_I` (in `{I}`)
+
+Notes:
+
+- The above uses a full 3×3 `A_a`. If `A_a` is near-singular, the state/prior must prevent it (bounded parameterization
+  recommended). The covariance remains full regardless of parameterization.
+- `R_a` is always taken as the provided full covariance (or a configured fallback if invalid).
+
+---
+
+### 3.5 Magnetometer measurement model (discrete-time)
+
+At each `magnetic_field` timestamp `t_k`:
+
+- Measurement: `z_m := m_raw` in `{M}`
+- Covariance input: `Σ_m_raw` (full 3×3), used to initialize / inform the adaptive `R_m(t)`.
+
+Prediction (in `{M}`; residual always formed in `{M}`):
+
+- Let `R_BM` be the rotation of `T_BM` (mag → body), so body→mag is `R_MB = R_BMᵀ`.
+- Let `R_BW` be world → body rotation from `q_WB`.
+- Predict:
+  - `m̂_M = R_MB * R_BW * m_W`
+
+Residual:
+
+- `ν_m = z_m - m̂_M` in `{M}`
+
+Measurement noise used:
+
+- `R_m(t)` (adaptive, bounded SPD; full 3×3)
+
+---
+
+## 4. Time Axis, Buffer, and Deterministic Replay (Fixed-lag)
+
+This AHRS uses the same deterministic fixed-lag design as the EKF spec.
+
+### 4.1 Time definitions
+
+- `t_meas`: `header.stamp` from the incoming message (authoritative event time)
+- `t_now`: receipt time (diagnostics only)
+- `t_filter`: max `t_meas` among **accepted** messages (frontier)
+
+Event-driven: each accepted message attaches at `t_meas`. Out-of-order messages are supported via fixed-lag replay.
+
+### 4.2 Message roles
+
+- **Measurement updates (high-rate):** `imu_raw` (gyro + accel updates)
+- **Initialization prior (one-shot):** `imu_calibration`
+- **Measurement updates:** `magnetic_field`
+- **Process model:** runs continuously between time nodes as the kinematic prior and slow parameter drift.
+
+### 4.3 IMU packet synchronization contract
+
+The AHRS consumes IMU as a synchronized pair:
+
+- `imu_pkt = (imu_raw, imu_calibration)` produced by `message_filters` using **ExactTime**.
+
+Timestamp policy:
+
+- Packet time: `t_meas := imu_raw.header.stamp`
+- Require `imu_calibration.header.stamp == imu_raw.header.stamp`; reject packet if not.
+
+Semantic policy:
+
+- `imu_calibration` is used **only before initialization** to set priors on `(b_a, A_a, b_g)` with full covariance.
+- After initialization, `imu_calibration` is ignored (except diagnostics).
+- `imu_raw` always produces measurement updates (gyro + accel) when accepted.
+
+### 4.4 Buffer model
+
+Maintain a time-ordered ring buffer of time nodes over fixed lag `T_buffer_sec`.
+
+Each node at `t_k` stores:
+
+- state mean `x_k`, covariance `P_k`
+- messages attached at `t_k` (IMU packet, mag)
+- sufficient metadata to re-run deterministic replay
+
+Node rules:
+
+- One node per distinct timestamp.
+- Multiple messages may attach to the same node.
+- Evict nodes older than `t_filter - T_buffer_sec` (with diagnostics).
+
+### 4.5 Propagation convention
+
+Between time nodes, propagate with the continuous-time process model (Section 3.3), discretized over each interval.
+
+Strict coverage rule:
+
+- For deterministic replay, the AHRS must be able to propagate across any interval used in replay.
+- If there is a timestamp gap larger than `Δt_imu_max` between consecutive nodes required to cover replay,
+  reject replay across that gap and emit diagnostics.
+
+### 4.6 Insertion + replay (deterministic)
+
+On message arrival:
+
+1. Validate timestamp
+   - reject missing/invalid
+   - reject `t_meas > t_now + ε_wall_future`
+
+2. Fixed-lag window
+   - if `t_filter` exists and `t_meas < t_filter - T_buffer_sec`, reject as too old
+
+3. Attach
+   - insert/attach message to node `t_meas` (create node if needed)
+
+4. Update frontier / replay
+   - if `t_meas > t_filter`: advance `t_filter` and propagate forward
+   - else: apply update at `t_meas`, then replay forward to `t_filter`
+
+Per-node application order (stable):
+
+1. Apply any priors/parameter constraints at `t_k` (including one-shot calibration prior if first valid)
+2. Apply measurement updates at `t_k` in stable tie-break order:
+   - lexicographic `(message_type, topic, frame_id)`
+   - Within IMU: apply gyro update then accel update (fixed order)
+
+Replay must never depend on arrival order.
+
+### 4.7 Drop / reset rules
+
+Reject and emit diagnostics if:
+
+- missing timestamp
+- required covariance contains NaN/Inf
+- message outside fixed-lag window
+- propagation coverage insufficient (`Δt_imu_max` violated)
+- clock discontinuity detected: reset filter + buffer if `|t_meas - t_filter| > Δt_clock_jump_max`
+  - Reset effects (explicit):
+    - clear the time buffer and set `t_filter` to unset
+    - set `initialized = false`
+    - allow consumption of the next valid `imu_calibration` as a new initialization prior
+    - reset adaptive `R_m(t)` to `R_m0`
+
+---
+
+### 4.8 Output publish trigger (explicit)
+
+The AHRS publishes "current estimate" outputs **only when the frontier advances**.
+
+- Let `t_filter_prev` be the frontier before processing an incoming message.
+- After processing a message:
+  - If `t_meas > t_filter_prev` (frontier advance), the filter propagates to `t_meas`, applies updates at `t_meas`,
+    sets `t_filter := t_meas`, and **publishes**:
+      - TF (`world -> odom`, `odom -> base_link`) stamped `t_filter`
+      - odometry outputs stamped `t_filter`
+      - `oasis_msgs/AhrsState` stamped `t_filter`
+      - `oasis_msgs/AhrsDiagnostics` stamped `t_filter`
+  - If `t_meas <= t_filter_prev` (out-of-order insertion), the filter may replay internally to maintain consistency at
+    `t_filter`, but **does not republish** TF/odometry/state/diagnostics (to avoid emitting past timestamps).
+
+Per-measurement update reports (`oasis_msgs/EkfUpdateReport`) are published at the measurement timestamp `t_meas` for
+every accepted/rejected update, regardless of whether the frontier advanced.
+
+---
+
+## 5. Outputs (poses + covariances + measurement stats)
+
+The AHRS publishes:
+
+1. state estimates in ROS-standard frames (`world`, `odom`, `base_link`)
+2. full covariances for those estimates (not diagonalized)
+3. per-measurement innovation / gating statistics (so “all measurements” have covariances too)
+
+### 5.1 TF
+
+- Broadcast `TF: odom -> base_link` from `T_OB` (`stamp = t_filter`)
+- Broadcast `TF: world -> odom` as identity (`stamp = t_filter`)
+
+TF is published on `/tf` (standard tf2 broadcaster).
+
+### 5.2 Odometry messages
+
+**(A) `nav_msgs/Odometry` in `odom`**
+
+- Topic: `ahrs/odom`
+- `header.stamp = t_filter`
+- `header.frame_id = "odom"`
+- `child_frame_id = "base_link"`
+- Pose: `T_OB` (translation from `p_WB`, rotation from `q_WB`)
+- Twist: derived from state (e.g., linear from `v_WB`, angular from `ω_WB` estimate as implied by IMU updates)
+- Covariance: derived from `P` (full covariance propagation, mapped into ROS odom convention)
+
+**(B) `nav_msgs/Odometry` in `world`**
+
+- Topic: `ahrs/world_odom`
+- Same values as (A) under `T_WO = I` contract; covariances derived from the same `P`.
+
+### 5.3 Extrinsic outputs
+
+- `geometry_msgs/PoseWithCovarianceStamped`:
+  - Topic: `ahrs/extrinsics/t_bi` for `T_BI`
+  - Topic: `ahrs/extrinsics/t_bm` for `T_BM`
+  - `header.stamp = t_filter`
+  - `header.frame_id = "base_link"`
+  - Covariance derived from `P` (full 6×6, not diagonalized)
+  - Publish: **on frontier advance** (Section 4.8)
+
+### 5.4 Covariance transformation rules
+
+The AHRS maintains a single covariance `P` over its internal error-state. Published covariances are obtained by:
+
+`Σ_y = J * P * Jᵀ`, with `J = ∂g/∂x` evaluated at `x̂`.
+
+For SE(3) pose errors in tangent (δρ, δθ), use the adjoint:
+
+`Σ_A = Ad_{T_AB} * Σ_B * Ad_{T_AB}ᵀ`
+
+All covariance matrices are full and must remain symmetric positive definite (or PSD as appropriate).
+
+### 5.5 Per-measurement reports
+
+Publish one report entry for every accepted/rejected update:
+
+- `ahrs/updates/accel`
+- `ahrs/updates/gyro`
+- `ahrs/updates/mag`
+
+Contents (recommended):
+
+- `header.stamp = t_meas`
+- `z`, `z_hat`, innovation `ν`
+- measurement noise used `R` (full)
+- predicted innovation covariance excluding R: `Ŝ = HPHᵀ`
+- total innovation covariance `S = Ŝ + R`
+- Mahalanobis distance `d² = νᵀ S^{-1} ν`
+- gating threshold + accept/reject flag
+
+Each per-measurement topic publishes `oasis_msgs/EkfUpdateReport` stamped at `t_meas` for every accepted/rejected update.
+
+### 5.6 `oasis_msgs/AhrsState` (full state + full covariance)
+
+- Topic: `ahrs/state`
+- Publish: **on frontier advance** (Section 4.8)
+- `header.stamp = t_filter`
+- Contents: full mean state (navigation + calibration + extrinsics + `g_W`, `m_W`) and full error-state covariance `P`
+  with explicit ordering (`error_state_names`). No diagonalization.
+
+### 5.7 `oasis_msgs/AhrsDiagnostics` (buffer + drop/replay stats)
+
+- Topic: `ahrs/diag`
+- Publish: **on frontier advance** (Section 4.8)
+- `header.stamp = t_filter`
+- Contents: buffer size/span, replay flag, and monotonic drop/reset counters.
+
+---
+
+## 6. Config Parameters
+
+Frames:
+
+- `world_frame_id` (default `"world"`)
+- `odom_frame_id` (default `"odom"`)
+- `body_frame_id` (default `"base_link"`)
+
+Time / buffering:
+
+- `T_buffer_sec`
+- `ε_wall_future`
+- `Δt_clock_jump_max`
+- `Δt_imu_max`
+
+Process noise intensities (continuous-time):
+
+- `Q_v` (for `w_v`)
+- `Q_ω` (for `w_ω`)
+- `Q_bg`, `Q_ba`
+- `Q_A` (for `vec(A_a)` drift)
+- `Q_BI`, `Q_BM` (for extrinsic drift in SE(3) tangent)
+- `Q_g`, `Q_m` (for `g_W`, `m_W` drift)
+
+Magnetometer adaptive noise:
+
+- `α`
+- `R_min`, `R_max`
+- default `R_m0` (if no valid `Σ_m_raw` observed)

--- a/mypy.ini
+++ b/mypy.ini
@@ -57,3 +57,6 @@ ignore_missing_imports = True
 
 [mypy-telemetrix_aio]
 ignore_missing_imports = True
+
+[mypy-tf2_ros]
+ignore_missing_imports = True

--- a/oasis_control/launch/control_launch.py
+++ b/oasis_control/launch/control_launch.py
@@ -69,6 +69,7 @@ def generate_launch_description() -> LaunchDescription:
     # Navigation
     if HOST_ID == "falcon":
         # ControlDescriptions.add_ekf_localizer(ld, HOST_ID, apriltag_resolution="hd")
+        ControlDescriptions.add_ahrs(ld, HOST_ID)
         ControlDescriptions.add_imu_fuser(ld, HOST_ID)
         ControlDescriptions.add_speedometer(ld, HOST_ID)
         ControlDescriptions.add_tilt_sensor(ld, HOST_ID)

--- a/oasis_control/oasis_control/cli/ahrs_cli.py
+++ b/oasis_control/oasis_control/cli/ahrs_cli.py
@@ -1,0 +1,38 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""
+ROS entry point for the AHRS node
+"""
+
+from typing import Optional
+
+import rclpy
+
+from oasis_control.nodes.ahrs_node import AhrsNode
+
+
+################################################################################
+# ROS entry point
+################################################################################
+
+
+def main(args: Optional[list[str]] = None) -> None:
+    rclpy.init(args=args)
+
+    node: AhrsNode = AhrsNode()
+
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.stop()
+        rclpy.shutdown()

--- a/oasis_control/oasis_control/launch/control_descriptions.py
+++ b/oasis_control/oasis_control/launch/control_descriptions.py
@@ -29,6 +29,31 @@ CONTROL_PACKAGE_NAME: str = "oasis_control"
 
 class ControlDescriptions:
     #
+    # AHRS
+    #
+
+    @staticmethod
+    def add_ahrs(ld: LaunchDescription, host_id: str) -> None:
+        ahrs_node: Node = Node(
+            namespace=ROS_NAMESPACE,
+            package=CONTROL_PACKAGE_NAME,
+            executable="ahrs",
+            name=f"ahrs_{host_id}",
+            output="screen",
+            remappings=[
+                ("ahrs/extrinsics/t_bi", f"{host_id}/ahrs/extrinsics/t_bi"),
+                ("ahrs/extrinsics/t_bm", f"{host_id}/ahrs/extrinsics/t_bm"),
+                ("ahrs/updates/accel", f"{host_id}/ahrs/updates/accel"),
+                ("ahrs/updates/gyro", f"{host_id}/ahrs/updates/gyro"),
+                ("ahrs/updates/mag", f"{host_id}/ahrs/updates/mag"),
+                ("imu_calibration", f"{host_id}/imu_calibration"),
+                ("imu_raw", f"{host_id}/imu_raw"),
+                ("magnetic_field", f"{host_id}/magnetic_field"),
+            ],
+        )
+        ld.add_action(ahrs_node)
+
+    #
     # EKF localizer
     #
 

--- a/oasis_control/oasis_control/localization/ahrs/ahrs_clock.py
+++ b/oasis_control/oasis_control/localization/ahrs/ahrs_clock.py
@@ -1,0 +1,57 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""
+Clock abstraction for AHRS localization
+"""
+
+from __future__ import annotations
+
+import rclpy.node
+from builtin_interfaces.msg import Time as TimeMsg
+
+from oasis_control.localization.ahrs.ahrs_conversions import ahrs_time_from_ros
+from oasis_control.localization.ahrs.ahrs_types import AhrsTime
+
+
+class AhrsClock:
+    """
+    Clock abstraction for retrieving ROS time
+    """
+
+    def now_ros_time(self) -> TimeMsg:
+        """
+        Return the current ROS time
+        """
+
+        raise NotImplementedError
+
+    def is_future_stamp(self, t_meas: AhrsTime, epsilon_sec: float) -> bool:
+        """
+        True when the measurement stamp is ahead of the wall clock
+        """
+
+        now: AhrsTime = ahrs_time_from_ros(self.now_ros_time())
+        now_sec: float = float(now.sec) + float(now.nanosec) * 1e-9
+        meas_sec: float = float(t_meas.sec) + float(t_meas.nanosec) * 1e-9
+
+        return meas_sec > now_sec + epsilon_sec
+
+
+class RosAhrsClock(AhrsClock):
+    """
+    ROS clock implementation backed by a node's time source
+    """
+
+    def __init__(self, node: rclpy.node.Node) -> None:
+        self._node: rclpy.node.Node = node
+
+    def now_ros_time(self) -> TimeMsg:
+        return self._node.get_clock().now().to_msg()

--- a/oasis_control/oasis_control/localization/ahrs/ahrs_clock.py
+++ b/oasis_control/oasis_control/localization/ahrs/ahrs_clock.py
@@ -14,21 +14,18 @@ Clock abstraction for AHRS localization
 
 from __future__ import annotations
 
-import rclpy.node
-from builtin_interfaces.msg import Time as TimeMsg
-
-from oasis_control.localization.ahrs.ahrs_conversions import ahrs_time_from_ros
+from oasis_control.localization.ahrs.ahrs_conversions import seconds_from_ahrs
 from oasis_control.localization.ahrs.ahrs_types import AhrsTime
 
 
 class AhrsClock:
     """
-    Clock abstraction for retrieving ROS time
+    Clock abstraction for retrieving AHRS time
     """
 
-    def now_ros_time(self) -> TimeMsg:
+    def now(self) -> AhrsTime:
         """
-        Return the current ROS time
+        Return the current AHRS time
         """
 
         raise NotImplementedError
@@ -38,20 +35,8 @@ class AhrsClock:
         True when the measurement stamp is ahead of the wall clock
         """
 
-        now: AhrsTime = ahrs_time_from_ros(self.now_ros_time())
-        now_sec: float = float(now.sec) + float(now.nanosec) * 1e-9
-        meas_sec: float = float(t_meas.sec) + float(t_meas.nanosec) * 1e-9
+        now: AhrsTime = self.now()
+        now_sec: float = seconds_from_ahrs(now)
+        meas_sec: float = seconds_from_ahrs(t_meas)
 
         return meas_sec > now_sec + epsilon_sec
-
-
-class RosAhrsClock(AhrsClock):
-    """
-    ROS clock implementation backed by a node's time source
-    """
-
-    def __init__(self, node: rclpy.node.Node) -> None:
-        self._node: rclpy.node.Node = node
-
-    def now_ros_time(self) -> TimeMsg:
-        return self._node.get_clock().now().to_msg()

--- a/oasis_control/oasis_control/localization/ahrs/ahrs_config.py
+++ b/oasis_control/oasis_control/localization/ahrs/ahrs_config.py
@@ -1,0 +1,68 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""
+Configuration data for AHRS localization
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class AhrsConfig:
+    """
+    Shared AHRS configuration values
+
+    Fields:
+        world_frame_id: Global drift-corrected frame name
+        odom_frame_id: Local continuous frame name
+        body_frame_id: Body frame name for state output
+        t_buffer_sec: Buffer span in seconds used for fixed-lag replay
+        epsilon_wall_future_sec: Max future offset in seconds allowed by wall clock
+        dt_clock_jump_max_sec: Threshold in seconds for detecting clock jumps
+        dt_imu_max_sec: Max IMU delta in seconds before skipping propagation
+        mag_alpha: Magnetometer covariance matching factor, unitless
+        mag_r_min: Minimum magnetometer covariance matrix, row-major
+        mag_r_max: Maximum magnetometer covariance matrix, row-major
+        mag_r0: Default initial magnetometer covariance matrix, row-major
+        q_v: Velocity process noise placeholder
+        q_w: Angular velocity process noise placeholder
+        q_bg: Gyro bias process noise placeholder
+        q_ba: Accel bias process noise placeholder
+        q_a: Accel scale process noise placeholder
+        q_bi: IMU extrinsic process noise placeholder
+        q_bm: Magnetometer extrinsic process noise placeholder
+        q_g: Gravity process noise placeholder
+        q_m: Magnetic field process noise placeholder
+    """
+
+    world_frame_id: str
+    odom_frame_id: str
+    body_frame_id: str
+
+    t_buffer_sec: float
+    epsilon_wall_future_sec: float
+    dt_clock_jump_max_sec: float
+    dt_imu_max_sec: float
+
+    mag_alpha: float
+    mag_r_min: list[float]
+    mag_r_max: list[float]
+    mag_r0: list[float]
+
+    q_v: float
+    q_w: float
+    q_bg: float
+    q_ba: float
+    q_a: float
+    q_bi: float
+    q_bm: float
+    q_g: float
+    q_m: float

--- a/oasis_control/oasis_control/localization/ahrs/ahrs_conversions.py
+++ b/oasis_control/oasis_control/localization/ahrs/ahrs_conversions.py
@@ -1,0 +1,81 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""
+Conversion helpers between ROS messages and AHRS types
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from typing import Protocol
+
+from builtin_interfaces.msg import Time as TimeMsg
+
+from oasis_control.localization.ahrs.ahrs_types import AhrsTime
+
+
+class Vector3Like(Protocol):
+    """
+    Protocol for geometry messages with x/y/z fields
+    """
+
+    x: float
+    y: float
+    z: float
+
+
+def ahrs_time_from_ros(stamp: TimeMsg) -> AhrsTime:
+    """
+    Convert a ROS time stamp into an AHRS time
+    """
+
+    return AhrsTime(sec=int(stamp.sec), nanosec=int(stamp.nanosec))
+
+
+def ros_time_from_ahrs(t: AhrsTime) -> TimeMsg:
+    """
+    Convert an AHRS time into a ROS time stamp
+    """
+
+    carry_sec: int = t.nanosec // 1_000_000_000
+    nanosec: int = t.nanosec % 1_000_000_000
+    sec: int = t.sec + carry_sec
+
+    stamp: TimeMsg = TimeMsg()
+    stamp.sec = sec
+    stamp.nanosec = nanosec
+
+    return stamp
+
+
+def cov3x3_from_ros(cov: Sequence[float]) -> list[float]:
+    """
+    Convert a ROS covariance list into a validated 3x3 covariance
+    """
+
+    if len(cov) != 9:
+        raise ValueError("Expected 9 covariance entries")
+
+    values: list[float] = [float(value) for value in cov]
+
+    if not all(math.isfinite(value) for value in values):
+        raise ValueError("Covariance entries must be finite")
+
+    return values
+
+
+def vector3_from_ros(msg: Vector3Like) -> list[float]:
+    """
+    Convert a ROS Vector3-like message into a list
+    """
+
+    return [float(msg.x), float(msg.y), float(msg.z)]

--- a/oasis_control/oasis_control/localization/ahrs/ahrs_filter.py
+++ b/oasis_control/oasis_control/localization/ahrs/ahrs_filter.py
@@ -1,0 +1,323 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""
+Stub AHRS filter implementation
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Optional
+from typing import cast
+
+from oasis_control.localization.ahrs.ahrs_clock import AhrsClock
+from oasis_control.localization.ahrs.ahrs_config import AhrsConfig
+from oasis_control.localization.ahrs.ahrs_types import AhrsDiagnosticsData
+from oasis_control.localization.ahrs.ahrs_types import AhrsEvent
+from oasis_control.localization.ahrs.ahrs_types import AhrsEventType
+from oasis_control.localization.ahrs.ahrs_types import AhrsFrameOutputs
+from oasis_control.localization.ahrs.ahrs_types import AhrsFrameTransform
+from oasis_control.localization.ahrs.ahrs_types import AhrsImuPacket
+from oasis_control.localization.ahrs.ahrs_types import AhrsMatrix
+from oasis_control.localization.ahrs.ahrs_types import AhrsOutputs
+from oasis_control.localization.ahrs.ahrs_types import AhrsSe3Transform
+from oasis_control.localization.ahrs.ahrs_types import AhrsStateData
+from oasis_control.localization.ahrs.ahrs_types import AhrsTime
+from oasis_control.localization.ahrs.ahrs_types import AhrsUpdateData
+from oasis_control.localization.ahrs.ahrs_types import MagSample
+
+
+class AhrsFilter:
+    """
+    Stubbed AHRS filter for deterministic event handling
+    """
+
+    def __init__(self, config: AhrsConfig, clock: AhrsClock) -> None:
+        self._config: AhrsConfig = config
+        self._clock: AhrsClock = clock
+
+        self._initialized: bool = False
+        self._t_filter: Optional[AhrsTime] = None
+        self._state_seq: int = 0
+        self._diag_seq: int = 0
+
+        self._dropped_missing_stamp: int = 0
+        self._dropped_future_stamp: int = 0
+        self._dropped_too_old: int = 0
+        self._dropped_nan_cov: int = 0
+        self._dropped_imu_gap: int = 0
+        self._dropped_clock_jump_reset: int = 0
+        self._reset_count: int = 0
+        self._last_reset_reason: str = ""
+
+        self._last_imu_time: Optional[AhrsTime] = None
+
+    def handle_event(self, event: AhrsEvent) -> AhrsOutputs:
+        update_reports: dict[str, Optional[AhrsUpdateData]] = (
+            self._build_update_reports(event)
+        )
+
+        if self._clock.is_future_stamp(
+            event.t_meas, self._config.epsilon_wall_future_sec
+        ):
+            self._dropped_future_stamp += 1
+            return self._outputs_for_drop(update_reports)
+
+        if self._has_nan_covariance(event):
+            self._dropped_nan_cov += 1
+            return self._outputs_for_drop(update_reports)
+
+        if self._is_clock_jump(event.t_meas):
+            self._dropped_clock_jump_reset += 1
+            self._reset_count += 1
+            self._last_reset_reason = "clock_jump"
+            self._initialized = False
+            self._t_filter = None
+            self._last_imu_time = None
+            return self._outputs_for_drop(update_reports)
+
+        if self._is_out_of_order(event.t_meas):
+            self._dropped_too_old += 1
+            return self._outputs_for_drop(update_reports)
+
+        if self._is_imu_gap(event):
+            self._dropped_imu_gap += 1
+            return self._outputs_for_drop(update_reports)
+
+        self._t_filter = event.t_meas
+        self._initialized = True
+        self._state_seq += 1
+        self._diag_seq += 1
+
+        if event.event_type == AhrsEventType.IMU:
+            self._last_imu_time = event.t_meas
+
+        state: AhrsStateData = self._build_state(event.t_meas)
+        diagnostics: AhrsDiagnosticsData = self._build_diagnostics(event.t_meas)
+        frame_transforms: AhrsFrameOutputs = self._build_frame_outputs()
+
+        return AhrsOutputs(
+            frontier_advanced=True,
+            t_filter=event.t_meas,
+            frame_transforms=frame_transforms,
+            state=state,
+            diagnostics=diagnostics,
+            gyro_update=update_reports["gyro"],
+            accel_update=update_reports["accel"],
+            mag_update=update_reports["mag"],
+        )
+
+    def _is_out_of_order(self, t_meas: AhrsTime) -> bool:
+        if self._t_filter is None:
+            return False
+
+        return (t_meas.sec, t_meas.nanosec) <= (
+            self._t_filter.sec,
+            self._t_filter.nanosec,
+        )
+
+    def _is_clock_jump(self, t_meas: AhrsTime) -> bool:
+        if self._t_filter is None:
+            return False
+
+        if self._config.dt_clock_jump_max_sec <= 0.0:
+            return False
+
+        if (t_meas.sec, t_meas.nanosec) >= (
+            self._t_filter.sec,
+            self._t_filter.nanosec,
+        ):
+            return False
+
+        dt_sec: float = self._seconds_between(self._t_filter, t_meas)
+        return dt_sec > self._config.dt_clock_jump_max_sec
+
+    def _is_imu_gap(self, event: AhrsEvent) -> bool:
+        if event.event_type != AhrsEventType.IMU:
+            return False
+
+        if self._last_imu_time is None:
+            return False
+
+        if self._config.dt_imu_max_sec <= 0.0:
+            return False
+
+        dt_sec: float = self._seconds_between(self._last_imu_time, event.t_meas)
+        return dt_sec > self._config.dt_imu_max_sec
+
+    def _seconds_between(self, t_start: AhrsTime, t_end: AhrsTime) -> float:
+        start_sec: float = float(t_start.sec) + float(t_start.nanosec) * 1e-9
+        end_sec: float = float(t_end.sec) + float(t_end.nanosec) * 1e-9
+
+        return abs(end_sec - start_sec)
+
+    def _has_nan_covariance(self, event: AhrsEvent) -> bool:
+        covariances: list[float] = []
+        if event.event_type == AhrsEventType.IMU:
+            payload_imu = cast(AhrsImuPacket, event.payload)
+            covariances = (
+                payload_imu.imu.angular_velocity_cov
+                + payload_imu.imu.linear_acceleration_cov
+            )
+        elif event.event_type == AhrsEventType.MAG:
+            payload_mag = cast(MagSample, event.payload)
+            covariances = payload_mag.magnetic_field_cov
+
+        return any(math.isnan(value) for value in covariances)
+
+    def _build_update_reports(
+        self, event: AhrsEvent
+    ) -> dict[str, Optional[AhrsUpdateData]]:
+        update_reports: dict[str, Optional[AhrsUpdateData]] = {
+            "gyro": None,
+            "accel": None,
+            "mag": None,
+        }
+
+        if event.event_type == AhrsEventType.IMU:
+            update_reports["gyro"] = self._build_update(
+                sensor="gyro",
+                frame_id=event.frame_id,
+                t_meas=event.t_meas,
+            )
+            update_reports["accel"] = self._build_update(
+                sensor="accel",
+                frame_id=event.frame_id,
+                t_meas=event.t_meas,
+            )
+        elif event.event_type == AhrsEventType.MAG:
+            update_reports["mag"] = self._build_update(
+                sensor="mag",
+                frame_id=event.frame_id,
+                t_meas=event.t_meas,
+            )
+
+        return update_reports
+
+    def _build_update(
+        self, sensor: str, frame_id: str, t_meas: AhrsTime
+    ) -> AhrsUpdateData:
+        empty_matrix: AhrsMatrix = AhrsMatrix(rows=0, cols=0, data=[])
+
+        return AhrsUpdateData(
+            sensor=sensor,
+            frame_id=frame_id,
+            t_meas=t_meas,
+            accepted=False,
+            reject_reason="not_implemented",
+            z=[],
+            z_hat=[],
+            nu=[],
+            r=empty_matrix,
+            s_hat=empty_matrix,
+            s=empty_matrix,
+            maha_d2=0.0,
+            gate_threshold=0.0,
+        )
+
+    def _build_state(self, t_filter: AhrsTime) -> AhrsStateData:
+        empty_matrix: AhrsMatrix = AhrsMatrix(rows=0, cols=0, data=[])
+        zero_vector: list[float] = [0.0, 0.0, 0.0]
+        zero_quaternion: list[float] = [1.0, 0.0, 0.0, 0.0]
+
+        t_bi: AhrsSe3Transform = AhrsSe3Transform(
+            parent_frame=self._config.body_frame_id,
+            child_frame="imu",
+            translation_m=zero_vector,
+            rotation_wxyz=zero_quaternion,
+        )
+        t_bm: AhrsSe3Transform = AhrsSe3Transform(
+            parent_frame=self._config.body_frame_id,
+            child_frame="mag",
+            translation_m=zero_vector,
+            rotation_wxyz=zero_quaternion,
+        )
+
+        return AhrsStateData(
+            t_filter=t_filter,
+            state_seq=self._state_seq,
+            initialized=self._initialized,
+            world_frame_id=self._config.world_frame_id,
+            odom_frame_id=self._config.odom_frame_id,
+            body_frame_id=self._config.body_frame_id,
+            p_wb_m=zero_vector,
+            v_wb_mps=zero_vector,
+            q_wb_wxyz=zero_quaternion,
+            b_g_rps=zero_vector,
+            b_a_mps2=zero_vector,
+            a_a=[0.0] * 9,
+            t_bi=t_bi,
+            t_bm=t_bm,
+            g_w_mps2=zero_vector,
+            m_w_t=zero_vector,
+            error_state_names=[],
+            p_cov=empty_matrix,
+        )
+
+    def _build_diagnostics(self, t_filter: AhrsTime) -> AhrsDiagnosticsData:
+        return AhrsDiagnosticsData(
+            t_filter=t_filter,
+            diag_seq=self._diag_seq,
+            buffer_node_count=0,
+            buffer_span_sec=0.0,
+            replay_happened=False,
+            dropped_missing_stamp=self._dropped_missing_stamp,
+            dropped_future_stamp=self._dropped_future_stamp,
+            dropped_too_old=self._dropped_too_old,
+            dropped_nan_cov=self._dropped_nan_cov,
+            dropped_imu_gap=self._dropped_imu_gap,
+            dropped_clock_jump_reset=self._dropped_clock_jump_reset,
+            reset_count=self._reset_count,
+            last_reset_reason=self._last_reset_reason,
+        )
+
+    def _build_frame_outputs(self) -> AhrsFrameOutputs:
+        zero_vector: list[float] = [0.0, 0.0, 0.0]
+        zero_quaternion: list[float] = [1.0, 0.0, 0.0, 0.0]
+
+        t_world_odom: AhrsFrameTransform = AhrsFrameTransform(
+            parent_frame="world",
+            child_frame="odom",
+            translation_m=zero_vector,
+            rotation_wxyz=zero_quaternion,
+        )
+        t_odom_base: AhrsFrameTransform = AhrsFrameTransform(
+            parent_frame="odom",
+            child_frame="base_link",
+            translation_m=zero_vector,
+            rotation_wxyz=zero_quaternion,
+        )
+        t_world_base: AhrsFrameTransform = AhrsFrameTransform(
+            parent_frame="world",
+            child_frame="base_link",
+            translation_m=zero_vector,
+            rotation_wxyz=zero_quaternion,
+        )
+
+        return AhrsFrameOutputs(
+            t_odom_base=t_odom_base,
+            t_world_odom=t_world_odom,
+            t_world_base=t_world_base,
+        )
+
+    def _outputs_for_drop(
+        self, update_reports: dict[str, Optional[AhrsUpdateData]]
+    ) -> AhrsOutputs:
+        return AhrsOutputs(
+            frontier_advanced=False,
+            t_filter=self._t_filter,
+            frame_transforms=None,
+            state=None,
+            diagnostics=None,
+            gyro_update=update_reports["gyro"],
+            accel_update=update_reports["accel"],
+            mag_update=update_reports["mag"],
+        )

--- a/oasis_control/oasis_control/localization/ahrs/ahrs_params.py
+++ b/oasis_control/oasis_control/localization/ahrs/ahrs_params.py
@@ -1,0 +1,161 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""
+ROS parameter helpers for the AHRS node
+"""
+
+from __future__ import annotations
+
+import rclpy.node
+
+from oasis_control.localization.ahrs.ahrs_config import AhrsConfig
+
+
+PARAM_WORLD_FRAME_ID: str = "world_frame_id"
+PARAM_ODOM_FRAME_ID: str = "odom_frame_id"
+PARAM_BODY_FRAME_ID: str = "body_frame_id"
+
+PARAM_T_BUFFER_SEC: str = "t_buffer_sec"
+PARAM_EPS_WALL_FUTURE_SEC: str = "epsilon_wall_future_sec"
+PARAM_DT_CLOCK_JUMP_MAX_SEC: str = "dt_clock_jump_max_sec"
+PARAM_DT_IMU_MAX_SEC: str = "dt_imu_max_sec"
+
+PARAM_MAG_ALPHA: str = "mag_alpha"
+PARAM_MAG_R_MIN: str = "mag_r_min"
+PARAM_MAG_R_MAX: str = "mag_r_max"
+PARAM_MAG_R0: str = "mag_r0"
+
+PARAM_Q_V: str = "q_v"
+PARAM_Q_W: str = "q_w"
+PARAM_Q_BG: str = "q_bg"
+PARAM_Q_BA: str = "q_ba"
+PARAM_Q_A: str = "q_a"
+PARAM_Q_BI: str = "q_bi"
+PARAM_Q_BM: str = "q_bm"
+PARAM_Q_G: str = "q_g"
+PARAM_Q_M: str = "q_m"
+
+DEFAULT_WORLD_FRAME_ID: str = "world"
+DEFAULT_ODOM_FRAME_ID: str = "odom"
+DEFAULT_BODY_FRAME_ID: str = "base_link"
+
+DEFAULT_T_BUFFER_SEC: float = 0.5
+DEFAULT_EPS_WALL_FUTURE_SEC: float = 0.1
+DEFAULT_DT_CLOCK_JUMP_MAX_SEC: float = 1.0
+DEFAULT_DT_IMU_MAX_SEC: float = 0.5
+
+DEFAULT_MAG_ALPHA: float = 1.0
+DEFAULT_MAG_R_MIN: list[float] = [0.0] * 9
+DEFAULT_MAG_R_MAX: list[float] = [0.0] * 9
+DEFAULT_MAG_R0: list[float] = [0.0] * 9
+
+DEFAULT_Q_V: float = 0.0
+DEFAULT_Q_W: float = 0.0
+DEFAULT_Q_BG: float = 0.0
+DEFAULT_Q_BA: float = 0.0
+DEFAULT_Q_A: float = 0.0
+DEFAULT_Q_BI: float = 0.0
+DEFAULT_Q_BM: float = 0.0
+DEFAULT_Q_G: float = 0.0
+DEFAULT_Q_M: float = 0.0
+
+
+def declare_ahrs_params(node: rclpy.node.Node) -> None:
+    """
+    Declare AHRS ROS parameters with defaults
+    """
+
+    node.declare_parameter(PARAM_WORLD_FRAME_ID, DEFAULT_WORLD_FRAME_ID)
+    node.declare_parameter(PARAM_ODOM_FRAME_ID, DEFAULT_ODOM_FRAME_ID)
+    node.declare_parameter(PARAM_BODY_FRAME_ID, DEFAULT_BODY_FRAME_ID)
+
+    node.declare_parameter(PARAM_T_BUFFER_SEC, DEFAULT_T_BUFFER_SEC)
+    node.declare_parameter(PARAM_EPS_WALL_FUTURE_SEC, DEFAULT_EPS_WALL_FUTURE_SEC)
+    node.declare_parameter(PARAM_DT_CLOCK_JUMP_MAX_SEC, DEFAULT_DT_CLOCK_JUMP_MAX_SEC)
+    node.declare_parameter(PARAM_DT_IMU_MAX_SEC, DEFAULT_DT_IMU_MAX_SEC)
+
+    node.declare_parameter(PARAM_MAG_ALPHA, DEFAULT_MAG_ALPHA)
+    node.declare_parameter(PARAM_MAG_R_MIN, DEFAULT_MAG_R_MIN)
+    node.declare_parameter(PARAM_MAG_R_MAX, DEFAULT_MAG_R_MAX)
+    node.declare_parameter(PARAM_MAG_R0, DEFAULT_MAG_R0)
+
+    node.declare_parameter(PARAM_Q_V, DEFAULT_Q_V)
+    node.declare_parameter(PARAM_Q_W, DEFAULT_Q_W)
+    node.declare_parameter(PARAM_Q_BG, DEFAULT_Q_BG)
+    node.declare_parameter(PARAM_Q_BA, DEFAULT_Q_BA)
+    node.declare_parameter(PARAM_Q_A, DEFAULT_Q_A)
+    node.declare_parameter(PARAM_Q_BI, DEFAULT_Q_BI)
+    node.declare_parameter(PARAM_Q_BM, DEFAULT_Q_BM)
+    node.declare_parameter(PARAM_Q_G, DEFAULT_Q_G)
+    node.declare_parameter(PARAM_Q_M, DEFAULT_Q_M)
+
+
+def load_ahrs_config(node: rclpy.node.Node) -> AhrsConfig:
+    """
+    Load AHRS configuration from ROS parameters
+    """
+
+    world_frame_id: str = str(node.get_parameter(PARAM_WORLD_FRAME_ID).value)
+    odom_frame_id: str = str(node.get_parameter(PARAM_ODOM_FRAME_ID).value)
+    body_frame_id: str = str(node.get_parameter(PARAM_BODY_FRAME_ID).value)
+
+    t_buffer_sec: float = float(node.get_parameter(PARAM_T_BUFFER_SEC).value)
+    epsilon_wall_future_sec: float = float(
+        node.get_parameter(PARAM_EPS_WALL_FUTURE_SEC).value
+    )
+    dt_clock_jump_max_sec: float = float(
+        node.get_parameter(PARAM_DT_CLOCK_JUMP_MAX_SEC).value
+    )
+    dt_imu_max_sec: float = float(node.get_parameter(PARAM_DT_IMU_MAX_SEC).value)
+
+    mag_alpha: float = float(node.get_parameter(PARAM_MAG_ALPHA).value)
+    mag_r_min: list[float] = [
+        float(value) for value in node.get_parameter(PARAM_MAG_R_MIN).value
+    ]
+    mag_r_max: list[float] = [
+        float(value) for value in node.get_parameter(PARAM_MAG_R_MAX).value
+    ]
+    mag_r0: list[float] = [
+        float(value) for value in node.get_parameter(PARAM_MAG_R0).value
+    ]
+
+    q_v: float = float(node.get_parameter(PARAM_Q_V).value)
+    q_w: float = float(node.get_parameter(PARAM_Q_W).value)
+    q_bg: float = float(node.get_parameter(PARAM_Q_BG).value)
+    q_ba: float = float(node.get_parameter(PARAM_Q_BA).value)
+    q_a: float = float(node.get_parameter(PARAM_Q_A).value)
+    q_bi: float = float(node.get_parameter(PARAM_Q_BI).value)
+    q_bm: float = float(node.get_parameter(PARAM_Q_BM).value)
+    q_g: float = float(node.get_parameter(PARAM_Q_G).value)
+    q_m: float = float(node.get_parameter(PARAM_Q_M).value)
+
+    return AhrsConfig(
+        world_frame_id=world_frame_id,
+        odom_frame_id=odom_frame_id,
+        body_frame_id=body_frame_id,
+        t_buffer_sec=t_buffer_sec,
+        epsilon_wall_future_sec=epsilon_wall_future_sec,
+        dt_clock_jump_max_sec=dt_clock_jump_max_sec,
+        dt_imu_max_sec=dt_imu_max_sec,
+        mag_alpha=mag_alpha,
+        mag_r_min=mag_r_min,
+        mag_r_max=mag_r_max,
+        mag_r0=mag_r0,
+        q_v=q_v,
+        q_w=q_w,
+        q_bg=q_bg,
+        q_ba=q_ba,
+        q_a=q_a,
+        q_bi=q_bi,
+        q_bm=q_bm,
+        q_g=q_g,
+        q_m=q_m,
+    )

--- a/oasis_control/oasis_control/localization/ahrs/ahrs_publishers.py
+++ b/oasis_control/oasis_control/localization/ahrs/ahrs_publishers.py
@@ -1,0 +1,155 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""
+ROS publishers for AHRS localization
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import rclpy.node
+import rclpy.publisher
+from geometry_msgs.msg import PoseWithCovarianceStamped
+from geometry_msgs.msg import TransformStamped
+from nav_msgs.msg import Odometry as OdometryMsg
+from rclpy.qos import QoSProfile
+from tf2_ros import TransformBroadcaster
+
+from oasis_control.localization.ahrs.ahrs_config import AhrsConfig
+from oasis_control.localization.ahrs.ahrs_ros_msgs import to_diag_msg
+from oasis_control.localization.ahrs.ahrs_ros_msgs import to_odom_msg
+from oasis_control.localization.ahrs.ahrs_ros_msgs import to_pose_cov_msg
+from oasis_control.localization.ahrs.ahrs_ros_msgs import to_state_msg
+from oasis_control.localization.ahrs.ahrs_ros_msgs import to_tf_msgs
+from oasis_control.localization.ahrs.ahrs_ros_msgs import to_update_report_msg
+from oasis_control.localization.ahrs.ahrs_types import AhrsOutputs
+from oasis_control.localization.ahrs.ahrs_types import AhrsUpdateData
+from oasis_msgs.msg import AhrsDiagnostics as AhrsDiagnosticsMsg
+from oasis_msgs.msg import AhrsState as AhrsStateMsg
+from oasis_msgs.msg import EkfUpdateReport as EkfUpdateReportMsg
+
+
+ACCEL_UPDATE_TOPIC: str = "ahrs/updates/accel"
+GYRO_UPDATE_TOPIC: str = "ahrs/updates/gyro"
+MAG_UPDATE_TOPIC: str = "ahrs/updates/mag"
+
+EXTRINSICS_T_BI_TOPIC: str = "ahrs/extrinsics/t_bi"
+EXTRINSICS_T_BM_TOPIC: str = "ahrs/extrinsics/t_bm"
+
+ODOM_TOPIC: str = "ahrs/odom"
+WORLD_ODOM_TOPIC: str = "ahrs/world_odom"
+
+STATE_TOPIC: str = "ahrs/state"
+DIAG_TOPIC: str = "ahrs/diag"
+
+
+class AhrsPublishers:
+    """
+    ROS publisher wrapper for AHRS outputs
+    """
+
+    def __init__(
+        self, node: rclpy.node.Node, config: AhrsConfig, qos: QoSProfile
+    ) -> None:
+        self._node: rclpy.node.Node = node
+        self._config: AhrsConfig = config
+
+        self._tf_broadcaster: TransformBroadcaster = TransformBroadcaster(node)
+
+        self._odom_pub: rclpy.publisher.Publisher = node.create_publisher(
+            OdometryMsg, ODOM_TOPIC, qos
+        )
+        self._world_odom_pub: rclpy.publisher.Publisher = node.create_publisher(
+            OdometryMsg, WORLD_ODOM_TOPIC, qos
+        )
+        self._t_bi_pub: rclpy.publisher.Publisher = node.create_publisher(
+            PoseWithCovarianceStamped, EXTRINSICS_T_BI_TOPIC, qos
+        )
+        self._t_bm_pub: rclpy.publisher.Publisher = node.create_publisher(
+            PoseWithCovarianceStamped, EXTRINSICS_T_BM_TOPIC, qos
+        )
+        self._state_pub: rclpy.publisher.Publisher = node.create_publisher(
+            AhrsStateMsg, STATE_TOPIC, qos
+        )
+        self._diag_pub: rclpy.publisher.Publisher = node.create_publisher(
+            AhrsDiagnosticsMsg, DIAG_TOPIC, qos
+        )
+        self._gyro_update_pub: rclpy.publisher.Publisher = node.create_publisher(
+            EkfUpdateReportMsg, GYRO_UPDATE_TOPIC, qos
+        )
+        self._accel_update_pub: rclpy.publisher.Publisher = node.create_publisher(
+            EkfUpdateReportMsg, ACCEL_UPDATE_TOPIC, qos
+        )
+        self._mag_update_pub: rclpy.publisher.Publisher = node.create_publisher(
+            EkfUpdateReportMsg, MAG_UPDATE_TOPIC, qos
+        )
+
+    def publish_outputs(self, outputs: AhrsOutputs) -> None:
+        self._publish_update(outputs.gyro_update, self._gyro_update_pub)
+        self._publish_update(outputs.accel_update, self._accel_update_pub)
+        self._publish_update(outputs.mag_update, self._mag_update_pub)
+
+        if not outputs.frontier_advanced:
+            return
+
+        if outputs.t_filter is None:
+            return
+
+        if outputs.frame_transforms is not None:
+            tf_msgs: list[TransformStamped] = to_tf_msgs(
+                outputs.t_filter, outputs.frame_transforms, self._config
+            )
+            self._tf_broadcaster.sendTransform(tf_msgs)
+
+            odom_msg: OdometryMsg = to_odom_msg(
+                outputs.t_filter,
+                outputs.frame_transforms.t_odom_base,
+                frame_id=self._config.odom_frame_id,
+                child_frame_id=self._config.body_frame_id,
+            )
+            world_odom_msg: OdometryMsg = to_odom_msg(
+                outputs.t_filter,
+                outputs.frame_transforms.t_world_odom,
+                frame_id=self._config.world_frame_id,
+                child_frame_id=self._config.odom_frame_id,
+            )
+            self._odom_pub.publish(odom_msg)
+            self._world_odom_pub.publish(world_odom_msg)
+
+        if outputs.state is not None:
+            state_msg: AhrsStateMsg = to_state_msg(outputs.state)
+            self._state_pub.publish(state_msg)
+
+            t_bi_msg: PoseWithCovarianceStamped = to_pose_cov_msg(
+                outputs.t_filter, outputs.state.t_bi
+            )
+            t_bm_msg: PoseWithCovarianceStamped = to_pose_cov_msg(
+                outputs.t_filter, outputs.state.t_bm
+            )
+            self._t_bi_pub.publish(t_bi_msg)
+            self._t_bm_pub.publish(t_bm_msg)
+
+        if outputs.diagnostics is not None:
+            diag_msg: AhrsDiagnosticsMsg = to_diag_msg(outputs.diagnostics)
+            diag_msg.header.frame_id = self._config.world_frame_id
+            self._diag_pub.publish(diag_msg)
+
+    def _publish_update(
+        self,
+        update: Optional[AhrsUpdateData],
+        publisher: rclpy.publisher.Publisher,
+    ) -> None:
+        if update is None:
+            return
+
+        msg: EkfUpdateReportMsg = to_update_report_msg(update)
+        publisher.publish(msg)

--- a/oasis_control/oasis_control/localization/ahrs/ahrs_ros_clock.py
+++ b/oasis_control/oasis_control/localization/ahrs/ahrs_ros_clock.py
@@ -1,0 +1,33 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""
+ROS clock implementation for AHRS localization
+"""
+
+from __future__ import annotations
+
+import rclpy.node
+
+from oasis_control.localization.ahrs.ahrs_clock import AhrsClock
+from oasis_control.localization.ahrs.ahrs_ros_conversions import ahrs_time_from_ros
+from oasis_control.localization.ahrs.ahrs_types import AhrsTime
+
+
+class RosAhrsClock(AhrsClock):
+    """
+    ROS clock implementation backed by a node's time source
+    """
+
+    def __init__(self, node: rclpy.node.Node) -> None:
+        self._node: rclpy.node.Node = node
+
+    def now(self) -> AhrsTime:
+        return ahrs_time_from_ros(self._node.get_clock().now().to_msg())

--- a/oasis_control/oasis_control/localization/ahrs/ahrs_ros_conversions.py
+++ b/oasis_control/oasis_control/localization/ahrs/ahrs_ros_conversions.py
@@ -1,0 +1,74 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""
+Conversion helpers between ROS messages and AHRS types
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Protocol
+
+from builtin_interfaces.msg import Time as TimeMsg
+
+from oasis_control.localization.ahrs.ahrs_conversions import ahrs_time_from_pair
+from oasis_control.localization.ahrs.ahrs_conversions import cov3x3_from_seq
+from oasis_control.localization.ahrs.ahrs_conversions import normalize_ahrs_time
+from oasis_control.localization.ahrs.ahrs_conversions import vector3_from_xyz
+from oasis_control.localization.ahrs.ahrs_types import AhrsTime
+
+
+class Vector3Like(Protocol):
+    """
+    Protocol for geometry messages with x/y/z fields
+    """
+
+    x: float
+    y: float
+    z: float
+
+
+def ahrs_time_from_ros(stamp: TimeMsg) -> AhrsTime:
+    """
+    Convert a ROS time stamp into an AHRS time
+    """
+
+    return ahrs_time_from_pair(sec=int(stamp.sec), nanosec=int(stamp.nanosec))
+
+
+def ros_time_from_ahrs(t: AhrsTime) -> TimeMsg:
+    """
+    Convert an AHRS time into a ROS time stamp
+    """
+
+    normalized: AhrsTime = normalize_ahrs_time(t)
+
+    stamp: TimeMsg = TimeMsg()
+    stamp.sec = normalized.sec
+    stamp.nanosec = normalized.nanosec
+
+    return stamp
+
+
+def cov3x3_from_ros(cov: Sequence[float]) -> list[float]:
+    """
+    Convert a ROS covariance list into a validated 3x3 covariance
+    """
+
+    return cov3x3_from_seq(cov)
+
+
+def vector3_from_ros(msg: Vector3Like) -> list[float]:
+    """
+    Convert a ROS Vector3-like message into a list
+    """
+
+    return vector3_from_xyz(msg.x, msg.y, msg.z)

--- a/oasis_control/oasis_control/localization/ahrs/ahrs_ros_msgs.py
+++ b/oasis_control/oasis_control/localization/ahrs/ahrs_ros_msgs.py
@@ -1,0 +1,281 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""
+ROS message builders for AHRS localization
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from geometry_msgs.msg import Point
+from geometry_msgs.msg import Pose
+from geometry_msgs.msg import PoseWithCovariance
+from geometry_msgs.msg import PoseWithCovarianceStamped
+from geometry_msgs.msg import Quaternion
+from geometry_msgs.msg import Transform
+from geometry_msgs.msg import TransformStamped
+from geometry_msgs.msg import Twist
+from geometry_msgs.msg import TwistWithCovariance
+from geometry_msgs.msg import Vector3
+from nav_msgs.msg import Odometry as OdometryMsg
+
+from oasis_control.localization.ahrs.ahrs_config import AhrsConfig
+from oasis_control.localization.ahrs.ahrs_conversions import ros_time_from_ahrs
+from oasis_control.localization.ahrs.ahrs_types import AhrsDiagnosticsData
+from oasis_control.localization.ahrs.ahrs_types import AhrsFrameOutputs
+from oasis_control.localization.ahrs.ahrs_types import AhrsFrameTransform
+from oasis_control.localization.ahrs.ahrs_types import AhrsMatrix
+from oasis_control.localization.ahrs.ahrs_types import AhrsSe3Transform
+from oasis_control.localization.ahrs.ahrs_types import AhrsStateData
+from oasis_control.localization.ahrs.ahrs_types import AhrsTime
+from oasis_control.localization.ahrs.ahrs_types import AhrsUpdateData
+from oasis_msgs.msg import AhrsDiagnostics as AhrsDiagnosticsMsg
+from oasis_msgs.msg import AhrsState as AhrsStateMsg
+from oasis_msgs.msg import EkfUpdateReport as EkfUpdateReportMsg
+from oasis_msgs.msg import Matrix as MatrixMsg
+
+
+def to_update_report_msg(update: AhrsUpdateData) -> EkfUpdateReportMsg:
+    msg: EkfUpdateReportMsg = EkfUpdateReportMsg()
+    msg.header.stamp = ros_time_from_ahrs(update.t_meas)
+    msg.sensor = update.sensor
+    msg.frame_id = update.frame_id
+    msg.update_seq = 0
+    msg.update_index_in_stamp = 0
+    msg.accepted = update.accepted
+    msg.reject_reason = update.reject_reason or ""
+    msg.z_dim = len(update.z)
+    msg.z = list(update.z)
+    msg.z_hat = list(update.z_hat)
+    msg.nu = list(update.nu)
+    msg.r = _to_matrix_msg(update.r)
+    msg.s_hat = _to_matrix_msg(update.s_hat)
+    msg.s = _to_matrix_msg(update.s)
+    msg.maha_d2 = update.maha_d2
+    msg.gate_d2_threshold = update.gate_threshold
+    msg.reproj_rms_px = 0.0
+
+    return msg
+
+
+def to_state_msg(state: AhrsStateData) -> AhrsStateMsg:
+    msg: AhrsStateMsg = AhrsStateMsg()
+    msg.header.stamp = ros_time_from_ahrs(state.t_filter)
+    msg.header.frame_id = state.world_frame_id
+    msg.world_frame_id = state.world_frame_id
+    msg.odom_frame_id = state.odom_frame_id
+    msg.body_frame_id = state.body_frame_id
+    msg.state_seq = state.state_seq
+    msg.initialized = state.initialized
+    msg.position_wb_m = _to_point(state.p_wb_m)
+    msg.velocity_wb_mps = _to_vector3(state.v_wb_mps)
+    msg.orientation_wb = _to_quaternion(state.q_wb_wxyz)
+    msg.gyro_bias = _to_vector3(state.b_g_rps)
+    msg.accel_bias = _to_vector3(state.b_a_mps2)
+    msg.accel_a = list(state.a_a)
+    msg.t_bi = _to_pose(state.t_bi)
+    msg.t_bm = _to_pose(state.t_bm)
+    msg.gravity_w_mps2 = _to_vector3(state.g_w_mps2)
+    msg.magnetic_field_w_t = _to_vector3(state.m_w_t)
+    msg.error_dim = state.p_cov.rows
+    msg.error_state_names = list(state.error_state_names)
+    msg.p = _to_matrix_msg(state.p_cov)
+
+    return msg
+
+
+def to_diag_msg(diag: AhrsDiagnosticsData) -> AhrsDiagnosticsMsg:
+    msg: AhrsDiagnosticsMsg = AhrsDiagnosticsMsg()
+    if diag.t_filter is not None:
+        msg.header.stamp = ros_time_from_ahrs(diag.t_filter)
+        msg.t_filter_sec = _seconds_from_ahrs(diag.t_filter)
+    else:
+        msg.t_filter_sec = 0.0
+    msg.diag_seq = diag.diag_seq
+    msg.buffer_node_count = diag.buffer_node_count
+    msg.buffer_span_sec = diag.buffer_span_sec
+    msg.replay_happened = diag.replay_happened
+    msg.dropped_missing_stamp = diag.dropped_missing_stamp
+    msg.dropped_future_stamp = diag.dropped_future_stamp
+    msg.dropped_too_old = diag.dropped_too_old
+    msg.dropped_nan_cov = diag.dropped_nan_cov
+    msg.dropped_imu_coverage_gap = diag.dropped_imu_gap
+    msg.dropped_clock_jump_reset = diag.dropped_clock_jump_reset
+    msg.last_reset_reason = diag.last_reset_reason
+
+    return msg
+
+
+def to_pose_cov_msg(
+    t: AhrsTime,
+    t_se3: AhrsSe3Transform,
+    covariance_6x6: Optional[list[float]] = None,
+) -> PoseWithCovarianceStamped:
+    msg: PoseWithCovarianceStamped = PoseWithCovarianceStamped()
+    msg.header.stamp = ros_time_from_ahrs(t)
+    msg.header.frame_id = t_se3.parent_frame
+    msg.pose = _to_pose_covariance(t_se3, covariance_6x6)
+
+    return msg
+
+
+def to_odom_msg(
+    t: AhrsTime,
+    transform: AhrsFrameTransform,
+    frame_id: str,
+    child_frame_id: str,
+) -> OdometryMsg:
+    msg: OdometryMsg = OdometryMsg()
+    msg.header.stamp = ros_time_from_ahrs(t)
+    msg.header.frame_id = frame_id
+    msg.child_frame_id = child_frame_id
+    msg.pose = _to_pose_with_covariance(transform)
+    msg.twist = _zero_twist_with_covariance()
+
+    return msg
+
+
+def to_tf_msgs(
+    t: AhrsTime, frame_transforms: AhrsFrameOutputs, config: AhrsConfig
+) -> list[TransformStamped]:
+    t_world_odom: TransformStamped = _to_transform_stamped(
+        t,
+        frame_transforms.t_world_odom,
+        config,
+    )
+    t_odom_base: TransformStamped = _to_transform_stamped(
+        t,
+        frame_transforms.t_odom_base,
+        config,
+    )
+
+    return [t_world_odom, t_odom_base]
+
+
+def _to_transform_stamped(
+    t: AhrsTime,
+    transform: AhrsFrameTransform,
+    config: AhrsConfig,
+) -> TransformStamped:
+    msg: TransformStamped = TransformStamped()
+    msg.header.stamp = ros_time_from_ahrs(t)
+    msg.header.frame_id = _map_frame_id(transform.parent_frame, config)
+    msg.child_frame_id = _map_frame_id(transform.child_frame, config)
+    msg.transform = _to_transform(transform)
+
+    return msg
+
+
+def _map_frame_id(frame_id: str, config: AhrsConfig) -> str:
+    if frame_id == "world":
+        return config.world_frame_id
+    if frame_id == "odom":
+        return config.odom_frame_id
+    if frame_id == "base_link":
+        return config.body_frame_id
+
+    return frame_id
+
+
+def _to_matrix_msg(matrix: AhrsMatrix) -> MatrixMsg:
+    msg: MatrixMsg = MatrixMsg()
+    msg.rows = matrix.rows
+    msg.cols = matrix.cols
+    msg.data = list(matrix.data)
+
+    return msg
+
+
+def _to_pose(transform: AhrsSe3Transform) -> Pose:
+    pose: Pose = Pose()
+    pose.position = _to_point(transform.translation_m)
+    pose.orientation = _to_quaternion(transform.rotation_wxyz)
+
+    return pose
+
+
+def _to_pose_covariance(
+    transform: AhrsSe3Transform, covariance: Optional[list[float]]
+) -> PoseWithCovariance:
+    pose_cov: PoseWithCovariance = PoseWithCovariance()
+    pose_cov.pose = _to_pose(transform)
+    pose_cov.covariance = _to_covariance_6x6(covariance)
+
+    return pose_cov
+
+
+def _to_pose_with_covariance(transform: AhrsFrameTransform) -> PoseWithCovariance:
+    pose_cov: PoseWithCovariance = PoseWithCovariance()
+    pose_cov.pose.position = _to_point(transform.translation_m)
+    pose_cov.pose.orientation = _to_quaternion(transform.rotation_wxyz)
+    pose_cov.covariance = _to_covariance_6x6(None)
+
+    return pose_cov
+
+
+def _zero_twist_with_covariance() -> TwistWithCovariance:
+    twist_cov: TwistWithCovariance = TwistWithCovariance()
+    twist_cov.twist = Twist()
+    twist_cov.twist.linear = Vector3()
+    twist_cov.twist.angular = Vector3()
+    twist_cov.covariance = _to_covariance_6x6(None)
+
+    return twist_cov
+
+
+def _to_transform(transform: AhrsFrameTransform) -> Transform:
+    msg: Transform = Transform()
+    msg.translation = _to_vector3(transform.translation_m)
+    msg.rotation = _to_quaternion(transform.rotation_wxyz)
+
+    return msg
+
+
+def _to_point(values: list[float]) -> Point:
+    point: Point = Point()
+    point.x = values[0]
+    point.y = values[1]
+    point.z = values[2]
+
+    return point
+
+
+def _to_vector3(values: list[float]) -> Vector3:
+    vec: Vector3 = Vector3()
+    vec.x = values[0]
+    vec.y = values[1]
+    vec.z = values[2]
+
+    return vec
+
+
+def _to_quaternion(values_wxyz: list[float]) -> Quaternion:
+    quat: Quaternion = Quaternion()
+    quat.w = values_wxyz[0]
+    quat.x = values_wxyz[1]
+    quat.y = values_wxyz[2]
+    quat.z = values_wxyz[3]
+
+    return quat
+
+
+def _to_covariance_6x6(covariance: Optional[list[float]]) -> list[float]:
+    if covariance is None:
+        return [0.0] * 36
+    if len(covariance) != 36:
+        raise ValueError("Expected 36 covariance entries")
+
+    return list(covariance)
+
+
+def _seconds_from_ahrs(t: AhrsTime) -> float:
+    return float(t.sec) + float(t.nanosec) * 1e-9

--- a/oasis_control/oasis_control/localization/ahrs/ahrs_ros_msgs.py
+++ b/oasis_control/oasis_control/localization/ahrs/ahrs_ros_msgs.py
@@ -29,7 +29,8 @@ from geometry_msgs.msg import Vector3
 from nav_msgs.msg import Odometry as OdometryMsg
 
 from oasis_control.localization.ahrs.ahrs_config import AhrsConfig
-from oasis_control.localization.ahrs.ahrs_conversions import ros_time_from_ahrs
+from oasis_control.localization.ahrs.ahrs_conversions import seconds_from_ahrs
+from oasis_control.localization.ahrs.ahrs_ros_conversions import ros_time_from_ahrs
 from oasis_control.localization.ahrs.ahrs_types import AhrsDiagnosticsData
 from oasis_control.localization.ahrs.ahrs_types import AhrsFrameOutputs
 from oasis_control.localization.ahrs.ahrs_types import AhrsFrameTransform
@@ -97,7 +98,7 @@ def to_diag_msg(diag: AhrsDiagnosticsData) -> AhrsDiagnosticsMsg:
     msg: AhrsDiagnosticsMsg = AhrsDiagnosticsMsg()
     if diag.t_filter is not None:
         msg.header.stamp = ros_time_from_ahrs(diag.t_filter)
-        msg.t_filter_sec = _seconds_from_ahrs(diag.t_filter)
+        msg.t_filter_sec = seconds_from_ahrs(diag.t_filter)
     else:
         msg.t_filter_sec = 0.0
     msg.diag_seq = diag.diag_seq
@@ -275,7 +276,3 @@ def _to_covariance_6x6(covariance: Optional[list[float]]) -> list[float]:
         raise ValueError("Expected 36 covariance entries")
 
     return list(covariance)
-
-
-def _seconds_from_ahrs(t: AhrsTime) -> float:
-    return float(t.sec) + float(t.nanosec) * 1e-9

--- a/oasis_control/oasis_control/localization/ahrs/ahrs_types.py
+++ b/oasis_control/oasis_control/localization/ahrs/ahrs_types.py
@@ -1,0 +1,371 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""
+Types and helpers for AHRS localization
+"""
+
+import enum
+from dataclasses import dataclass
+from typing import Literal
+from typing import Optional
+from typing import Union
+
+
+@dataclass(frozen=True)
+class AhrsTime:
+    """
+    AHRS timestamp stored as seconds and nanoseconds
+
+    Fields:
+        sec: Whole seconds since the AHRS time reference
+        nanosec: Sub-second remainder in nanoseconds [0, 1e9)
+    """
+
+    sec: int
+    nanosec: int
+
+
+AhrsFrameId = Literal["world", "odom", "base_link"]
+
+
+@dataclass(frozen=True)
+class AhrsFrameTransform:
+    """
+    Rigid transform between semantic frames
+
+    Fields:
+        parent_frame: Semantic parent frame
+        child_frame: Semantic child frame
+        translation_m: Translation in meters, XYZ order
+        rotation_wxyz: Quaternion rotation in wxyz order, unit length
+    """
+
+    parent_frame: AhrsFrameId
+    child_frame: AhrsFrameId
+    translation_m: list[float]
+    rotation_wxyz: list[float]
+
+
+@dataclass(frozen=True)
+class AhrsSe3Transform:
+    """
+    Rigid transform between arbitrary frames
+
+    Fields:
+        parent_frame: Parent frame name for the transform
+        child_frame: Child frame name for the transform
+        translation_m: Translation in meters, XYZ order
+        rotation_wxyz: Quaternion rotation in wxyz order, unit length
+    """
+
+    parent_frame: str
+    child_frame: str
+    translation_m: list[float]
+    rotation_wxyz: list[float]
+
+
+@dataclass(frozen=True)
+class AhrsFrameOutputs:
+    """
+    Frame outputs derived from the canonical odom state
+
+    Fields:
+        t_odom_base: Transform from odom to base
+        t_world_odom: Transform from world to odom
+        t_world_base: Transform from world to base derived by composition
+    """
+
+    t_odom_base: AhrsFrameTransform
+    t_world_odom: AhrsFrameTransform
+    t_world_base: AhrsFrameTransform
+
+
+class AhrsEventType(enum.Enum):
+    """
+    Enumerates the kinds of time-ordered AHRS events
+
+    Attributes:
+        IMU: Inertial sample or IMU packet event
+        MAG: Magnetometer measurement event
+    """
+
+    IMU = "imu"
+    MAG = "mag"
+
+
+@dataclass(frozen=True)
+class ImuCalibrationData:
+    """
+    Calibration prior data for IMU bias and scale parameters
+
+    Fields:
+        valid: True when the calibration payload is safe to apply
+        frame_id: IMU frame identifier expected to match the IMU sample frame
+        accel_bias_mps2: Accelerometer bias in m/s^2, XYZ order
+        accel_a: 3x3 accel scale/misalignment matrix, row-major
+        accel_param_cov: 12x12 covariance of accel calibration params
+        gyro_bias_rps: Gyroscope bias in rad/s, XYZ order
+        gyro_bias_cov: 3x3 covariance of gyro bias params, row-major
+        gravity_mps2: Gravity magnitude assumed during calibration in m/s^2
+        fit_sample_count: Number of samples used in the calibration fit
+        rms_residual_mps2: RMS gravity residual of the calibration in m/s^2
+        temperature_c: Mean calibration temperature in deg C
+        temperature_var_c2: Temperature variance in (deg C)^2
+    """
+
+    valid: bool
+    frame_id: str
+    accel_bias_mps2: list[float]
+    accel_a: list[float]
+    accel_param_cov: list[float]
+    gyro_bias_rps: list[float]
+    gyro_bias_cov: list[float]
+    gravity_mps2: float
+    fit_sample_count: int
+    rms_residual_mps2: float
+    temperature_c: float
+    temperature_var_c2: float
+
+
+@dataclass(frozen=True)
+class ImuSample:
+    """
+    IMU sample with raw motion data
+
+    Fields:
+        frame_id: IMU frame identifier for this sample
+        angular_velocity_rps: Angular velocity in rad/s, XYZ order
+        linear_acceleration_mps2: Linear acceleration in m/s^2, XYZ order
+        angular_velocity_cov: 3x3 gyro covariance, row-major
+        linear_acceleration_cov: 3x3 accel covariance, row-major
+    """
+
+    frame_id: str
+    angular_velocity_rps: list[float]
+    linear_acceleration_mps2: list[float]
+    angular_velocity_cov: list[float]
+    linear_acceleration_cov: list[float]
+
+
+@dataclass(frozen=True)
+class AhrsImuPacket:
+    """
+    IMU packet event payload
+
+    Fields:
+        imu: Raw IMU measurement sample
+        calibration: IMU calibration prior tied to the IMU frame
+    """
+
+    imu: ImuSample
+    calibration: ImuCalibrationData
+
+
+@dataclass(frozen=True)
+class MagSample:
+    """
+    Magnetometer sample data
+
+    Fields:
+        frame_id: Magnetometer frame identifier
+        magnetic_field_t: Magnetic field vector in tesla, XYZ order
+        magnetic_field_cov: 3x3 covariance in tesla^2, row-major
+    """
+
+    frame_id: str
+    magnetic_field_t: list[float]
+    magnetic_field_cov: list[float]
+
+
+AhrsEventPayload = Union[
+    AhrsImuPacket,
+    MagSample,
+]
+
+
+@dataclass(frozen=True)
+class AhrsEvent:
+    """
+    Time-stamped AHRS event in the common filter timeline
+
+    Fields:
+        t_meas: Measurement timestamp
+        topic: Topic name that produced the event
+        frame_id: Frame identifier from the event header
+        event_type: Event category for dispatching updates
+        payload: Event data payload for the selected type
+    """
+
+    t_meas: AhrsTime
+    topic: str
+    frame_id: str
+    event_type: AhrsEventType
+    payload: AhrsEventPayload
+
+
+@dataclass(frozen=True)
+class AhrsMatrix:
+    """
+    Row-major matrix data used by update reporting
+
+    Fields:
+        rows: Number of rows in the matrix
+        cols: Number of columns in the matrix
+        data: Row-major matrix entries
+    """
+
+    rows: int
+    cols: int
+    data: list[float]
+
+
+@dataclass(frozen=True)
+class AhrsUpdateData:
+    """
+    Generic update report payload
+
+    Fields:
+        sensor: Sensor name such as gyro, accel, or mag
+        frame_id: Measurement frame identifier
+        t_meas: Measurement timestamp
+        accepted: True when the update was accepted by the filter
+        reject_reason: Optional reason string when the update is rejected
+        z: Measurement vector in sensor units, as received
+        z_hat: Predicted measurement vector in sensor units
+        nu: Innovation vector (z - z_hat) in sensor units
+        r: Measurement covariance in sensor units, row-major
+        s_hat: Predicted innovation covariance, row-major
+        s: Innovation covariance after conditioning, row-major
+        maha_d2: Mahalanobis distance squared for gating
+        gate_threshold: Gate threshold for the Mahalanobis distance
+    """
+
+    sensor: str
+    frame_id: str
+    t_meas: AhrsTime
+    accepted: bool
+    reject_reason: Optional[str]
+    z: list[float]
+    z_hat: list[float]
+    nu: list[float]
+    r: AhrsMatrix
+    s_hat: AhrsMatrix
+    s: AhrsMatrix
+    maha_d2: float
+    gate_threshold: float
+
+
+@dataclass(frozen=True)
+class AhrsStateData:
+    """
+    Filter state output payload for AhrsState publication
+
+    Fields:
+        t_filter: Filter frontier timestamp for this state
+        state_seq: Monotonic state sequence identifier
+        initialized: True when the filter has a valid initial state
+        world_frame_id: World frame identifier for the state
+        odom_frame_id: Odometry frame identifier for the state
+        body_frame_id: Body frame identifier for the state
+        p_wb_m: Position of the body in world in meters, XYZ order
+        v_wb_mps: Velocity of the body in world in m/s, XYZ order
+        q_wb_wxyz: Orientation of the body in world, quaternion wxyz order
+        b_g_rps: Gyro bias in rad/s, XYZ order
+        b_a_mps2: Accel bias in m/s^2, XYZ order
+        a_a: Accel scale/misalignment matrix, 3x3 row-major
+        t_bi: IMU -> body transform (T_BI)
+        t_bm: Magnetometer -> body transform (T_BM)
+        g_w_mps2: Gravity vector in world in m/s^2, XYZ order
+        m_w_t: Magnetic field vector in world in tesla, XYZ order
+        error_state_names: Names of error-state entries in the covariance
+        p_cov: Full error-state covariance, row-major
+    """
+
+    t_filter: AhrsTime
+    state_seq: int
+    initialized: bool
+    world_frame_id: str
+    odom_frame_id: str
+    body_frame_id: str
+    p_wb_m: list[float]
+    v_wb_mps: list[float]
+    q_wb_wxyz: list[float]
+    b_g_rps: list[float]
+    b_a_mps2: list[float]
+    a_a: list[float]
+    t_bi: AhrsSe3Transform
+    t_bm: AhrsSe3Transform
+    g_w_mps2: list[float]
+    m_w_t: list[float]
+    error_state_names: list[str]
+    p_cov: AhrsMatrix
+
+
+@dataclass(frozen=True)
+class AhrsDiagnosticsData:
+    """
+    Diagnostics output payload for AhrsDiagnostics publication
+
+    Fields:
+        t_filter: Filter frontier timestamp if an output was published
+        diag_seq: Monotonic diagnostics sequence identifier
+        buffer_node_count: Number of time nodes currently buffered
+        buffer_span_sec: Time span of buffered events in seconds
+        replay_happened: True when a replay was triggered
+        dropped_missing_stamp: Count of updates dropped for missing stamps
+        dropped_future_stamp: Count of updates dropped for future stamps
+        dropped_too_old: Count of updates dropped for being too old
+        dropped_nan_cov: Count of updates dropped for NaN covariance entries
+        dropped_imu_gap: Count of updates dropped for IMU gap detection
+        dropped_clock_jump_reset: Count of updates dropped for clock jump reset
+        reset_count: Number of filter resets performed
+        last_reset_reason: Latest reset reason description
+    """
+
+    t_filter: Optional[AhrsTime]
+    diag_seq: int
+    buffer_node_count: int
+    buffer_span_sec: float
+    replay_happened: bool
+    dropped_missing_stamp: int
+    dropped_future_stamp: int
+    dropped_too_old: int
+    dropped_nan_cov: int
+    dropped_imu_gap: int
+    dropped_clock_jump_reset: int
+    reset_count: int
+    last_reset_reason: str
+
+
+@dataclass(frozen=True)
+class AhrsOutputs:
+    """
+    Outputs produced by AHRS event processing
+
+    Fields:
+        frontier_advanced: True when the filter frontier advanced on this event
+        t_filter: Frontier timestamp for the current estimate outputs
+        frame_transforms: Frame transforms derived from the AHRS state
+        state: State output payload for AhrsState publication
+        diagnostics: Diagnostics output payload for AhrsDiagnostics publication
+        gyro_update: Update report payload for gyro updates
+        accel_update: Update report payload for accel updates
+        mag_update: Update report payload for magnetometer updates
+    """
+
+    frontier_advanced: bool
+    t_filter: Optional[AhrsTime]
+    frame_transforms: Optional[AhrsFrameOutputs]
+    state: Optional[AhrsStateData]
+    diagnostics: Optional[AhrsDiagnosticsData]
+    gyro_update: Optional[AhrsUpdateData]
+    accel_update: Optional[AhrsUpdateData]
+    mag_update: Optional[AhrsUpdateData]

--- a/oasis_control/oasis_control/nodes/ahrs_node.py
+++ b/oasis_control/oasis_control/nodes/ahrs_node.py
@@ -1,0 +1,159 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+import message_filters
+import rclpy.node
+import rclpy.publisher
+import rclpy.qos
+import rclpy.subscription
+from nav_msgs.msg import Odometry as OdometryMsg
+from sensor_msgs.msg import Imu as ImuMsg
+from sensor_msgs.msg import MagneticField as MagneticFieldMsg
+from oasis_msgs.msg import ImuCalibration as ImuCalibrationMsg
+
+
+################################################################################
+# ROS parameters
+################################################################################
+
+
+NODE_NAME: str = "ahrs"
+
+# ROS topics
+IMU_RAW_TOPIC: str = "imu_raw"
+IMU_CAL_TOPIC: str = "imu_calibration"
+MAG_TOPIC: str = "magnetic_field"
+
+ACCEL_UPDATE_TOPIC: str = "ahrs/updates/accel"
+GYRO_UPDATE_TOPIC: str = "ahrs/updates/gyro"
+MAG_UPDATE_TOPIC: str = "ahrs/updates/mag"
+
+EXTRINSICS_T_BI_TOPIC: str = "ahrs/extrinsics/t_bi"
+EXTRINSICS_T_BM_TOPIC: str = "ahrs/extrinsics/t_bm"
+
+# ROS parameters and defaults
+PARAM_WORLD_FRAME_ID: str = "world_frame_id"
+PARAM_ODOM_FRAME_ID: str = "odom_frame_id"
+PARAM_BODY_FRAME_ID: str = "body_frame_id"
+
+DEFAULT_WORLD_FRAME_ID: str = "world"
+DEFAULT_ODOM_FRAME_ID: str = "odom"
+DEFAULT_BODY_FRAME_ID: str = "base_link"
+
+# TODO: AHRS parameters and defaults
+PARAM_GRAVITY_MPS2: str = "gravity_mps2"
+
+DEFAULT_GRAVITY_MPS2: float = 9.80665
+
+
+################################################################################
+# Utilities
+################################################################################
+
+
+# Nanoseconds per second for converting ROS params to AHRS nanoseconds
+NS_PER_S: int = 1_000_000_000
+
+
+# Convert seconds to nanoseconds
+def _ns_from_seconds(seconds: float) -> int:
+    return int(round(seconds * NS_PER_S))
+
+
+################################################################################
+# ROS node
+################################################################################
+
+
+class AhrsNode(rclpy.node.Node):
+    def __init__(self) -> None:
+        """
+        Initialize resources
+        """
+
+        super().__init__(NODE_NAME)
+
+        # Declare parameters
+        self.declare_parameter(PARAM_WORLD_FRAME_ID, DEFAULT_WORLD_FRAME_ID)
+        self.declare_parameter(PARAM_ODOM_FRAME_ID, DEFAULT_ODOM_FRAME_ID)
+        self.declare_parameter(PARAM_BODY_FRAME_ID, DEFAULT_BODY_FRAME_ID)
+
+        # TODO: AHRS parameters
+        self.declare_parameter(PARAM_GRAVITY_MPS2, DEFAULT_GRAVITY_MPS2)
+
+        # Load parameters
+        self._world_frame_id: str = str(self.get_parameter(PARAM_WORLD_FRAME_ID).value)
+        self._odom_frame_id: str = str(self.get_parameter(PARAM_ODOM_FRAME_ID).value)
+        self._body_frame_id: str = str(self.get_parameter(PARAM_BODY_FRAME_ID).value)
+
+        # TODO: AHRS parameters
+        self._gravity_mps2: float = float(self.get_parameter(PARAM_GRAVITY_MPS2).value)
+
+        # QoS profile
+        qos_profile: rclpy.qos.QoSProfile = (
+            rclpy.qos.QoSPresetProfiles.SENSOR_DATA.value
+        )
+
+        # ROS Publishers
+        # TODO
+
+        # ROS Subscribers
+        self._mag_sub: rclpy.subscription.Subscription = self.create_subscription(
+            msg_type=MagneticFieldMsg,
+            topic=MAG_TOPIC,
+            callback=self._handle_mag,
+            qos_profile=qos_profile,
+        )
+        self._imu_raw_filter_sub: message_filters.Subscriber = (
+            message_filters.Subscriber(
+                self,
+                ImuMsg,
+                IMU_RAW_TOPIC,
+                qos_profile=qos_profile,
+            )
+        )
+        self._imu_cal_filter_sub: message_filters.Subscriber = (
+            message_filters.Subscriber(
+                self,
+                ImuCalibrationMsg,
+                IMU_CAL_TOPIC,
+                qos_profile=qos_profile,
+            )
+        )
+
+        # ROS message synchronizers
+        self._imu_sync: message_filters.TimeSynchronizer = (
+            message_filters.TimeSynchronizer(
+                [self._imu_raw_filter_sub, self._imu_cal_filter_sub],
+                queue_size=20,
+            )
+        )
+        self._imu_sync.registerCallback(self._handle_imu_raw_with_calibration)
+
+        # TODO: AHRS parameters
+
+        # TODO: State
+
+        self.get_logger().info("AHRS node initialized")
+
+    def stop(self) -> None:
+        self.get_logger().info("AHRS node deinitialized")
+
+        self.destroy_node()
+
+    def _handle_imu_raw_with_calibration(
+        self, imu_msg: ImuMsg, cal_msg: ImuCalibrationMsg
+    ) -> None:
+        # TODO
+        pass
+
+    def _handle_mag(self, message: MagneticFieldMsg) -> None:
+        # TODO
+        pass

--- a/oasis_control/oasis_control/nodes/ahrs_node.py
+++ b/oasis_control/oasis_control/nodes/ahrs_node.py
@@ -16,14 +16,14 @@ import rclpy.subscription
 from sensor_msgs.msg import Imu as ImuMsg
 from sensor_msgs.msg import MagneticField as MagneticFieldMsg
 
-from oasis_control.localization.ahrs.ahrs_clock import RosAhrsClock
-from oasis_control.localization.ahrs.ahrs_conversions import ahrs_time_from_ros
-from oasis_control.localization.ahrs.ahrs_conversions import cov3x3_from_ros
-from oasis_control.localization.ahrs.ahrs_conversions import vector3_from_ros
 from oasis_control.localization.ahrs.ahrs_filter import AhrsFilter
 from oasis_control.localization.ahrs.ahrs_params import declare_ahrs_params
 from oasis_control.localization.ahrs.ahrs_params import load_ahrs_config
 from oasis_control.localization.ahrs.ahrs_publishers import AhrsPublishers
+from oasis_control.localization.ahrs.ahrs_ros_clock import RosAhrsClock
+from oasis_control.localization.ahrs.ahrs_ros_conversions import ahrs_time_from_ros
+from oasis_control.localization.ahrs.ahrs_ros_conversions import cov3x3_from_ros
+from oasis_control.localization.ahrs.ahrs_ros_conversions import vector3_from_ros
 from oasis_control.localization.ahrs.ahrs_types import AhrsEvent
 from oasis_control.localization.ahrs.ahrs_types import AhrsEventType
 from oasis_control.localization.ahrs.ahrs_types import AhrsImuPacket

--- a/oasis_control/oasis_control/nodes/ahrs_node.py
+++ b/oasis_control/oasis_control/nodes/ahrs_node.py
@@ -13,9 +13,23 @@ import rclpy.node
 import rclpy.publisher
 import rclpy.qos
 import rclpy.subscription
-from nav_msgs.msg import Odometry as OdometryMsg
 from sensor_msgs.msg import Imu as ImuMsg
 from sensor_msgs.msg import MagneticField as MagneticFieldMsg
+
+from oasis_control.localization.ahrs.ahrs_clock import RosAhrsClock
+from oasis_control.localization.ahrs.ahrs_conversions import ahrs_time_from_ros
+from oasis_control.localization.ahrs.ahrs_conversions import cov3x3_from_ros
+from oasis_control.localization.ahrs.ahrs_conversions import vector3_from_ros
+from oasis_control.localization.ahrs.ahrs_filter import AhrsFilter
+from oasis_control.localization.ahrs.ahrs_params import declare_ahrs_params
+from oasis_control.localization.ahrs.ahrs_params import load_ahrs_config
+from oasis_control.localization.ahrs.ahrs_publishers import AhrsPublishers
+from oasis_control.localization.ahrs.ahrs_types import AhrsEvent
+from oasis_control.localization.ahrs.ahrs_types import AhrsEventType
+from oasis_control.localization.ahrs.ahrs_types import AhrsImuPacket
+from oasis_control.localization.ahrs.ahrs_types import ImuCalibrationData
+from oasis_control.localization.ahrs.ahrs_types import ImuSample
+from oasis_control.localization.ahrs.ahrs_types import MagSample
 from oasis_msgs.msg import ImuCalibration as ImuCalibrationMsg
 
 
@@ -38,34 +52,6 @@ MAG_UPDATE_TOPIC: str = "ahrs/updates/mag"
 EXTRINSICS_T_BI_TOPIC: str = "ahrs/extrinsics/t_bi"
 EXTRINSICS_T_BM_TOPIC: str = "ahrs/extrinsics/t_bm"
 
-# ROS parameters and defaults
-PARAM_WORLD_FRAME_ID: str = "world_frame_id"
-PARAM_ODOM_FRAME_ID: str = "odom_frame_id"
-PARAM_BODY_FRAME_ID: str = "body_frame_id"
-
-DEFAULT_WORLD_FRAME_ID: str = "world"
-DEFAULT_ODOM_FRAME_ID: str = "odom"
-DEFAULT_BODY_FRAME_ID: str = "base_link"
-
-# TODO: AHRS parameters and defaults
-PARAM_GRAVITY_MPS2: str = "gravity_mps2"
-
-DEFAULT_GRAVITY_MPS2: float = 9.80665
-
-
-################################################################################
-# Utilities
-################################################################################
-
-
-# Nanoseconds per second for converting ROS params to AHRS nanoseconds
-NS_PER_S: int = 1_000_000_000
-
-
-# Convert seconds to nanoseconds
-def _ns_from_seconds(seconds: float) -> int:
-    return int(round(seconds * NS_PER_S))
-
 
 ################################################################################
 # ROS node
@@ -81,20 +67,8 @@ class AhrsNode(rclpy.node.Node):
         super().__init__(NODE_NAME)
 
         # Declare parameters
-        self.declare_parameter(PARAM_WORLD_FRAME_ID, DEFAULT_WORLD_FRAME_ID)
-        self.declare_parameter(PARAM_ODOM_FRAME_ID, DEFAULT_ODOM_FRAME_ID)
-        self.declare_parameter(PARAM_BODY_FRAME_ID, DEFAULT_BODY_FRAME_ID)
-
-        # TODO: AHRS parameters
-        self.declare_parameter(PARAM_GRAVITY_MPS2, DEFAULT_GRAVITY_MPS2)
-
-        # Load parameters
-        self._world_frame_id: str = str(self.get_parameter(PARAM_WORLD_FRAME_ID).value)
-        self._odom_frame_id: str = str(self.get_parameter(PARAM_ODOM_FRAME_ID).value)
-        self._body_frame_id: str = str(self.get_parameter(PARAM_BODY_FRAME_ID).value)
-
-        # TODO: AHRS parameters
-        self._gravity_mps2: float = float(self.get_parameter(PARAM_GRAVITY_MPS2).value)
+        declare_ahrs_params(self)
+        config = load_ahrs_config(self)
 
         # QoS profile
         qos_profile: rclpy.qos.QoSProfile = (
@@ -102,7 +76,10 @@ class AhrsNode(rclpy.node.Node):
         )
 
         # ROS Publishers
-        # TODO
+        self._publishers: AhrsPublishers = AhrsPublishers(self, config, qos_profile)
+
+        # AHRS filter
+        self._filter: AhrsFilter = AhrsFilter(config=config, clock=RosAhrsClock(self))
 
         # ROS Subscribers
         self._mag_sub: rclpy.subscription.Subscription = self.create_subscription(
@@ -137,10 +114,6 @@ class AhrsNode(rclpy.node.Node):
         )
         self._imu_sync.registerCallback(self._handle_imu_raw_with_calibration)
 
-        # TODO: AHRS parameters
-
-        # TODO: State
-
         self.get_logger().info("AHRS node initialized")
 
     def stop(self) -> None:
@@ -151,9 +124,78 @@ class AhrsNode(rclpy.node.Node):
     def _handle_imu_raw_with_calibration(
         self, imu_msg: ImuMsg, cal_msg: ImuCalibrationMsg
     ) -> None:
-        # TODO
-        pass
+        if (
+            imu_msg.header.stamp.sec != cal_msg.header.stamp.sec
+            or imu_msg.header.stamp.nanosec != cal_msg.header.stamp.nanosec
+        ):
+            self.get_logger().warning(
+                "IMU sample and calibration have mismatched timestamps"
+            )
+            return
+
+        try:
+            imu_sample: ImuSample = ImuSample(
+                frame_id=imu_msg.header.frame_id,
+                angular_velocity_rps=vector3_from_ros(imu_msg.angular_velocity),
+                linear_acceleration_mps2=vector3_from_ros(imu_msg.linear_acceleration),
+                angular_velocity_cov=cov3x3_from_ros(
+                    imu_msg.angular_velocity_covariance
+                ),
+                linear_acceleration_cov=cov3x3_from_ros(
+                    imu_msg.linear_acceleration_covariance
+                ),
+            )
+            calibration: ImuCalibrationData = ImuCalibrationData(
+                valid=bool(cal_msg.valid),
+                frame_id=cal_msg.header.frame_id,
+                accel_bias_mps2=vector3_from_ros(cal_msg.accel_bias),
+                accel_a=[float(value) for value in cal_msg.accel_a],
+                accel_param_cov=[float(value) for value in cal_msg.accel_param_cov],
+                gyro_bias_rps=vector3_from_ros(cal_msg.gyro_bias),
+                gyro_bias_cov=cov3x3_from_ros(cal_msg.gyro_bias_cov),
+                gravity_mps2=float(cal_msg.gravity_mps2),
+                fit_sample_count=int(cal_msg.fit_sample_count),
+                rms_residual_mps2=float(cal_msg.rms_residual_mps2),
+                temperature_c=float(cal_msg.temperature_c),
+                temperature_var_c2=float(cal_msg.temperature_var_c2),
+            )
+        except ValueError as exc:
+            self.get_logger().warning(f"Invalid IMU covariance data: {exc}")
+            return
+
+        packet: AhrsImuPacket = AhrsImuPacket(
+            imu=imu_sample,
+            calibration=calibration,
+        )
+        event: AhrsEvent = AhrsEvent(
+            t_meas=ahrs_time_from_ros(imu_msg.header.stamp),
+            topic=IMU_RAW_TOPIC,
+            frame_id=imu_msg.header.frame_id,
+            event_type=AhrsEventType.IMU,
+            payload=packet,
+        )
+
+        outputs = self._filter.handle_event(event)
+        self._publishers.publish_outputs(outputs)
 
     def _handle_mag(self, message: MagneticFieldMsg) -> None:
-        # TODO
-        pass
+        try:
+            sample: MagSample = MagSample(
+                frame_id=message.header.frame_id,
+                magnetic_field_t=vector3_from_ros(message.magnetic_field),
+                magnetic_field_cov=cov3x3_from_ros(message.magnetic_field_covariance),
+            )
+        except ValueError as exc:
+            self.get_logger().warning(f"Invalid magnetometer covariance data: {exc}")
+            return
+
+        event: AhrsEvent = AhrsEvent(
+            t_meas=ahrs_time_from_ros(message.header.stamp),
+            topic=MAG_TOPIC,
+            frame_id=message.header.frame_id,
+            event_type=AhrsEventType.MAG,
+            payload=sample,
+        )
+
+        outputs = self._filter.handle_event(event)
+        self._publishers.publish_outputs(outputs)

--- a/oasis_control/setup.py
+++ b/oasis_control/setup.py
@@ -74,6 +74,7 @@ setuptools.setup(
             "engine_manager = oasis_control.cli.engine_manager_cli:main",
             "engineer_manager = oasis_control.cli.engineer_manager_cli:main",
             "home_manager = oasis_control.cli.home_manager_cli:main",
+            "ahrs = oasis_control.cli.ahrs_cli:main",
             "imu_fuser = oasis_control.cli.imu_fuser_cli:main",
             "lab_manager_firmata = oasis_control.cli.lab_manager_firmata_cli:main",
             "lab_manager_telemetrix = oasis_control.cli.lab_manager_telemetrix_cli:main",

--- a/oasis_control/test/test_ahrs_conversions.py
+++ b/oasis_control/test/test_ahrs_conversions.py
@@ -1,0 +1,45 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from builtin_interfaces.msg import Time as TimeMsg
+
+from oasis_control.localization.ahrs.ahrs_conversions import ahrs_time_from_ros
+from oasis_control.localization.ahrs.ahrs_conversions import cov3x3_from_ros
+from oasis_control.localization.ahrs.ahrs_conversions import ros_time_from_ahrs
+from oasis_control.localization.ahrs.ahrs_types import AhrsTime
+
+
+def test_cov3x3_from_ros_rejects_length() -> None:
+    with pytest.raises(ValueError):
+        cov3x3_from_ros([0.0] * 8)
+
+
+def test_cov3x3_from_ros_rejects_nan() -> None:
+    cov: list[float] = [0.0] * 8 + [math.nan]
+
+    with pytest.raises(ValueError):
+        cov3x3_from_ros(cov)
+
+
+def test_ahrs_time_round_trip() -> None:
+    stamp: TimeMsg = TimeMsg()
+    stamp.sec = 123
+    stamp.nanosec = 456_789_123
+
+    ahrs_time: AhrsTime = ahrs_time_from_ros(stamp)
+    round_trip: TimeMsg = ros_time_from_ahrs(ahrs_time)
+
+    assert round_trip.sec == stamp.sec
+    assert round_trip.nanosec == stamp.nanosec

--- a/oasis_control/test/test_ahrs_filter_stub.py
+++ b/oasis_control/test/test_ahrs_filter_stub.py
@@ -10,8 +10,6 @@
 
 from __future__ import annotations
 
-from builtin_interfaces.msg import Time as TimeMsg
-
 from oasis_control.localization.ahrs.ahrs_clock import AhrsClock
 from oasis_control.localization.ahrs.ahrs_config import AhrsConfig
 from oasis_control.localization.ahrs.ahrs_filter import AhrsFilter
@@ -26,12 +24,8 @@ class FixedClock(AhrsClock):
         self._now_sec: int = now_sec
         self._now_nanosec: int = now_nanosec
 
-    def now_ros_time(self) -> TimeMsg:
-        stamp: TimeMsg = TimeMsg()
-        stamp.sec = self._now_sec
-        stamp.nanosec = self._now_nanosec
-
-        return stamp
+    def now(self) -> AhrsTime:
+        return AhrsTime(sec=self._now_sec, nanosec=self._now_nanosec)
 
 
 def _config() -> AhrsConfig:

--- a/oasis_control/test/test_ahrs_filter_stub.py
+++ b/oasis_control/test/test_ahrs_filter_stub.py
@@ -1,0 +1,107 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+from __future__ import annotations
+
+from builtin_interfaces.msg import Time as TimeMsg
+
+from oasis_control.localization.ahrs.ahrs_clock import AhrsClock
+from oasis_control.localization.ahrs.ahrs_config import AhrsConfig
+from oasis_control.localization.ahrs.ahrs_filter import AhrsFilter
+from oasis_control.localization.ahrs.ahrs_types import AhrsEvent
+from oasis_control.localization.ahrs.ahrs_types import AhrsEventType
+from oasis_control.localization.ahrs.ahrs_types import AhrsTime
+from oasis_control.localization.ahrs.ahrs_types import MagSample
+
+
+class FixedClock(AhrsClock):
+    def __init__(self, now_sec: int, now_nanosec: int) -> None:
+        self._now_sec: int = now_sec
+        self._now_nanosec: int = now_nanosec
+
+    def now_ros_time(self) -> TimeMsg:
+        stamp: TimeMsg = TimeMsg()
+        stamp.sec = self._now_sec
+        stamp.nanosec = self._now_nanosec
+
+        return stamp
+
+
+def _config() -> AhrsConfig:
+    return AhrsConfig(
+        world_frame_id="world",
+        odom_frame_id="odom",
+        body_frame_id="base_link",
+        t_buffer_sec=0.5,
+        epsilon_wall_future_sec=1.0,
+        dt_clock_jump_max_sec=0.0,
+        dt_imu_max_sec=0.0,
+        mag_alpha=1.0,
+        mag_r_min=[0.0] * 9,
+        mag_r_max=[0.0] * 9,
+        mag_r0=[0.0] * 9,
+        q_v=0.0,
+        q_w=0.0,
+        q_bg=0.0,
+        q_ba=0.0,
+        q_a=0.0,
+        q_bi=0.0,
+        q_bm=0.0,
+        q_g=0.0,
+        q_m=0.0,
+    )
+
+
+def _event_at(sec: int, nanosec: int) -> AhrsEvent:
+    sample: MagSample = MagSample(
+        frame_id="mag",
+        magnetic_field_t=[0.0, 0.0, 0.0],
+        magnetic_field_cov=[0.0] * 9,
+    )
+
+    return AhrsEvent(
+        t_meas=AhrsTime(sec=sec, nanosec=nanosec),
+        topic="magnetic_field",
+        frame_id="mag",
+        event_type=AhrsEventType.MAG,
+        payload=sample,
+    )
+
+
+def test_filter_frontier_advances() -> None:
+    clock: FixedClock = FixedClock(now_sec=10, now_nanosec=0)
+    filt: AhrsFilter = AhrsFilter(config=_config(), clock=clock)
+
+    first = filt.handle_event(_event_at(1, 0))
+    second = filt.handle_event(_event_at(2, 0))
+
+    assert first.frontier_advanced is True
+    assert second.frontier_advanced is True
+    assert first.state is not None
+    assert second.state is not None
+    assert first.state.state_seq == 1
+    assert second.state.state_seq == 2
+
+
+def test_filter_out_of_order_does_not_advance() -> None:
+    clock: FixedClock = FixedClock(now_sec=10, now_nanosec=0)
+    filt: AhrsFilter = AhrsFilter(config=_config(), clock=clock)
+
+    first = filt.handle_event(_event_at(2, 0))
+    out_of_order = filt.handle_event(_event_at(1, 0))
+    third = filt.handle_event(_event_at(3, 0))
+
+    assert first.frontier_advanced is True
+    assert out_of_order.frontier_advanced is False
+    assert out_of_order.state is None
+    assert third.state is not None
+    assert third.state.state_seq == 2
+    assert third.diagnostics is not None
+    assert third.diagnostics.diag_seq == 2

--- a/oasis_msgs/CMakeLists.txt
+++ b/oasis_msgs/CMakeLists.txt
@@ -31,6 +31,8 @@ ament_export_dependencies(rosidl_default_runtime)
 rosidl_generate_interfaces(
   ${PROJECT_NAME}
     msg/Accelerometer.msg
+    msg/AhrsDiagnostics.msg
+    msg/AhrsState.msg
     msg/AirQuality.msg
     msg/AnalogButton.msg
     msg/AnalogReading.msg

--- a/oasis_msgs/msg/AhrsDiagnostics.msg
+++ b/oasis_msgs/msg/AhrsDiagnostics.msg
@@ -1,0 +1,55 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+#
+# Health / replay / drop diagnostics for the AHRS node.
+#
+# Conventions
+# - header.stamp = t_filter (frontier)
+# - header.frame_id = world frame_id
+#
+
+# Frontier timestamp and world frame_id
+std_msgs/Header header
+
+# Monotonic diagnostic sequence index
+uint64 diag_seq
+
+# The filter's current frontier timestamp in seconds (for convenience)
+float64 t_filter_sec
+
+#
+# Buffer / replay stats
+#
+
+# Number of time nodes currently retained
+uint32 buffer_node_count
+
+# Approximate time span covered by the buffer (s)
+float32 buffer_span_sec
+
+# True if an out-of-order message triggered replay on the most recent callback
+bool replay_happened
+
+#
+# Drop counters (monotonic since node start)
+#
+
+uint64 dropped_missing_stamp
+uint64 dropped_future_stamp
+uint64 dropped_too_old
+uint64 dropped_nan_cov
+uint64 dropped_imu_coverage_gap
+uint64 dropped_clock_jump_reset
+
+#
+# Most recent reset reason (empty if no reset yet)
+#
+string last_reset_reason

--- a/oasis_msgs/msg/AhrsState.msg
+++ b/oasis_msgs/msg/AhrsState.msg
@@ -1,0 +1,124 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+#
+# Full AHRS filter state snapshot at the current frontier time t_filter.
+#
+# This message exists so consumers can inspect ALL in-state parameters and
+# their FULL (non-diagonalized) covariance in a single place.
+#
+# Conventions
+# - header.stamp = t_filter (frontier)
+# - header.frame_id = world frame ("world") for all world-expressed vectors
+#
+# Frames
+# - {W}: world
+# - {B}: base_link (body)
+# - {I}: IMU frame
+# - {M}: magnetometer frame
+#
+
+# Frontier timestamp and world frame_id
+std_msgs/Header header
+
+#
+# Frame ids in use by the node (published contract)
+#
+string world_frame_id
+string odom_frame_id
+string body_frame_id
+
+#
+# Monotonic sequence index for state publications
+#
+uint64 state_seq
+
+#
+# True when the filter has consumed its initial priors and is running
+#
+bool initialized
+
+#
+# Navigation state
+#
+
+# Position of B expressed in W (m)
+geometry_msgs/Point position_wb_m
+
+# Velocity of B expressed in W (m/s)
+geometry_msgs/Vector3 velocity_wb_mps
+
+# Attitude (world -> body), unit quaternion
+geometry_msgs/Quaternion orientation_wb
+
+#
+# IMU systematic parameters (in-state)
+#
+
+# Gyroscope bias b_g (rad/s), expressed in IMU frame {I} unless otherwise specified by the node
+geometry_msgs/Vector3 gyro_bias
+
+# Accelerometer bias b_a (m/s^2), expressed in IMU frame {I} unless otherwise specified by the node
+geometry_msgs/Vector3 accel_bias
+
+# Accelerometer scale/misalignment matrix A_a
+# Units: unitless
+# Layout: 3x3 row-major
+float64[9] accel_a
+
+#
+# Extrinsics (sensor -> body)
+#
+
+# IMU -> body transform T_BI
+geometry_msgs/Pose t_bi
+
+# Magnetometer -> body transform T_BM
+geometry_msgs/Pose t_bm
+
+#
+# Environment / reference vectors (in-state)
+#
+
+# Gravity vector expressed in world (m/s^2)
+geometry_msgs/Vector3 gravity_w_mps2
+
+# Earth magnetic field vector expressed in world (tesla)
+geometry_msgs/Vector3 magnetic_field_w_t
+
+#
+# FULL covariance over the AHRS internal error-state.
+#
+# This is the single source of truth for "not diagonalized" covariance reporting.
+#
+# Matrix is row-major with dimensions error_dim x error_dim.
+#
+# IMPORTANT: error_state_names defines the exact ordering of this covariance.
+#
+
+# Error-state dimension (must match p.rows == p.cols == error_dim)
+uint32 error_dim
+
+# Names of each scalar error-state element, length = error_dim.
+# Example entries:
+# - "dp.x", "dp.y", "dp.z"
+# - "dv.x", "dv.y", "dv.z"
+# - "dtheta.x", "dtheta.y", "dtheta.z"
+# - "dbg.x", ...
+# - "dba.x", ...
+# - "dAa.0", ..., "dAa.8"
+# - "dT_BI.rho.x", ..., "dT_BI.theta.z"
+# - "dT_BM.rho.x", ..., "dT_BM.theta.z"
+# - "dg.x", ...
+# - "dm.x", ...
+string[] error_state_names
+
+# Full error-state covariance P
+oasis_msgs/Matrix p


### PR DESCRIPTION
### Motivation

- Enable AHRS unit tests to run in plain Python without a ROS install by removing ROS imports from core modules. 
- Isolate ROS-specific conversions and clock behavior into ROS-only modules so runtime ROS integration remains supported. 

### Description

- Introduced ROS-free core helpers in `ahrs_conversions.py`: `ahrs_time_from_pair`, `normalize_ahrs_time`, `cov3x3_from_seq`, `vector3_from_xyz`, and `seconds_from_ahrs`. 
- Added ROS-only adapters in `ahrs_ros_conversions.py` that import ROS message types and delegate to the core helpers (providing `ahrs_time_from_ros`, `ros_time_from_ahrs`, `vector3_from_ros`, `cov3x3_from_ros`). 
- Made the clock interface ROS-agnostic by changing `AhrsClock.now()` to return `AhrsTime` and moved the ROS-backed implementation into `ahrs_ros_clock.py` as `RosAhrsClock`. 
- Updated ROS-only modules (`ahrs_ros_msgs.py`, node `nodes/ahrs_node.py`) to use the new ROS-only conversion/clock modules. 
- Updated unit tests (`test_ahrs_conversions.py`, `test_ahrs_filter_stub.py`) to be ROS-free by using core helpers and a `FixedClock` returning `AhrsTime`. 
- Ran code-style fixes (Black/isort) as part of the change to satisfy lint checks.

### Testing

- Ran `tox` which executes formatting checks, linters, `mypy`, and `pytest`, and the run completed successfully. 
- `pytest` (via `tox`) collected and ran the AHRS tests: all tests passed (`45 passed`). 
- `mypy`, `black` and `isort` checks that are part of the `tox` workflow also passed during the run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696c9e07c65c832ebd40b2d84e3b4d4a)