### PR TITLE
Add shared AHRS quaternion helpers and validation

### DIFF
--- a/docs/AHRS.md
+++ b/docs/AHRS.md
@@ -1,0 +1,610 @@
+# AHRS Design Document
+
+This document defines the **state-space model** and **time-handling policy** for an AHRS that uses:
+
+- a continuous-time **process model**: kinematic evolution + slow parameter drift (priors), and
+- discrete-time **measurement models**:
+  - IMU gyro + accel measurements (`imu_raw`) and
+  - magnetometer measurements (`magnetic_field`),
+
+all applied on a common time axis with deterministic fixed-lag replay.
+
+---
+
+## World / Odom frame contract
+
+The AHRS publishes the standard TF chain:
+
+`world -> odom -> base_link`
+
+Policy (no teleports, no global correction):
+
+- `world` is initialized at startup to the origin (continuous).
+- `odom` is continuous and **drifts locally**.
+- There are no discontinuities because no global constraints exist.
+
+Recommended implementation contract:
+
+- Publish `TF: world -> odom` as identity for the entire session:
+  - `T_WO := I`
+- Publish `TF: odom -> base_link` as the AHRS estimate:
+  - `T_OB := T_WB` (since `world == odom` under the identity `T_WO`)
+
+This keeps the TF tree compatible with a future localization EKF that may later produce non-identity `T_WO`.
+
+---
+
+## 1. ROS Inputs
+
+### 1.1 Streams
+
+- Single `message_filters` combination (ExactTime) producing an **IMU packet**:
+  - `imu_raw` (`sensor_msgs/Imu`): inertial sample stream (time-stamped)
+  - `imu_calibration` (`oasis_msgs/ImuCalibration`): calibration priors + uncertainty
+    - **Semantic rule:** used **only once** to initialize in-state calibration parameters (initial prior).
+    - After initialization, `imu_calibration` contents are ignored (except diagnostics / consistency checks).
+- `magnetic_field` (`sensor_msgs/MagneticField`): magnetometer samples (time-stamped)
+
+---
+
+### 1.2 `imu_raw` — `sensor_msgs/Imu`
+
+Used fields:
+
+- `header.stamp` (`t_meas`)
+- `header.frame_id` → IMU frame `{I}`
+- `angular_velocity` `ω_raw` and **full** `angular_velocity_covariance` `Σ_ω_raw` (3×3)
+- `linear_acceleration` `a_raw` and **full** `linear_acceleration_covariance` `Σ_a_raw` (3×3)
+
+Ignored:
+
+- `orientation`, `orientation_covariance`
+
+Requirements:
+
+- Covariances are interpreted as **per-sample measurement noise**.
+- `ω_raw`, `a_raw` are expressed in `{I}`.
+- Do not diagonalize any provided covariance.
+
+---
+
+### 1.3 `imu_calibration` — `oasis_msgs/ImuCalibration`
+
+Role: **one-shot initialization prior** for systematic parameters that live in the shared state.
+
+Validity:
+
+- If `valid == false`, ignore.
+
+Frame:
+
+- `header.frame_id` must match `imu_raw.header.frame_id` (calibration is defined in `{I}`).
+
+Models (parameter meaning):
+
+- Accel: `a_corr = A_a (a_raw − b_a)` where `b_a, A_a` are **in-state**
+- Gyro: `ω_corr = ω_raw − b_g` where `b_g` is **in-state**
+
+Requirements:
+
+- Consume **only while uninitialized**:
+  - The **first** valid calibration observed is applied as an initial prior on `(b_a, A_a, b_g)` with its covariance.
+  - After initialization, ignore subsequent calibration messages (except diagnostics).
+- Calibration uncertainty is **systematic parameter uncertainty**, not per-sample noise.
+- Always use full covariance matrices when provided (do not diagonalize).
+
+---
+
+### 1.4 `magnetic_field` — `sensor_msgs/MagneticField`
+
+Used fields:
+
+- `header.stamp` (`t_meas`)
+- `header.frame_id` → mag frame `{M}`
+- `magnetic_field` `m_raw`
+- **full** `magnetic_field_covariance` `Σ_m_raw` (3×3)
+
+Measurement convention:
+
+- Form magnetometer residual in `{M}` (do not rotate the raw measurement into `{B}`):
+  - `z := m_raw` in `{M}`
+  - `z_hat := m̂_M` in `{M}`
+  - `ν := z - z_hat` in `{M}`
+
+Noise interpretation:
+
+- `Σ_m_raw` is the driver’s estimate of measurement noise covariance and is used as a prior / input to the
+  internally maintained `R_m(t)` (but not treated as per-sample truth).
+- Do not diagonalize any provided covariance.
+
+Adaptive noise policy (covariance matching):
+
+- Initialize `R_m0` from first valid `Σ_m_raw`, else default:
+  - `R_m0 = diag([4e-10, 4e-10, 4e-10])` (tesla²) (20 µT RMS per axis)
+- Maintain adaptive `R_m(t)` bounded SPD:
+  - `R_min = diag([1e-12, 1e-12, 1e-12])` (tesla²)
+  - `R_max = diag([2.5e-9, 2.5e-9, 2.5e-9])` (tesla²)
+- Update:
+  - Let innovation be `ν_k`, predicted innovation covariance excluding R be `Ŝ_k = HPHᵀ`
+  - `R_m ← clamp_SPD( (1-α) R_m + α (ν_k ν_kᵀ - Ŝ_k), R_min, R_max )`
+  - default `α = 0.01`
+
+---
+
+## 2. Frames and Extrinsics
+
+Frames:
+
+- `{W}`: world frame, ROS frame_id = `world`
+- `{O}`: odom frame, ROS frame_id = `odom`
+- `{B}`: body frame, ROS child_frame_id = `base_link`
+- `{I}`: IMU measurement frame (`imu_raw.header.frame_id`)
+- `{M}`: magnetometer frame (`magnetic_field.header.frame_id`)
+
+Estimated extrinsics (in-state):
+
+- `T_BI` (IMU → body)
+- `T_BM` (mag → body)
+
+Parameterization:
+
+- Poses in SE(3): quaternion rotation + 3-vector translation
+- Uncertainty: 6D tangent (δρ, δθ) for SE(3) quantities
+
+Initialization priors (broad but finite; full covariances allowed and recommended):
+
+- `T_BI` prior:
+  - mean: identity
+  - rotation stddev: `π` rad per axis (tangent)
+  - translation stddev: `1.0 m` per axis
+- `T_BM` prior:
+  - mean: identity
+  - rotation stddev: `π` rad per axis (tangent)
+  - translation stddev: `1.0 m` per axis
+
+---
+
+## 3. State, Process Model, and Measurement Models
+
+This AHRS is a **single optimizer** over a **shared state** with multiple models.
+
+### 3.1 State (full model)
+
+The AHRS maintains a full navigation + calibration + extrinsic state:
+
+Navigation (in `{W}` unless noted):
+
+- Position: `p_WB ∈ ℝ³`
+- Velocity: `v_WB ∈ ℝ³`
+- Attitude: `q_WB` (unit quaternion, world → body rotation)
+
+IMU systematic parameters:
+
+- Gyro bias: `b_g ∈ ℝ³`
+- Accel bias: `b_a ∈ ℝ³`
+- Accel scale/misalignment: `A_a ∈ ℝ^{3×3}` (full matrix)
+
+Extrinsics (sensor-to-body in SE(3)):
+
+- `T_BI ∈ SE(3)` (IMU → body)
+- `T_BM ∈ SE(3)` (mag → body)
+
+Environment / reference vectors (kept in-state, full covariance):
+
+- Gravity vector in world: `g_W ∈ ℝ³`
+- Earth magnetic field vector in world: `m_W ∈ ℝ³`
+
+Full covariance policy:
+
+- The AHRS maintains a single covariance `P` over its internal error-state.
+- Do not diagonalize:
+  - any incoming sensor covariance (`Σ_ω_raw`, `Σ_a_raw`, `Σ_m_raw`),
+  - any priors / initialization covariances,
+  - or internal state covariance blocks.
+
+---
+
+### 3.2 Error-state definition (for covariance)
+
+The AHRS uses an error-state EKF.
+
+Representative error coordinates:
+
+- `δp, δv ∈ ℝ³`
+- `δθ ∈ ℝ³` small-angle attitude error s.t. `q_WB ≈ Exp(δθ) ⊗ q̂_WB`
+- `δb_g, δb_a ∈ ℝ³`
+- `δA_a ∈ ℝ⁹` (row-major perturbation of `A_a`) or an equivalent minimal parameterization
+- `δξ_BI ∈ ℝ⁶`, `δξ_BM ∈ ℝ⁶` (SE(3) tangent: translation + rotation)
+- `δg_W, δm_W ∈ ℝ³`
+
+`P` is the covariance over the stacked error-state vector above (full matrix).
+
+---
+
+### 3.3 Continuous-time process model (kinematic prior + slow drift)
+
+The process model provides time evolution between measurements. Sensor data does **not** drive propagation in this option;
+IMU and mag are measurement updates.
+
+Define continuous-time dynamics:
+
+Navigation kinematics:
+
+- `ṗ_WB = v_WB`
+- `v̇_WB = g_W + w_v`
+- `q̇_WB = 1/2 * Ω(ω_WB) * q_WB`
+
+where:
+- `ω_WB` is the body angular rate (world → body) treated as **latent** (not directly measured in the process model),
+  modeled as:
+  - `ω_WB = w_ω`
+- `w_v`, `w_ω` are zero-mean white noises (continuous-time) representing smoothness priors.
+
+Systematic parameter drift (random walks):
+
+- `ḃ_g = w_bg`
+- `ḃ_a = w_ba`
+- `Ȧ_a = W_A` (element-wise random walk; `vec(Ȧ_a) = w_A`)
+- `Ṫ_BI = W_BI` (SE(3) random walk in tangent; `δξ̇_BI = w_BI`)
+- `Ṫ_BM = W_BM` (SE(3) random walk in tangent; `δξ̇_BM = w_BM`)
+
+Reference vector drift (slow):
+
+- `ġ_W = w_g`
+- `ṁ_W = w_m`
+
+Notes:
+
+- This process is intentionally **weak**: it encodes “motion is smooth” and “parameters drift slowly”.
+- The IMU measurements will strongly constrain the state at high rate.
+
+Process noise covariance:
+
+- Continuous-time noise intensities:
+  - `Q_c = cov([w_v, w_ω, w_bg, w_ba, w_A, w_BI, w_BM, w_g, w_m])`
+- `Q_c` may be block-diagonal by default, but the **state covariance P is full** and will develop cross-terms through
+  Jacobians and updates.
+- If you have known cross-correlations (e.g., coupled accel axes), you may encode them in `Q_c` (full blocks permitted).
+
+Discretization:
+
+- Over interval `Δt`, compute discrete `F_k` and `Q_k` using a standard EKF discretization
+  (e.g., first-order: `Q_k ≈ G Q_c Gᵀ Δt`, with `F_k ≈ I + AΔt`),
+  keeping full matrices.
+
+---
+
+### 3.4 IMU measurement model (discrete-time)
+
+At each `imu_raw` timestamp `t_k`, treat IMU outputs as measurements.
+
+#### 3.4.1 Frame handling for IMU
+
+- IMU raw signals are in `{I}`.
+- Use the estimated extrinsic `T_BI` to relate `{I}` and `{B}`:
+  - Let `R_BI` be the rotation from IMU to body from `T_BI`.
+  - Then body-to-IMU rotation is `R_IB = R_BIᵀ`.
+
+#### 3.4.2 Gyro measurement
+
+Measurement:
+
+- `z_ω := ω_raw` in `{I}` with covariance `R_ω := Σ_ω_raw` (full 3×3)
+
+Prediction:
+
+- Predict IMU-frame angular rate as:
+  - `ω̂_I = R_IB * ω_WB + b_g`
+
+Residual:
+
+- `ν_ω = z_ω - ω̂_I` (in `{I}`)
+
+#### 3.4.3 Accelerometer measurement
+
+Measurement:
+
+- `z_a := a_raw` in `{I}` with covariance `R_a := Σ_a_raw` (full 3×3)
+
+Specific-force prediction:
+
+- Compute world-frame acceleration of the body origin from kinematics:
+  - `a_WB := v̇_WB` (from process state; in the mean model, `v̇_WB ≈ g_W`, but this is refined by measurements)
+- Specific force in body frame is:
+  - `f_B = R_BW * (a_WB - g_W)` where `R_BW` is world → body rotation from `q_WB`
+- Convert to IMU frame:
+  - `f_I = R_IB * f_B`
+
+Apply accel systematic model (as defined by calibration semantics):
+
+- The measurement model uses:
+  - `a_corr = A_a (a_raw − b_a)`
+- Equivalently, the predicted raw measurement is:
+  - `â_raw = A_a^{-1} * f_I + b_a`
+
+Prediction:
+
+- `â_I = A_a^{-1} * f_I + b_a`
+
+Residual:
+
+- `ν_a = z_a - â_I` (in `{I}`)
+
+Notes:
+
+- The above uses a full 3×3 `A_a`. If `A_a` is near-singular, the state/prior must prevent it (bounded parameterization
+  recommended). The covariance remains full regardless of parameterization.
+- `R_a` is always taken as the provided full covariance (or a configured fallback if invalid).
+
+---
+
+### 3.5 Magnetometer measurement model (discrete-time)
+
+At each `magnetic_field` timestamp `t_k`:
+
+- Measurement: `z_m := m_raw` in `{M}`
+- Covariance input: `Σ_m_raw` (full 3×3), used to initialize / inform the adaptive `R_m(t)`.
+
+Prediction (in `{M}`; residual always formed in `{M}`):
+
+- Let `R_BM` be the rotation of `T_BM` (mag → body), so body→mag is `R_MB = R_BMᵀ`.
+- Let `R_BW` be world → body rotation from `q_WB`.
+- Predict:
+  - `m̂_M = R_MB * R_BW * m_W`
+
+Residual:
+
+- `ν_m = z_m - m̂_M` in `{M}`
+
+Measurement noise used:
+
+- `R_m(t)` (adaptive, bounded SPD; full 3×3)
+
+---
+
+## 4. Time Axis, Buffer, and Deterministic Replay (Fixed-lag)
+
+This AHRS uses the same deterministic fixed-lag design as the EKF spec.
+
+### 4.1 Time definitions
+
+- `t_meas`: `header.stamp` from the incoming message (authoritative event time)
+- `t_now`: receipt time (diagnostics only)
+- `t_filter`: max `t_meas` among **accepted** messages (frontier)
+
+Event-driven: each accepted message attaches at `t_meas`. Out-of-order messages are supported via fixed-lag replay.
+
+### 4.2 Message roles
+
+- **Measurement updates (high-rate):** `imu_raw` (gyro + accel updates)
+- **Initialization prior (one-shot):** `imu_calibration`
+- **Measurement updates:** `magnetic_field`
+- **Process model:** runs continuously between time nodes as the kinematic prior and slow parameter drift.
+
+### 4.3 IMU packet synchronization contract
+
+The AHRS consumes IMU as a synchronized pair:
+
+- `imu_pkt = (imu_raw, imu_calibration)` produced by `message_filters` using **ExactTime**.
+
+Timestamp policy:
+
+- Packet time: `t_meas := imu_raw.header.stamp`
+- Require `imu_calibration.header.stamp == imu_raw.header.stamp`; reject packet if not.
+
+Semantic policy:
+
+- `imu_calibration` is used **only before initialization** to set priors on `(b_a, A_a, b_g)` with full covariance.
+- After initialization, `imu_calibration` is ignored (except diagnostics).
+- `imu_raw` always produces measurement updates (gyro + accel) when accepted.
+
+### 4.4 Buffer model
+
+Maintain a time-ordered ring buffer of time nodes over fixed lag `T_buffer_sec`.
+
+Each node at `t_k` stores:
+
+- state mean `x_k`, covariance `P_k`
+- messages attached at `t_k` (IMU packet, mag)
+- sufficient metadata to re-run deterministic replay
+
+Node rules:
+
+- One node per distinct timestamp.
+- Multiple messages may attach to the same node.
+- Evict nodes older than `t_filter - T_buffer_sec` (with diagnostics).
+
+### 4.5 Propagation convention
+
+Between time nodes, propagate with the continuous-time process model (Section 3.3), discretized over each interval.
+
+Strict coverage rule:
+
+- For deterministic replay, the AHRS must be able to propagate across any interval used in replay.
+- If there is a timestamp gap larger than `Δt_imu_max` between consecutive nodes required to cover replay,
+  reject replay across that gap and emit diagnostics.
+
+### 4.6 Insertion + replay (deterministic)
+
+On message arrival:
+
+1. Validate timestamp
+   - reject missing/invalid
+   - reject `t_meas > t_now + ε_wall_future`
+
+2. Fixed-lag window
+   - if `t_filter` exists and `t_meas < t_filter - T_buffer_sec`, reject as too old
+
+3. Attach
+   - insert/attach message to node `t_meas` (create node if needed)
+
+4. Update frontier / replay
+   - if `t_meas > t_filter`: advance `t_filter` and propagate forward
+   - else: apply update at `t_meas`, then replay forward to `t_filter`
+
+Per-node application order (stable):
+
+1. Apply any priors/parameter constraints at `t_k` (including one-shot calibration prior if first valid)
+2. Apply measurement updates at `t_k` in stable tie-break order:
+   - lexicographic `(message_type, topic, frame_id)`
+   - Within IMU: apply gyro update then accel update (fixed order)
+
+Replay must never depend on arrival order.
+
+### 4.7 Drop / reset rules
+
+Reject and emit diagnostics if:
+
+- missing timestamp
+- required covariance contains NaN/Inf
+- message outside fixed-lag window
+- propagation coverage insufficient (`Δt_imu_max` violated)
+- clock discontinuity detected: reset filter + buffer if `|t_meas - t_filter| > Δt_clock_jump_max`
+  - Reset effects (explicit):
+    - clear the time buffer and set `t_filter` to unset
+    - set `initialized = false`
+    - allow consumption of the next valid `imu_calibration` as a new initialization prior
+    - reset adaptive `R_m(t)` to `R_m0`
+
+---
+
+### 4.8 Output publish trigger (explicit)
+
+The AHRS publishes "current estimate" outputs **only when the frontier advances**.
+
+- Let `t_filter_prev` be the frontier before processing an incoming message.
+- After processing a message:
+  - If `t_meas > t_filter_prev` (frontier advance), the filter propagates to `t_meas`, applies updates at `t_meas`,
+    sets `t_filter := t_meas`, and **publishes**:
+      - TF (`world -> odom`, `odom -> base_link`) stamped `t_filter`
+      - odometry outputs stamped `t_filter`
+      - `oasis_msgs/AhrsState` stamped `t_filter`
+      - `oasis_msgs/AhrsDiagnostics` stamped `t_filter`
+  - If `t_meas <= t_filter_prev` (out-of-order insertion), the filter may replay internally to maintain consistency at
+    `t_filter`, but **does not republish** TF/odometry/state/diagnostics (to avoid emitting past timestamps).
+
+Per-measurement update reports (`oasis_msgs/EkfUpdateReport`) are published at the measurement timestamp `t_meas` for
+every accepted/rejected update, regardless of whether the frontier advanced.
+
+---
+
+## 5. Outputs (poses + covariances + measurement stats)
+
+The AHRS publishes:
+
+1. state estimates in ROS-standard frames (`world`, `odom`, `base_link`)
+2. full covariances for those estimates (not diagonalized)
+3. per-measurement innovation / gating statistics (so “all measurements” have covariances too)
+
+### 5.1 TF
+
+- Broadcast `TF: odom -> base_link` from `T_OB` (`stamp = t_filter`)
+- Broadcast `TF: world -> odom` as identity (`stamp = t_filter`)
+
+TF is published on `/tf` (standard tf2 broadcaster).
+
+### 5.2 Odometry messages
+
+**(A) `nav_msgs/Odometry` in `odom`**
+
+- Topic: `ahrs/odom`
+- `header.stamp = t_filter`
+- `header.frame_id = "odom"`
+- `child_frame_id = "base_link"`
+- Pose: `T_OB` (translation from `p_WB`, rotation from `q_WB`)
+- Twist: derived from state (e.g., linear from `v_WB`, angular from `ω_WB` estimate as implied by IMU updates)
+- Covariance: derived from `P` (full covariance propagation, mapped into ROS odom convention)
+
+**(B) `nav_msgs/Odometry` in `world`**
+
+- Topic: `ahrs/world_odom`
+- Same values as (A) under `T_WO = I` contract; covariances derived from the same `P`.
+
+### 5.3 Extrinsic outputs
+
+- `geometry_msgs/PoseWithCovarianceStamped`:
+  - Topic: `ahrs/extrinsics/t_bi` for `T_BI`
+  - Topic: `ahrs/extrinsics/t_bm` for `T_BM`
+  - `header.stamp = t_filter`
+  - `header.frame_id = "base_link"`
+  - Covariance derived from `P` (full 6×6, not diagonalized)
+  - Publish: **on frontier advance** (Section 4.8)
+
+### 5.4 Covariance transformation rules
+
+The AHRS maintains a single covariance `P` over its internal error-state. Published covariances are obtained by:
+
+`Σ_y = J * P * Jᵀ`, with `J = ∂g/∂x` evaluated at `x̂`.
+
+For SE(3) pose errors in tangent (δρ, δθ), use the adjoint:
+
+`Σ_A = Ad_{T_AB} * Σ_B * Ad_{T_AB}ᵀ`
+
+All covariance matrices are full and must remain symmetric positive definite (or PSD as appropriate).
+
+### 5.5 Per-measurement reports
+
+Publish one report entry for every accepted/rejected update:
+
+- `ahrs/updates/accel`
+- `ahrs/updates/gyro`
+- `ahrs/updates/mag`
+
+Contents (recommended):
+
+- `header.stamp = t_meas`
+- `z`, `z_hat`, innovation `ν`
+- measurement noise used `R` (full)
+- predicted innovation covariance excluding R: `Ŝ = HPHᵀ`
+- total innovation covariance `S = Ŝ + R`
+- Mahalanobis distance `d² = νᵀ S^{-1} ν`
+- gating threshold + accept/reject flag
+
+Each per-measurement topic publishes `oasis_msgs/EkfUpdateReport` stamped at `t_meas` for every accepted/rejected update.
+
+### 5.6 `oasis_msgs/AhrsState` (full state + full covariance)
+
+- Topic: `ahrs/state`
+- Publish: **on frontier advance** (Section 4.8)
+- `header.stamp = t_filter`
+- Contents: full mean state (navigation + calibration + extrinsics + `g_W`, `m_W`) and full error-state covariance `P`
+  with explicit ordering (`error_state_names`). No diagonalization.
+
+### 5.7 `oasis_msgs/AhrsDiagnostics` (buffer + drop/replay stats)
+
+- Topic: `ahrs/diag`
+- Publish: **on frontier advance** (Section 4.8)
+- `header.stamp = t_filter`
+- Contents: buffer size/span, replay flag, and monotonic drop/reset counters.
+
+---
+
+## 6. Config Parameters
+
+Frames:
+
+- `world_frame_id` (default `"world"`)
+- `odom_frame_id` (default `"odom"`)
+- `body_frame_id` (default `"base_link"`)
+
+Time / buffering:
+
+- `T_buffer_sec`
+- `ε_wall_future`
+- `Δt_clock_jump_max`
+- `Δt_imu_max`
+
+Process noise intensities (continuous-time):
+
+- `Q_v` (for `w_v`)
+- `Q_ω` (for `w_ω`)
+- `Q_bg`, `Q_ba`
+- `Q_A` (for `vec(A_a)` drift)
+- `Q_BI`, `Q_BM` (for extrinsic drift in SE(3) tangent)
+- `Q_g`, `Q_m` (for `g_W`, `m_W` drift)
+
+Magnetometer adaptive noise:
+
+- `α`
+- `R_min`, `R_max`
+- default `R_m0` (if no valid `Σ_m_raw` observed)

--- a/mypy.ini
+++ b/mypy.ini
@@ -57,3 +57,6 @@ ignore_missing_imports = True
 
 [mypy-telemetrix_aio]
 ignore_missing_imports = True
+
+[mypy-tf2_ros]
+ignore_missing_imports = True

--- a/oasis_control/launch/control_launch.py
+++ b/oasis_control/launch/control_launch.py
@@ -69,6 +69,7 @@ def generate_launch_description() -> LaunchDescription:
     # Navigation
     if HOST_ID == "falcon":
         # ControlDescriptions.add_ekf_localizer(ld, HOST_ID, apriltag_resolution="hd")
+        ControlDescriptions.add_ahrs(ld, HOST_ID)
         ControlDescriptions.add_imu_fuser(ld, HOST_ID)
         ControlDescriptions.add_speedometer(ld, HOST_ID)
         ControlDescriptions.add_tilt_sensor(ld, HOST_ID)

--- a/oasis_control/oasis_control/cli/ahrs_cli.py
+++ b/oasis_control/oasis_control/cli/ahrs_cli.py
@@ -1,0 +1,38 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""
+ROS entry point for the AHRS node
+"""
+
+from typing import Optional
+
+import rclpy
+
+from oasis_control.nodes.ahrs_node import AhrsNode
+
+
+################################################################################
+# ROS entry point
+################################################################################
+
+
+def main(args: Optional[list[str]] = None) -> None:
+    rclpy.init(args=args)
+
+    node: AhrsNode = AhrsNode()
+
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.stop()
+        rclpy.shutdown()

--- a/oasis_control/oasis_control/launch/control_descriptions.py
+++ b/oasis_control/oasis_control/launch/control_descriptions.py
@@ -29,6 +29,31 @@ CONTROL_PACKAGE_NAME: str = "oasis_control"
 
 class ControlDescriptions:
     #
+    # AHRS
+    #
+
+    @staticmethod
+    def add_ahrs(ld: LaunchDescription, host_id: str) -> None:
+        ahrs_node: Node = Node(
+            namespace=ROS_NAMESPACE,
+            package=CONTROL_PACKAGE_NAME,
+            executable="ahrs",
+            name=f"ahrs_{host_id}",
+            output="screen",
+            remappings=[
+                ("ahrs/extrinsics/t_bi", f"{host_id}/ahrs/extrinsics/t_bi"),
+                ("ahrs/extrinsics/t_bm", f"{host_id}/ahrs/extrinsics/t_bm"),
+                ("ahrs/updates/accel", f"{host_id}/ahrs/updates/accel"),
+                ("ahrs/updates/gyro", f"{host_id}/ahrs/updates/gyro"),
+                ("ahrs/updates/mag", f"{host_id}/ahrs/updates/mag"),
+                ("imu_calibration", f"{host_id}/imu_calibration"),
+                ("imu_raw", f"{host_id}/imu_raw"),
+                ("magnetic_field", f"{host_id}/magnetic_field"),
+            ],
+        )
+        ld.add_action(ahrs_node)
+
+    #
     # EKF localizer
     #
 

--- a/oasis_control/oasis_control/localization/ahrs/ahrs_clock.py
+++ b/oasis_control/oasis_control/localization/ahrs/ahrs_clock.py
@@ -1,0 +1,42 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""
+Clock abstraction for AHRS localization
+"""
+
+from __future__ import annotations
+
+from oasis_control.localization.ahrs.ahrs_conversions import seconds_from_ahrs
+from oasis_control.localization.ahrs.ahrs_types import AhrsTime
+
+
+class AhrsClock:
+    """
+    Clock abstraction for retrieving AHRS time
+    """
+
+    def now(self) -> AhrsTime:
+        """
+        Return the current AHRS time
+        """
+
+        raise NotImplementedError
+
+    def is_future_stamp(self, t_meas: AhrsTime, epsilon_sec: float) -> bool:
+        """
+        True when the measurement stamp is ahead of the wall clock
+        """
+
+        now: AhrsTime = self.now()
+        now_sec: float = seconds_from_ahrs(now)
+        meas_sec: float = seconds_from_ahrs(t_meas)
+
+        return meas_sec > now_sec + epsilon_sec

--- a/oasis_control/oasis_control/localization/ahrs/ahrs_config.py
+++ b/oasis_control/oasis_control/localization/ahrs/ahrs_config.py
@@ -1,0 +1,70 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""
+Configuration data for AHRS localization
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class AhrsConfig:
+    """
+    Shared AHRS configuration values
+
+    Fields:
+        world_frame_id: Global drift-corrected frame name
+        odom_frame_id: Local continuous frame name
+        body_frame_id: Body frame name for state output
+        t_buffer_sec: Buffer span in seconds used for fixed-lag replay
+        epsilon_wall_future_sec: Max future offset in seconds allowed by wall clock
+        dt_clock_jump_max_sec: Threshold in seconds for detecting clock jumps
+        dt_imu_max_sec: Max IMU delta in seconds before skipping propagation
+        gyro_gate_d2_threshold: Mahalanobis gate threshold for gyro updates
+        mag_alpha: Magnetometer covariance matching factor, unitless
+        mag_r_min: Minimum magnetometer covariance matrix, row-major
+        mag_r_max: Maximum magnetometer covariance matrix, row-major
+        mag_r0: Default initial magnetometer covariance matrix, row-major
+        q_v: Velocity process noise placeholder
+        q_w: Angular velocity process noise placeholder
+        q_bg: Gyro bias process noise placeholder
+        q_ba: Accel bias process noise placeholder
+        q_a: Accel scale process noise placeholder
+        q_bi: IMU extrinsic process noise placeholder
+        q_bm: Magnetometer extrinsic process noise placeholder
+        q_g: Gravity process noise placeholder
+        q_m: Magnetic field process noise placeholder
+    """
+
+    world_frame_id: str
+    odom_frame_id: str
+    body_frame_id: str
+
+    t_buffer_sec: float
+    epsilon_wall_future_sec: float
+    dt_clock_jump_max_sec: float
+    dt_imu_max_sec: float
+    gyro_gate_d2_threshold: float
+
+    mag_alpha: float
+    mag_r_min: list[float]
+    mag_r_max: list[float]
+    mag_r0: list[float]
+
+    q_v: float
+    q_w: float
+    q_bg: float
+    q_ba: float
+    q_a: float
+    q_bi: float
+    q_bm: float
+    q_g: float
+    q_m: float

--- a/oasis_control/oasis_control/localization/ahrs/ahrs_conversions.py
+++ b/oasis_control/oasis_control/localization/ahrs/ahrs_conversions.py
@@ -1,0 +1,73 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""
+Conversion helpers between core AHRS types
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+
+from oasis_control.localization.ahrs.ahrs_types import AhrsTime
+
+
+def ahrs_time_from_pair(sec: int, nanosec: int) -> AhrsTime:
+    """
+    Build an AHRS time from a seconds/nanoseconds pair
+    """
+
+    return normalize_ahrs_time(AhrsTime(sec=int(sec), nanosec=int(nanosec)))
+
+
+def normalize_ahrs_time(t: AhrsTime) -> AhrsTime:
+    """
+    Normalize nanoseconds so they always live in [0, 1e9)
+    """
+
+    carry_sec: int
+    nanosec: int
+    carry_sec, nanosec = divmod(t.nanosec, 1_000_000_000)
+    sec: int = t.sec + carry_sec
+
+    return AhrsTime(sec=sec, nanosec=nanosec)
+
+
+def cov3x3_from_seq(cov: Sequence[float]) -> list[float]:
+    """
+    Validate and convert a covariance sequence into a 3x3 covariance
+    """
+
+    if len(cov) != 9:
+        raise ValueError("Expected 9 covariance entries")
+
+    values: list[float] = [float(value) for value in cov]
+
+    if not all(math.isfinite(value) for value in values):
+        raise ValueError("Covariance entries must be finite")
+
+    return values
+
+
+def vector3_from_xyz(x: float, y: float, z: float) -> list[float]:
+    """
+    Convert XYZ components into a vector list
+    """
+
+    return [float(x), float(y), float(z)]
+
+
+def seconds_from_ahrs(t: AhrsTime) -> float:
+    """
+    Convert an AHRS timestamp into seconds
+    """
+
+    return float(t.sec) + float(t.nanosec) * 1e-9

--- a/oasis_control/oasis_control/localization/ahrs/ahrs_error_state.py
+++ b/oasis_control/oasis_control/localization/ahrs/ahrs_error_state.py
@@ -1,0 +1,204 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""
+Explicit error-state layout for AHRS covariance bookkeeping
+
+The error-state stores small deviations from the nominal state so the filter
+can track uncertainty with linearized dynamics. The covariance matrix uses
+this stacked error vector, so a deterministic layout and stable naming are
+critical for mapping blocks and publishing diagnostics.
+
+The extrinsic pose blocks use an SE(3) tangent representation. Each block is
+stacked as (delta rho, delta theta), where delta rho is the small translation
+error and delta theta is the small-angle rotation error.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ErrorBlock:
+    """
+    Descriptor for a contiguous block in the stacked error-state vector
+
+    Fields:
+        name: Human-readable name for the block
+        dim: Dimension of the block in the error vector
+        start: Starting index of the block in the stacked vector
+    """
+
+    name: str
+    dim: int
+    start: int
+
+    @property
+    def sl(self) -> slice:
+        """
+        Slice for this block inside the stacked error-state vector
+        """
+
+        return slice(self.start, self.start + self.dim)
+
+
+class AhrsErrorStateLayout:
+    """
+    Deterministic error-state layout for the AHRS covariance matrix
+    """
+
+    def __init__(self) -> None:
+        order: list[str] = []
+        blocks: dict[str, ErrorBlock] = {}
+        start: int = 0
+
+        for key, name, dim in (
+            ("p", "p_wb", 3),
+            ("v", "v_wb", 3),
+            ("theta", "theta_wb", 3),
+            ("omega", "omega_wb", 3),
+            ("bg", "b_g", 3),
+            ("ba", "b_a", 3),
+            ("Aa", "A_a", 9),
+            ("xi_bi", "xi_bi", 6),
+            ("xi_bm", "xi_bm", 6),
+            ("g", "g_w", 3),
+            ("m", "m_w", 3),
+        ):
+            blocks[key] = ErrorBlock(name=name, dim=dim, start=start)
+            order.append(key)
+            start += dim
+
+        self.blocks: dict[str, ErrorBlock] = blocks
+        self.order: list[str] = order
+        self.dim: int = start
+
+    def sl_p(self) -> slice:
+        """
+        Slice for position error delta p
+        """
+
+        return self.blocks["p"].sl
+
+    def sl_v(self) -> slice:
+        """
+        Slice for velocity error delta v
+        """
+
+        return self.blocks["v"].sl
+
+    def sl_theta(self) -> slice:
+        """
+        Slice for attitude small-angle error delta theta
+        """
+
+        return self.blocks["theta"].sl
+
+    def sl_omega(self) -> slice:
+        """
+        Slice for angular-rate error delta omega
+        """
+
+        return self.blocks["omega"].sl
+
+    def sl_bg(self) -> slice:
+        """
+        Slice for gyro bias error delta b_g
+        """
+
+        return self.blocks["bg"].sl
+
+    def sl_ba(self) -> slice:
+        """
+        Slice for accel bias error delta b_a
+        """
+
+        return self.blocks["ba"].sl
+
+    def sl_Aa(self) -> slice:
+        """
+        Slice for accel matrix error delta A_a
+        """
+
+        return self.blocks["Aa"].sl
+
+    def sl_xi_bi(self) -> slice:
+        """
+        Slice for IMU extrinsic error delta xi_bi
+        """
+
+        return self.blocks["xi_bi"].sl
+
+    def sl_xi_bm(self) -> slice:
+        """
+        Slice for magnetometer extrinsic error delta xi_bm
+        """
+
+        return self.blocks["xi_bm"].sl
+
+    def sl_g(self) -> slice:
+        """
+        Slice for gravity vector error delta g_w
+        """
+
+        return self.blocks["g"].sl
+
+    def sl_m(self) -> slice:
+        """
+        Slice for magnetic field error delta m_w
+        """
+
+        return self.blocks["m"].sl
+
+
+def error_state_names(layout: AhrsErrorStateLayout) -> list[str]:
+    """
+    Build per-element error-state names in the stacked layout order
+    """
+
+    names: list[str] = []
+    axes: tuple[str, str, str] = ("x", "y", "z")
+
+    for key in layout.order:
+        if key == "p":
+            names.extend([f"δp_wb_{axis}" for axis in axes])
+        elif key == "v":
+            names.extend([f"δv_wb_{axis}" for axis in axes])
+        elif key == "theta":
+            names.extend([f"δtheta_wb_{axis}" for axis in axes])
+        elif key == "omega":
+            names.extend([f"δomega_wb_{axis}" for axis in axes])
+        elif key == "bg":
+            names.extend([f"δb_g_{axis}" for axis in axes])
+        elif key == "ba":
+            names.extend([f"δb_a_{axis}" for axis in axes])
+        elif key == "Aa":
+            for row in range(3):
+                for col in range(3):
+                    names.append(f"δA_a_r{row}c{col}")
+        elif key == "xi_bi":
+            names.extend([f"δxi_bi_rho_{axis}" for axis in axes])
+            names.extend([f"δxi_bi_theta_{axis}" for axis in axes])
+        elif key == "xi_bm":
+            names.extend([f"δxi_bm_rho_{axis}" for axis in axes])
+            names.extend([f"δxi_bm_theta_{axis}" for axis in axes])
+        elif key == "g":
+            names.extend([f"δg_w_{axis}" for axis in axes])
+        elif key == "m":
+            names.extend([f"δm_w_{axis}" for axis in axes])
+        else:
+            raise ValueError(f"Unknown error-state block key: {key}")
+
+    if len(names) != layout.dim:
+        raise ValueError(
+            f"Error-state names length {len(names)} does not match "
+            f"layout dim {layout.dim}"
+        )
+
+    return names

--- a/oasis_control/oasis_control/localization/ahrs/ahrs_filter.py
+++ b/oasis_control/oasis_control/localization/ahrs/ahrs_filter.py
@@ -1,0 +1,630 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""
+Stub AHRS filter implementation
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Iterable
+from typing import Optional
+from typing import cast
+
+from oasis_control.localization.ahrs.ahrs_clock import AhrsClock
+from oasis_control.localization.ahrs.ahrs_config import AhrsConfig
+from oasis_control.localization.ahrs.ahrs_error_state import AhrsErrorStateLayout
+from oasis_control.localization.ahrs.ahrs_error_state import error_state_names
+from oasis_control.localization.ahrs.ahrs_predict import predict_step
+from oasis_control.localization.ahrs.ahrs_state import AhrsNominalState
+from oasis_control.localization.ahrs.ahrs_state import default_nominal_state
+from oasis_control.localization.ahrs.ahrs_timeline import AhrsTimeBuffer
+from oasis_control.localization.ahrs.ahrs_timeline import AhrsTimeNode
+from oasis_control.localization.ahrs.ahrs_types import AhrsDiagnosticsData
+from oasis_control.localization.ahrs.ahrs_types import AhrsEvent
+from oasis_control.localization.ahrs.ahrs_types import AhrsEventType
+from oasis_control.localization.ahrs.ahrs_types import AhrsFrameOutputs
+from oasis_control.localization.ahrs.ahrs_types import AhrsFrameTransform
+from oasis_control.localization.ahrs.ahrs_types import AhrsImuPacket
+from oasis_control.localization.ahrs.ahrs_types import AhrsMatrix
+from oasis_control.localization.ahrs.ahrs_types import AhrsOutputs
+from oasis_control.localization.ahrs.ahrs_types import AhrsSe3Transform
+from oasis_control.localization.ahrs.ahrs_types import AhrsStateData
+from oasis_control.localization.ahrs.ahrs_types import AhrsTime
+from oasis_control.localization.ahrs.ahrs_types import AhrsUpdateData
+from oasis_control.localization.ahrs.ahrs_types import MagSample
+from oasis_control.localization.ahrs.ahrs_update_gyro import update_gyro
+
+
+class AhrsFilter:
+    """
+    Stubbed AHRS filter for deterministic event handling
+    """
+
+    def __init__(self, config: AhrsConfig, clock: AhrsClock) -> None:
+        self._config: AhrsConfig = config
+        self._clock: AhrsClock = clock
+
+        self._initialized: bool = False
+        self._t_filter: Optional[AhrsTime] = None
+        self._state_seq: int = 0
+        self._diag_seq: int = 0
+
+        self._dropped_missing_stamp: int = 0
+        self._dropped_future_stamp: int = 0
+        self._dropped_too_old: int = 0
+        self._dropped_nan_cov: int = 0
+        self._dropped_imu_gap: int = 0
+        self._dropped_clock_jump_reset: int = 0
+        self._reset_count: int = 0
+        self._last_reset_reason: str = ""
+
+        self._last_imu_time: Optional[AhrsTime] = None
+        self._buffer: AhrsTimeBuffer = AhrsTimeBuffer()
+        self._replay_happened_since_publish: bool = False
+        self._layout: AhrsErrorStateLayout = AhrsErrorStateLayout()
+        self._x: Optional[AhrsNominalState] = None
+        self._p: Optional[list[float]] = None
+        self._t_state: Optional[AhrsTime] = None
+        self._last_update_reports: dict[str, Optional[AhrsUpdateData]] = {
+            "gyro": None,
+            "accel": None,
+            "mag": None,
+        }
+
+    def handle_event(self, event: AhrsEvent) -> AhrsOutputs:
+        if self._clock.is_future_stamp(
+            event.t_meas, self._config.epsilon_wall_future_sec
+        ):
+            self._dropped_future_stamp += 1
+            return self._outputs_for_drop(self._build_update_reports(event))
+
+        if self._has_nan_covariance(event):
+            self._dropped_nan_cov += 1
+            return self._outputs_for_drop(self._build_update_reports(event))
+
+        if self._is_clock_jump(event.t_meas):
+            self._reset_for_clock_jump()
+            return self._outputs_for_drop(self._build_update_reports(event))
+
+        if self._is_too_old(event.t_meas):
+            self._dropped_too_old += 1
+            return self._outputs_for_drop(self._build_update_reports(event))
+
+        self._buffer.insert_event(event)
+
+        if self._frontier_advances(event.t_meas):
+            if self._replay_has_imu_gap(
+                start_time=self._t_filter, end_time=event.t_meas
+            ):
+                self._dropped_imu_gap += 1
+                return self._outputs_for_drop(self._build_update_reports(event))
+
+            self._t_filter = event.t_meas
+            self._initialized = True
+            self._state_seq += 1
+            self._diag_seq += 1
+            self._evict_before(self._t_filter)
+            self._replay_events(start_time=None, end_time=self._t_filter)
+
+            state: AhrsStateData = self._build_state(event.t_meas)
+            replay_happened: bool = self._replay_happened_since_publish
+            diagnostics: AhrsDiagnosticsData = self._build_diagnostics(
+                t_filter=event.t_meas,
+                replay_happened=replay_happened,
+            )
+            self._replay_happened_since_publish = False
+            frame_transforms: AhrsFrameOutputs = self._build_frame_outputs()
+
+            update_reports: dict[str, Optional[AhrsUpdateData]] = (
+                self._update_reports_for_event(event)
+            )
+
+            return AhrsOutputs(
+                frontier_advanced=True,
+                t_filter=event.t_meas,
+                frame_transforms=frame_transforms,
+                state=state,
+                diagnostics=diagnostics,
+                gyro_update=update_reports["gyro"],
+                accel_update=update_reports["accel"],
+                mag_update=update_reports["mag"],
+            )
+
+        if self._replay_has_imu_gap(start_time=event.t_meas, end_time=self._t_filter):
+            self._dropped_imu_gap += 1
+        else:
+            replayed: bool = self._replay_events(
+                start_time=event.t_meas, end_time=self._t_filter
+            )
+            if replayed:
+                self._replay_happened_since_publish = True
+
+        return self._outputs_for_drop(self._build_update_reports(event))
+
+    def _frontier_advances(self, t_meas: AhrsTime) -> bool:
+        if self._t_filter is None:
+            return True
+
+        return self._time_key(t_meas) > self._time_key(self._t_filter)
+
+    def _is_clock_jump(self, t_meas: AhrsTime) -> bool:
+        if self._t_filter is None:
+            return False
+
+        if self._config.dt_clock_jump_max_sec <= 0.0:
+            return False
+
+        dt_sec: float = self._seconds_between(self._t_filter, t_meas)
+        return dt_sec > self._config.dt_clock_jump_max_sec
+
+    def _is_too_old(self, t_meas: AhrsTime) -> bool:
+        if self._t_filter is None:
+            return False
+
+        if self._config.t_buffer_sec <= 0.0:
+            return False
+
+        # t_buffer_sec converted to nanoseconds for window comparison
+        buffer_ns: int = int(self._config.t_buffer_sec * 1_000_000_000)
+        cutoff_ns: int = self._time_to_ns(self._t_filter) - buffer_ns
+        return self._time_to_ns(t_meas) < cutoff_ns
+
+    def _seconds_between(self, t_start: AhrsTime, t_end: AhrsTime) -> float:
+        start_sec: float = float(t_start.sec) + float(t_start.nanosec) * 1e-9
+        end_sec: float = float(t_end.sec) + float(t_end.nanosec) * 1e-9
+
+        return abs(end_sec - start_sec)
+
+    def _has_nan_covariance(self, event: AhrsEvent) -> bool:
+        covariances: list[float] = []
+        if event.event_type == AhrsEventType.IMU:
+            payload_imu = cast(AhrsImuPacket, event.payload)
+            covariances = (
+                payload_imu.imu.angular_velocity_cov
+                + payload_imu.imu.linear_acceleration_cov
+            )
+        elif event.event_type == AhrsEventType.MAG:
+            payload_mag = cast(MagSample, event.payload)
+            covariances = payload_mag.magnetic_field_cov
+
+        return any(math.isnan(value) for value in covariances)
+
+    def _reset_for_clock_jump(self) -> None:
+        self._dropped_clock_jump_reset += 1
+        self._reset_count += 1
+        self._last_reset_reason = "clock_jump"
+        self._initialized = False
+        self._t_filter = None
+        self._last_imu_time = None
+        self._buffer = AhrsTimeBuffer()
+        self._replay_happened_since_publish = False
+        self._x = None
+        self._p = None
+        self._t_state = None
+        self._last_update_reports = {
+            "gyro": None,
+            "accel": None,
+            "mag": None,
+        }
+
+    def _reset_for_invalid_dt(self) -> None:
+        self._reset_count += 1
+        self._last_reset_reason = "invalid_dt"
+        self._initialized = False
+        self._t_filter = None
+        self._last_imu_time = None
+        self._buffer = AhrsTimeBuffer()
+        self._replay_happened_since_publish = False
+        self._x = None
+        self._p = None
+        self._t_state = None
+        self._last_update_reports = {
+            "gyro": None,
+            "accel": None,
+            "mag": None,
+        }
+
+    def _replay_has_imu_gap(
+        self, start_time: Optional[AhrsTime], end_time: Optional[AhrsTime]
+    ) -> bool:
+        if end_time is None:
+            return False
+
+        if self._config.dt_imu_max_sec <= 0.0:
+            return False
+
+        # dt_imu_max_sec converted to nanoseconds for gap detection
+        gap_threshold_ns: int = int(self._config.dt_imu_max_sec * 1_000_000_000)
+        previous_imu_time: Optional[AhrsTime] = None
+        for node in self._iter_nodes_for_replay(start_time, end_time):
+            has_imu_event: bool = any(
+                event.event_type == AhrsEventType.IMU for event in node.events
+            )
+            if not has_imu_event:
+                continue
+
+            if previous_imu_time is not None:
+                dt_ns: int = self._time_to_ns(node.t) - self._time_to_ns(
+                    previous_imu_time
+                )
+                if dt_ns > gap_threshold_ns:
+                    return True
+            previous_imu_time = node.t
+
+        return False
+
+    def _iter_nodes_for_replay(
+        self, start_time: Optional[AhrsTime], end_time: AhrsTime
+    ) -> Iterable[AhrsTimeNode]:
+        nodes: Iterable[AhrsTimeNode]
+        if start_time is None:
+            nodes = self._buffer.iter_nodes()
+        else:
+            nodes = self._buffer.iter_nodes_from(start_time)
+
+        end_key: tuple[int, int] = self._time_key(end_time)
+        for node in nodes:
+            if self._time_key(node.t) > end_key:
+                break
+            yield node
+
+    def _replay_events(
+        self, start_time: Optional[AhrsTime], end_time: Optional[AhrsTime]
+    ) -> bool:
+        if end_time is None:
+            return False
+
+        if start_time is None:
+            self._reset_replay_state(None)
+        elif self._t_state is None or self._time_key(start_time) < self._time_key(
+            self._t_state
+        ):
+            self._reset_replay_state(start_time)
+
+        replayed: bool = False
+        for node in self._iter_nodes_for_replay(start_time, end_time):
+            replayed = True
+            try:
+                self._propagate_to(node.t)
+            except ValueError:
+                self._reset_for_invalid_dt()
+                return False
+            for event in self._sorted_events(node):
+                self._apply_event(event)
+        return replayed
+
+    def _sorted_events(self, node: AhrsTimeNode) -> list[AhrsEvent]:
+        return sorted(
+            node.events,
+            key=lambda event: (
+                event.event_type.value,
+                event.topic,
+                event.frame_id,
+            ),
+        )
+
+    def _apply_event(self, event: AhrsEvent) -> None:
+        if event.event_type == AhrsEventType.IMU:
+            payload_imu: AhrsImuPacket = cast(AhrsImuPacket, event.payload)
+            gyro_report: AhrsUpdateData
+            if self._x is None or self._p is None:
+                gyro_report = self._build_update(
+                    sensor="gyro",
+                    frame_id=event.frame_id,
+                    t_meas=event.t_meas,
+                    reject_reason="not_applied",
+                )
+            else:
+                self._x, self._p, gyro_report = update_gyro(
+                    self._layout,
+                    self._x,
+                    self._p,
+                    payload_imu.imu,
+                    self._config,
+                    frame_id=event.frame_id,
+                    t_meas=event.t_meas,
+                )
+            self._last_update_reports["gyro"] = gyro_report
+            accel_report: AhrsUpdateData = self._build_update(
+                sensor="accel",
+                frame_id=event.frame_id,
+                t_meas=event.t_meas,
+            )
+            self._last_update_reports["accel"] = accel_report
+            self._last_imu_time = event.t_meas
+            return
+
+        if event.event_type == AhrsEventType.MAG:
+            mag_report: AhrsUpdateData = self._build_update(
+                sensor="mag",
+                frame_id=event.frame_id,
+                t_meas=event.t_meas,
+            )
+            self._last_update_reports["mag"] = mag_report
+
+    def _evict_before(self, t_filter: AhrsTime) -> None:
+        if self._config.t_buffer_sec <= 0.0:
+            return
+
+        # t_buffer_sec converted to nanoseconds for eviction cutoff
+        buffer_ns: int = int(self._config.t_buffer_sec * 1_000_000_000)
+        cutoff_ns: int = self._time_to_ns(t_filter) - buffer_ns
+        cutoff_time: AhrsTime = self._time_from_ns(cutoff_ns)
+        self._buffer.evict_older_than(cutoff_time)
+
+    def _time_key(self, t: AhrsTime) -> tuple[int, int]:
+        return (t.sec, t.nanosec)
+
+    def _time_to_ns(self, t: AhrsTime) -> int:
+        # 1e9 converts seconds to nanoseconds for integer time arithmetic
+        return t.sec * 1_000_000_000 + t.nanosec
+
+    def _time_from_ns(self, nanoseconds: int) -> AhrsTime:
+        sec: int
+        nanosec: int
+        # 1e9 converts nanoseconds to seconds for integer time arithmetic
+        sec, nanosec = divmod(nanoseconds, 1_000_000_000)
+        return AhrsTime(sec=sec, nanosec=nanosec)
+
+    def _build_update_reports(
+        self, event: AhrsEvent
+    ) -> dict[str, Optional[AhrsUpdateData]]:
+        update_reports: dict[str, Optional[AhrsUpdateData]] = {
+            "gyro": None,
+            "accel": None,
+            "mag": None,
+        }
+
+        if event.event_type == AhrsEventType.IMU:
+            update_reports["gyro"] = self._build_update(
+                sensor="gyro",
+                frame_id=event.frame_id,
+                t_meas=event.t_meas,
+                reject_reason="not_applied",
+            )
+            update_reports["accel"] = self._build_update(
+                sensor="accel",
+                frame_id=event.frame_id,
+                t_meas=event.t_meas,
+            )
+        elif event.event_type == AhrsEventType.MAG:
+            update_reports["mag"] = self._build_update(
+                sensor="mag",
+                frame_id=event.frame_id,
+                t_meas=event.t_meas,
+            )
+
+        return update_reports
+
+    def _update_reports_for_event(
+        self, event: AhrsEvent
+    ) -> dict[str, Optional[AhrsUpdateData]]:
+        update_reports: dict[str, Optional[AhrsUpdateData]] = {
+            "gyro": None,
+            "accel": None,
+            "mag": None,
+        }
+
+        if event.event_type == AhrsEventType.IMU:
+            update_reports["gyro"] = self._last_update_reports["gyro"]
+            if update_reports["gyro"] is None:
+                update_reports["gyro"] = self._build_update(
+                    sensor="gyro",
+                    frame_id=event.frame_id,
+                    t_meas=event.t_meas,
+                    reject_reason="not_applied",
+                )
+            update_reports["accel"] = self._last_update_reports["accel"]
+            if update_reports["accel"] is None:
+                update_reports["accel"] = self._build_update(
+                    sensor="accel",
+                    frame_id=event.frame_id,
+                    t_meas=event.t_meas,
+                )
+        elif event.event_type == AhrsEventType.MAG:
+            update_reports["mag"] = self._last_update_reports["mag"]
+            if update_reports["mag"] is None:
+                update_reports["mag"] = self._build_update(
+                    sensor="mag",
+                    frame_id=event.frame_id,
+                    t_meas=event.t_meas,
+                )
+
+        return update_reports
+
+    def _build_update(
+        self,
+        sensor: str,
+        frame_id: str,
+        t_meas: AhrsTime,
+        *,
+        reject_reason: str = "not_implemented",
+    ) -> AhrsUpdateData:
+        empty_matrix: AhrsMatrix = AhrsMatrix(rows=0, cols=0, data=[])
+
+        return AhrsUpdateData(
+            sensor=sensor,
+            frame_id=frame_id,
+            t_meas=t_meas,
+            accepted=False,
+            reject_reason=reject_reason,
+            z=[],
+            z_hat=[],
+            nu=[],
+            r=empty_matrix,
+            s_hat=empty_matrix,
+            s=empty_matrix,
+            maha_d2=0.0,
+            gate_threshold=0.0,
+        )
+
+    def _build_state(self, t_filter: AhrsTime) -> AhrsStateData:
+        error_names: list[str] = error_state_names(self._layout)
+        error_dim: int = self._layout.dim
+        p_data: list[float]
+        if self._p is None:
+            p_data = [0.0] * (error_dim * error_dim)
+        else:
+            p_data = list(self._p)
+        p_cov: AhrsMatrix = AhrsMatrix(
+            rows=error_dim,
+            cols=error_dim,
+            data=p_data,
+        )
+
+        if self._x is None:
+            x: AhrsNominalState = default_nominal_state(
+                body_frame_id=self._config.body_frame_id,
+                imu_frame_id="imu",
+                mag_frame_id="mag",
+            )
+        else:
+            x = self._x
+
+        t_bi: AhrsSe3Transform = x.t_bi
+        t_bm: AhrsSe3Transform = x.t_bm
+
+        return AhrsStateData(
+            t_filter=t_filter,
+            state_seq=self._state_seq,
+            initialized=self._initialized,
+            world_frame_id=self._config.world_frame_id,
+            odom_frame_id=self._config.odom_frame_id,
+            body_frame_id=self._config.body_frame_id,
+            p_wb_m=list(x.p_wb_m),
+            v_wb_mps=list(x.v_wb_mps),
+            q_wb_wxyz=list(x.q_wb_wxyz),
+            b_g_rps=list(x.b_g_rps),
+            b_a_mps2=list(x.b_a_mps2),
+            a_a=list(x.a_a),
+            t_bi=t_bi,
+            t_bm=t_bm,
+            g_w_mps2=list(x.g_w_mps2),
+            m_w_t=list(x.m_w_t),
+            error_state_names=error_names,
+            p_cov=p_cov,
+        )
+
+    def _build_diagnostics(
+        self, t_filter: AhrsTime, replay_happened: bool
+    ) -> AhrsDiagnosticsData:
+        return AhrsDiagnosticsData(
+            t_filter=t_filter,
+            diag_seq=self._diag_seq,
+            buffer_node_count=self._buffer.node_count(),
+            buffer_span_sec=self._buffer.span_sec(),
+            replay_happened=replay_happened,
+            dropped_missing_stamp=self._dropped_missing_stamp,
+            dropped_future_stamp=self._dropped_future_stamp,
+            dropped_too_old=self._dropped_too_old,
+            dropped_nan_cov=self._dropped_nan_cov,
+            dropped_imu_gap=self._dropped_imu_gap,
+            dropped_clock_jump_reset=self._dropped_clock_jump_reset,
+            reset_count=self._reset_count,
+            last_reset_reason=self._last_reset_reason,
+        )
+
+    def _build_frame_outputs(self) -> AhrsFrameOutputs:
+        zero_vector: list[float] = [0.0, 0.0, 0.0]
+        zero_quaternion: list[float] = [1.0, 0.0, 0.0, 0.0]
+
+        t_world_odom: AhrsFrameTransform = AhrsFrameTransform(
+            parent_frame="world",
+            child_frame="odom",
+            translation_m=zero_vector,
+            rotation_wxyz=zero_quaternion,
+        )
+        t_odom_base: AhrsFrameTransform = AhrsFrameTransform(
+            parent_frame="odom",
+            child_frame="base_link",
+            translation_m=zero_vector,
+            rotation_wxyz=zero_quaternion,
+        )
+        t_world_base: AhrsFrameTransform = AhrsFrameTransform(
+            parent_frame="world",
+            child_frame="base_link",
+            translation_m=zero_vector,
+            rotation_wxyz=zero_quaternion,
+        )
+
+        return AhrsFrameOutputs(
+            t_odom_base=t_odom_base,
+            t_world_odom=t_world_odom,
+            t_world_base=t_world_base,
+        )
+
+    def _outputs_for_drop(
+        self, update_reports: dict[str, Optional[AhrsUpdateData]]
+    ) -> AhrsOutputs:
+        return AhrsOutputs(
+            frontier_advanced=False,
+            t_filter=self._t_filter,
+            frame_transforms=None,
+            state=None,
+            diagnostics=None,
+            gyro_update=update_reports["gyro"],
+            accel_update=update_reports["accel"],
+            mag_update=update_reports["mag"],
+        )
+
+    def _reset_replay_state(self, t_state: Optional[AhrsTime]) -> None:
+        if t_state is None:
+            self._x = None
+            self._p = None
+            self._t_state = None
+            self._last_update_reports = {
+                "gyro": None,
+                "accel": None,
+                "mag": None,
+            }
+            return
+
+        self._x = default_nominal_state(
+            body_frame_id=self._config.body_frame_id,
+            imu_frame_id="imu",
+            mag_frame_id="mag",
+        )
+        self._p = self._initial_covariance()
+        self._t_state = t_state
+        self._last_update_reports = {
+            "gyro": None,
+            "accel": None,
+            "mag": None,
+        }
+
+    def _initial_covariance(self) -> list[float]:
+        dim: int = self._layout.dim
+        p: list[float] = [0.0] * (dim * dim)
+        # Initial covariance diagonal in nominal state units
+        prior_var: float = 1.0e-3
+        for i in range(dim):
+            p[i * dim + i] = prior_var
+        return p
+
+    def _propagate_to(self, t_target: AhrsTime) -> None:
+        if self._x is None or self._p is None or self._t_state is None:
+            self._reset_replay_state(t_target)
+            return
+
+        dt_ns: int = self._time_to_ns(t_target) - self._time_to_ns(self._t_state)
+        # 1e-9 converts nanoseconds to seconds for propagation
+        dt_sec: float = float(dt_ns) * 1.0e-9
+        if dt_sec < 0.0:
+            # Negative dt implies a replay ordering error
+            raise ValueError("dt_sec must be non-negative")
+
+        if dt_sec > 0.0:
+            self._x, self._p = predict_step(
+                self._layout, self._x, self._p, dt_sec, self._config
+            )
+
+        self._t_state = t_target

--- a/oasis_control/oasis_control/localization/ahrs/ahrs_inject.py
+++ b/oasis_control/oasis_control/localization/ahrs/ahrs_inject.py
@@ -1,0 +1,223 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""
+Nominal-state error injection utilities for the AHRS core
+
+The error-state EKF stores small perturbations in a stacked error vector. The
+injection step applies a correction ``delta_x`` to the nominal state and
+resets the error-state estimate to zero. Attitude and extrinsic rotations are
+updated using a small-angle exponential map applied as
+``q_new = q_nominal ⊗ Exp(delta_theta)``. The error-state layout controls how
+``delta_x`` is partitioned into translation, velocity, attitude, bias, and
+sensor transform corrections.
+"""
+
+from __future__ import annotations
+
+import math
+
+from oasis_control.localization.ahrs.ahrs_error_state import AhrsErrorStateLayout
+from oasis_control.localization.ahrs.ahrs_linalg import is_finite_seq
+from oasis_control.localization.ahrs.ahrs_state import AhrsNominalState
+from oasis_control.localization.ahrs.ahrs_types import AhrsSe3Transform
+
+
+def _quat_mul(q_left: list[float], q_right: list[float]) -> list[float]:
+    """
+    Multiply two quaternions in wxyz order
+    """
+
+    w1: float = q_left[0]
+    x1: float = q_left[1]
+    y1: float = q_left[2]
+    z1: float = q_left[3]
+
+    w2: float = q_right[0]
+    x2: float = q_right[1]
+    y2: float = q_right[2]
+    z2: float = q_right[3]
+
+    return [
+        w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2,
+        w1 * x2 + x1 * w2 + y1 * z2 - z1 * y2,
+        w1 * y2 - x1 * z2 + y1 * w2 + z1 * x2,
+        w1 * z2 + x1 * y2 - y1 * x2 + z1 * w2,
+    ]
+
+
+def _quat_normalize(q_wxyz: list[float]) -> list[float]:
+    """
+    Normalize a quaternion in wxyz order
+    """
+
+    norm: float = math.sqrt(
+        q_wxyz[0] * q_wxyz[0]
+        + q_wxyz[1] * q_wxyz[1]
+        + q_wxyz[2] * q_wxyz[2]
+        + q_wxyz[3] * q_wxyz[3]
+    )
+    if norm <= 0.0:
+        raise ValueError("Quaternion norm must be positive")
+    inv: float = 1.0 / norm
+    return [
+        q_wxyz[0] * inv,
+        q_wxyz[1] * inv,
+        q_wxyz[2] * inv,
+        q_wxyz[3] * inv,
+    ]
+
+
+def _quat_from_rotvec(rotvec: list[float]) -> list[float]:
+    """
+    Build a quaternion from a rotation vector using Exp(delta_theta)
+    """
+
+    rx: float = rotvec[0]
+    ry: float = rotvec[1]
+    rz: float = rotvec[2]
+    angle: float = math.sqrt(rx * rx + ry * ry + rz * rz)
+
+    # Rotation magnitude threshold in rad for small-angle series
+    small_angle_rad: float = 1.0e-12
+
+    if angle < small_angle_rad:
+        dq_wb: list[float] = [1.0, 0.5 * rx, 0.5 * ry, 0.5 * rz]
+        return _quat_normalize(dq_wb)
+
+    # Half-angle term used in quaternion exponential
+    half_angle: float = 0.5 * angle
+    sin_half: float = math.sin(half_angle)
+    inv_angle: float = 1.0 / angle
+    return [
+        math.cos(half_angle),
+        rx * inv_angle * sin_half,
+        ry * inv_angle * sin_half,
+        rz * inv_angle * sin_half,
+    ]
+
+
+def _apply_se3_delta(
+    transform: AhrsSe3Transform,
+    delta_rho: list[float],
+    delta_theta: list[float],
+) -> AhrsSe3Transform:
+    rotation_delta: list[float] = _quat_from_rotvec(delta_theta)
+    rotation_wxyz: list[float] = _quat_mul(
+        list(transform.rotation_wxyz),
+        rotation_delta,
+    )
+    rotation_wxyz = _quat_normalize(rotation_wxyz)
+    return AhrsSe3Transform(
+        parent_frame=transform.parent_frame,
+        child_frame=transform.child_frame,
+        translation_m=[
+            transform.translation_m[0] + delta_rho[0],
+            transform.translation_m[1] + delta_rho[1],
+            transform.translation_m[2] + delta_rho[2],
+        ],
+        rotation_wxyz=rotation_wxyz,
+    )
+
+
+def inject_error_state(
+    layout: AhrsErrorStateLayout,
+    state: AhrsNominalState,
+    delta_x: list[float],
+) -> AhrsNominalState:
+    """
+    Inject an error-state correction into the nominal state
+    """
+
+    if len(delta_x) != layout.dim:
+        raise ValueError("delta_x length does not match layout.dim")
+    if not is_finite_seq(delta_x):
+        raise ValueError("delta_x must contain finite values")
+
+    sl_p: slice = layout.sl_p()
+    sl_v: slice = layout.sl_v()
+    sl_theta: slice = layout.sl_theta()
+    sl_omega: slice = layout.sl_omega()
+    sl_bg: slice = layout.sl_bg()
+    sl_ba: slice = layout.sl_ba()
+    sl_aa: slice = layout.sl_Aa()
+    sl_xi_bi: slice = layout.sl_xi_bi()
+    sl_xi_bm: slice = layout.sl_xi_bm()
+    sl_g: slice = layout.sl_g()
+    sl_m: slice = layout.sl_m()
+
+    delta_p: list[float] = delta_x[sl_p]
+    delta_v: list[float] = delta_x[sl_v]
+    delta_theta: list[float] = delta_x[sl_theta]
+    delta_omega: list[float] = delta_x[sl_omega]
+    delta_bg: list[float] = delta_x[sl_bg]
+    delta_ba: list[float] = delta_x[sl_ba]
+    delta_aa: list[float] = delta_x[sl_aa]
+    delta_xi_bi: list[float] = delta_x[sl_xi_bi]
+    delta_xi_bm: list[float] = delta_x[sl_xi_bm]
+    delta_g: list[float] = delta_x[sl_g]
+    delta_m: list[float] = delta_x[sl_m]
+
+    dq_wb: list[float] = _quat_from_rotvec(delta_theta)
+    q_wb: list[float] = _quat_mul(list(state.q_wb_wxyz), dq_wb)
+    q_wb = _quat_normalize(q_wb)
+
+    t_bi: AhrsSe3Transform = _apply_se3_delta(
+        state.t_bi,
+        delta_xi_bi[0:3],
+        delta_xi_bi[3:6],
+    )
+    t_bm: AhrsSe3Transform = _apply_se3_delta(
+        state.t_bm,
+        delta_xi_bm[0:3],
+        delta_xi_bm[3:6],
+    )
+
+    return AhrsNominalState(
+        p_wb_m=[
+            state.p_wb_m[0] + delta_p[0],
+            state.p_wb_m[1] + delta_p[1],
+            state.p_wb_m[2] + delta_p[2],
+        ],
+        v_wb_mps=[
+            state.v_wb_mps[0] + delta_v[0],
+            state.v_wb_mps[1] + delta_v[1],
+            state.v_wb_mps[2] + delta_v[2],
+        ],
+        q_wb_wxyz=q_wb,
+        omega_wb_rps=[
+            state.omega_wb_rps[0] + delta_omega[0],
+            state.omega_wb_rps[1] + delta_omega[1],
+            state.omega_wb_rps[2] + delta_omega[2],
+        ],
+        b_g_rps=[
+            state.b_g_rps[0] + delta_bg[0],
+            state.b_g_rps[1] + delta_bg[1],
+            state.b_g_rps[2] + delta_bg[2],
+        ],
+        b_a_mps2=[
+            state.b_a_mps2[0] + delta_ba[0],
+            state.b_a_mps2[1] + delta_ba[1],
+            state.b_a_mps2[2] + delta_ba[2],
+        ],
+        a_a=[state.a_a[i] + delta_aa[i] for i in range(len(state.a_a))],
+        t_bi=t_bi,
+        t_bm=t_bm,
+        g_w_mps2=[
+            state.g_w_mps2[0] + delta_g[0],
+            state.g_w_mps2[1] + delta_g[1],
+            state.g_w_mps2[2] + delta_g[2],
+        ],
+        m_w_t=[
+            state.m_w_t[0] + delta_m[0],
+            state.m_w_t[1] + delta_m[1],
+            state.m_w_t[2] + delta_m[2],
+        ],
+    )

--- a/oasis_control/oasis_control/localization/ahrs/ahrs_inject.py
+++ b/oasis_control/oasis_control/localization/ahrs/ahrs_inject.py
@@ -22,86 +22,18 @@ sensor transform corrections.
 
 from __future__ import annotations
 
-import math
-
 from oasis_control.localization.ahrs.ahrs_error_state import AhrsErrorStateLayout
 from oasis_control.localization.ahrs.ahrs_linalg import is_finite_seq
+from oasis_control.localization.ahrs.ahrs_quat import quat_from_rotvec_wxyz
+from oasis_control.localization.ahrs.ahrs_quat import quat_mul_wxyz
+from oasis_control.localization.ahrs.ahrs_quat import quat_normalize_wxyz
 from oasis_control.localization.ahrs.ahrs_state import AhrsNominalState
 from oasis_control.localization.ahrs.ahrs_types import AhrsSe3Transform
 
 
-def _quat_mul(q_left: list[float], q_right: list[float]) -> list[float]:
-    """
-    Multiply two quaternions in wxyz order
-    """
-
-    w1: float = q_left[0]
-    x1: float = q_left[1]
-    y1: float = q_left[2]
-    z1: float = q_left[3]
-
-    w2: float = q_right[0]
-    x2: float = q_right[1]
-    y2: float = q_right[2]
-    z2: float = q_right[3]
-
-    return [
-        w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2,
-        w1 * x2 + x1 * w2 + y1 * z2 - z1 * y2,
-        w1 * y2 - x1 * z2 + y1 * w2 + z1 * x2,
-        w1 * z2 + x1 * y2 - y1 * x2 + z1 * w2,
-    ]
-
-
-def _quat_normalize(q_wxyz: list[float]) -> list[float]:
-    """
-    Normalize a quaternion in wxyz order
-    """
-
-    norm: float = math.sqrt(
-        q_wxyz[0] * q_wxyz[0]
-        + q_wxyz[1] * q_wxyz[1]
-        + q_wxyz[2] * q_wxyz[2]
-        + q_wxyz[3] * q_wxyz[3]
-    )
-    if norm <= 0.0:
-        raise ValueError("Quaternion norm must be positive")
-    inv: float = 1.0 / norm
-    return [
-        q_wxyz[0] * inv,
-        q_wxyz[1] * inv,
-        q_wxyz[2] * inv,
-        q_wxyz[3] * inv,
-    ]
-
-
-def _quat_from_rotvec(rotvec: list[float]) -> list[float]:
-    """
-    Build a quaternion from a rotation vector using Exp(delta_theta)
-    """
-
-    rx: float = rotvec[0]
-    ry: float = rotvec[1]
-    rz: float = rotvec[2]
-    angle: float = math.sqrt(rx * rx + ry * ry + rz * rz)
-
-    # Rotation magnitude threshold in rad for small-angle series
-    small_angle_rad: float = 1.0e-12
-
-    if angle < small_angle_rad:
-        dq_wb: list[float] = [1.0, 0.5 * rx, 0.5 * ry, 0.5 * rz]
-        return _quat_normalize(dq_wb)
-
-    # Half-angle term used in quaternion exponential
-    half_angle: float = 0.5 * angle
-    sin_half: float = math.sin(half_angle)
-    inv_angle: float = 1.0 / angle
-    return [
-        math.cos(half_angle),
-        rx * inv_angle * sin_half,
-        ry * inv_angle * sin_half,
-        rz * inv_angle * sin_half,
-    ]
+def _require_block_length(name: str, block: list[float], expected: int) -> None:
+    if len(block) != expected:
+        raise ValueError(f"{name} must have length {expected}")
 
 
 def _apply_se3_delta(
@@ -109,12 +41,12 @@ def _apply_se3_delta(
     delta_rho: list[float],
     delta_theta: list[float],
 ) -> AhrsSe3Transform:
-    rotation_delta: list[float] = _quat_from_rotvec(delta_theta)
-    rotation_wxyz: list[float] = _quat_mul(
+    rotation_delta: list[float] = quat_from_rotvec_wxyz(delta_theta)
+    rotation_wxyz: list[float] = quat_mul_wxyz(
         list(transform.rotation_wxyz),
         rotation_delta,
     )
-    rotation_wxyz = _quat_normalize(rotation_wxyz)
+    rotation_wxyz = quat_normalize_wxyz(rotation_wxyz)
     return AhrsSe3Transform(
         parent_frame=transform.parent_frame,
         child_frame=transform.child_frame,
@@ -165,9 +97,21 @@ def inject_error_state(
     delta_g: list[float] = delta_x[sl_g]
     delta_m: list[float] = delta_x[sl_m]
 
-    dq_wb: list[float] = _quat_from_rotvec(delta_theta)
-    q_wb: list[float] = _quat_mul(list(state.q_wb_wxyz), dq_wb)
-    q_wb = _quat_normalize(q_wb)
+    _require_block_length("delta_p", delta_p, 3)
+    _require_block_length("delta_v", delta_v, 3)
+    _require_block_length("delta_theta", delta_theta, 3)
+    _require_block_length("delta_omega", delta_omega, 3)
+    _require_block_length("delta_bg", delta_bg, 3)
+    _require_block_length("delta_ba", delta_ba, 3)
+    _require_block_length("delta_aa", delta_aa, 9)
+    _require_block_length("delta_xi_bi", delta_xi_bi, 6)
+    _require_block_length("delta_xi_bm", delta_xi_bm, 6)
+    _require_block_length("delta_g", delta_g, 3)
+    _require_block_length("delta_m", delta_m, 3)
+
+    dq_wb: list[float] = quat_from_rotvec_wxyz(delta_theta)
+    q_wb: list[float] = quat_mul_wxyz(list(state.q_wb_wxyz), dq_wb)
+    q_wb = quat_normalize_wxyz(q_wb)
 
     t_bi: AhrsSe3Transform = _apply_se3_delta(
         state.t_bi,
@@ -207,7 +151,7 @@ def inject_error_state(
             state.b_a_mps2[1] + delta_ba[1],
             state.b_a_mps2[2] + delta_ba[2],
         ],
-        a_a=[state.a_a[i] + delta_aa[i] for i in range(len(state.a_a))],
+        a_a=[state.a_a[i] + delta_aa[i] for i in range(9)],
         t_bi=t_bi,
         t_bm=t_bm,
         g_w_mps2=[

--- a/oasis_control/oasis_control/localization/ahrs/ahrs_linalg.py
+++ b/oasis_control/oasis_control/localization/ahrs/ahrs_linalg.py
@@ -1,0 +1,494 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""
+Small linear-algebra helpers for AHRS core math
+
+Matrices are represented as row-major lists of floats. Element (r, c) for a
+matrix with ``cols`` columns is stored at ``data[r * cols + c]``. This matches
+existing AHRS matrix conventions and keeps the math layer dependency-light.
+
+Covariance matrices are expected to be symmetric positive (semi-)definite (SPD
+or PSD). For AHRS updates, the innovation covariance ``S`` is the sum of the
+predicted measurement covariance and the measurement noise covariance. The
+Mahalanobis distance ``d^2 = nu^T S^{-1} nu`` is used for gating updates.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+
+
+Matrix = list[float]
+Vector = list[float]
+
+
+def _validate_matrix_size(a: Matrix, rows: int, cols: int, name: str) -> None:
+    if rows <= 0 or cols <= 0:
+        raise ValueError(f"{name} rows and cols must be positive")
+    expected: int = rows * cols
+    if len(a) != expected:
+        raise ValueError(f"{name} must have length {expected} for {rows}x{cols}")
+
+
+def _validate_vector_size(x: Vector, size: int, name: str) -> None:
+    if size <= 0:
+        raise ValueError(f"{name} size must be positive")
+    if len(x) != size:
+        raise ValueError(f"{name} must have length {size}")
+
+
+def _validate_mat3(a: Matrix, name: str) -> None:
+    if len(a) != 9:
+        raise ValueError(f"{name} must have length 9 for 3x3")
+
+
+def _diag_only_from_matrix(a: Matrix, diag_min: float) -> Matrix:
+    d0: float = max(a[0], diag_min)
+    d1: float = max(a[4], diag_min)
+    d2: float = max(a[8], diag_min)
+    return [
+        d0,
+        0.0,
+        0.0,
+        0.0,
+        d1,
+        0.0,
+        0.0,
+        0.0,
+        d2,
+    ]
+
+
+def mat_get(a: Matrix, rows: int, cols: int, r: int, c: int) -> float:
+    """Return a matrix entry using row-major indexing.
+
+    Args:
+        a: Matrix in row-major form
+        rows: Number of rows in the matrix
+        cols: Number of columns in the matrix
+        r: Row index
+        c: Column index
+
+    Returns:
+        Matrix value at (r, c)
+
+    Raises:
+        ValueError: If size or indices are invalid
+    """
+    _validate_matrix_size(a, rows, cols, "a")
+    if r < 0 or r >= rows or c < 0 or c >= cols:
+        raise ValueError("row or column index out of range")
+    return a[r * cols + c]
+
+
+def mat_set(a: Matrix, rows: int, cols: int, r: int, c: int, v: float) -> None:
+    """Set a matrix entry using row-major indexing.
+
+    Args:
+        a: Matrix in row-major form
+        rows: Number of rows in the matrix
+        cols: Number of columns in the matrix
+        r: Row index
+        c: Column index
+        v: Value to set
+
+    Raises:
+        ValueError: If size or indices are invalid
+    """
+    _validate_matrix_size(a, rows, cols, "a")
+    if r < 0 or r >= rows or c < 0 or c >= cols:
+        raise ValueError("row or column index out of range")
+    a[r * cols + c] = v
+
+
+def mat_transpose(a: Matrix, rows: int, cols: int) -> Matrix:
+    """Return the transpose of a matrix.
+
+    Args:
+        a: Matrix in row-major form
+        rows: Number of rows in the matrix
+        cols: Number of columns in the matrix
+
+    Returns:
+        Transposed matrix with shape (cols, rows)
+
+    Raises:
+        ValueError: If the input size is invalid
+    """
+    _validate_matrix_size(a, rows, cols, "a")
+    out: Matrix = [0.0] * (rows * cols)
+    for r in range(rows):
+        for c in range(cols):
+            out[c * rows + r] = a[r * cols + c]
+    return out
+
+
+def mat_mul(
+    a: Matrix,
+    a_rows: int,
+    a_cols: int,
+    b: Matrix,
+    b_rows: int,
+    b_cols: int,
+) -> Matrix:
+    """Multiply two matrices.
+
+    Args:
+        a: Left matrix in row-major form
+        a_rows: Number of rows in ``a``
+        a_cols: Number of columns in ``a``
+        b: Right matrix in row-major form
+        b_rows: Number of rows in ``b``
+        b_cols: Number of columns in ``b``
+
+    Returns:
+        Matrix product with shape (a_rows, b_cols)
+
+    Raises:
+        ValueError: If sizes are invalid or inner dimensions mismatch
+    """
+    _validate_matrix_size(a, a_rows, a_cols, "a")
+    _validate_matrix_size(b, b_rows, b_cols, "b")
+    if a_cols != b_rows:
+        raise ValueError("a_cols must match b_rows")
+    out: Matrix = [0.0] * (a_rows * b_cols)
+    for r in range(a_rows):
+        row_base: int = r * a_cols
+        for c in range(b_cols):
+            total: float = 0.0
+            for k in range(a_cols):
+                total += a[row_base + k] * b[k * b_cols + c]
+            out[r * b_cols + c] = total
+    return out
+
+
+def mat_vec_mul(a: Matrix, rows: int, cols: int, x: Vector) -> Vector:
+    """Multiply a matrix by a vector.
+
+    Args:
+        a: Matrix in row-major form
+        rows: Number of rows in the matrix
+        cols: Number of columns in the matrix
+        x: Vector with length ``cols``
+
+    Returns:
+        Vector with length ``rows``
+
+    Raises:
+        ValueError: If sizes are invalid
+    """
+    _validate_matrix_size(a, rows, cols, "a")
+    _validate_vector_size(x, cols, "x")
+    out: Vector = [0.0] * rows
+    for r in range(rows):
+        row_base: int = r * cols
+        total: float = 0.0
+        for c in range(cols):
+            total += a[row_base + c] * x[c]
+        out[r] = total
+    return out
+
+
+def mat_add(a: Matrix, b: Matrix) -> Matrix:
+    """Add two matrices of the same size.
+
+    Args:
+        a: Left matrix in row-major form
+        b: Right matrix in row-major form
+
+    Returns:
+        Element-wise sum of ``a`` and ``b``
+
+    Raises:
+        ValueError: If sizes do not match
+    """
+    if len(a) != len(b):
+        raise ValueError("matrices must have the same length")
+    return [ai + bi for ai, bi in zip(a, b, strict=True)]
+
+
+def mat_sub(a: Matrix, b: Matrix) -> Matrix:
+    """Subtract two matrices of the same size.
+
+    Args:
+        a: Left matrix in row-major form
+        b: Right matrix in row-major form
+
+    Returns:
+        Element-wise difference ``a - b``
+
+    Raises:
+        ValueError: If sizes do not match
+    """
+    if len(a) != len(b):
+        raise ValueError("matrices must have the same length")
+    return [ai - bi for ai, bi in zip(a, b, strict=True)]
+
+
+def mat_scale(a: Matrix, s: float) -> Matrix:
+    """Scale a matrix by a scalar.
+
+    Args:
+        a: Matrix in row-major form
+        s: Scalar multiplier
+
+    Returns:
+        Scaled matrix
+    """
+    return [ai * s for ai in a]
+
+
+def symmetrize(a: Matrix, n: int) -> Matrix:
+    """Return the symmetric part of a square matrix.
+
+    Symmetry is expected for covariance matrices and enforcing it reduces
+    numerical drift from repeated updates.
+
+    Args:
+        a: Matrix in row-major form
+        n: Matrix dimension
+
+    Returns:
+        Symmetric matrix ``0.5 * (A + A^T)``
+
+    Raises:
+        ValueError: If size is invalid
+    """
+    _validate_matrix_size(a, n, n, "a")
+    out: Matrix = [0.0] * (n * n)
+    for r in range(n):
+        for c in range(n):
+            # 0.5 is the average of A and A^T
+            out[r * n + c] = 0.5 * (a[r * n + c] + a[c * n + r])
+    return out
+
+
+def is_finite_seq(values: Sequence[float]) -> bool:
+    """Return True when all values are finite.
+
+    Args:
+        values: Sequence to validate
+
+    Returns:
+        True if every element is finite
+    """
+    return all(math.isfinite(value) for value in values)
+
+
+def mat3_det(a: Matrix) -> float:
+    """Return the determinant of a 3x3 matrix.
+
+    Args:
+        a: 3x3 matrix in row-major form
+
+    Returns:
+        Determinant of ``a``
+
+    Raises:
+        ValueError: If the matrix size is invalid
+    """
+    _validate_mat3(a, "a")
+    a00: float = a[0]
+    a01: float = a[1]
+    a02: float = a[2]
+    a10: float = a[3]
+    a11: float = a[4]
+    a12: float = a[5]
+    a20: float = a[6]
+    a21: float = a[7]
+    a22: float = a[8]
+    return (
+        a00 * (a11 * a22 - a12 * a21)
+        - a01 * (a10 * a22 - a12 * a20)
+        + a02 * (a10 * a21 - a11 * a20)
+    )
+
+
+def mat3_inv(a: Matrix) -> Matrix:
+    """Invert a 3x3 matrix for innovation covariance solves.
+
+    Args:
+        a: 3x3 matrix in row-major form
+
+    Returns:
+        Inverse of ``a``
+
+    Raises:
+        ValueError: If the matrix is singular or nearly singular
+    """
+    _validate_mat3(a, "a")
+    det: float = mat3_det(a)
+    # 1e-12 is the determinant threshold for near-singular matrices
+    if abs(det) < 1.0e-12:
+        raise ValueError("matrix is singular or nearly singular")
+
+    a00: float = a[0]
+    a01: float = a[1]
+    a02: float = a[2]
+    a10: float = a[3]
+    a11: float = a[4]
+    a12: float = a[5]
+    a20: float = a[6]
+    a21: float = a[7]
+    a22: float = a[8]
+
+    inv_det: float = 1.0 / det
+
+    return [
+        (a11 * a22 - a12 * a21) * inv_det,
+        (a02 * a21 - a01 * a22) * inv_det,
+        (a01 * a12 - a02 * a11) * inv_det,
+        (a12 * a20 - a10 * a22) * inv_det,
+        (a00 * a22 - a02 * a20) * inv_det,
+        (a02 * a10 - a00 * a12) * inv_det,
+        (a10 * a21 - a11 * a20) * inv_det,
+        (a01 * a20 - a00 * a21) * inv_det,
+        (a00 * a11 - a01 * a10) * inv_det,
+    ]
+
+
+def mat3_solve(a: Matrix, b: Vector) -> Vector:
+    """Solve a 3x3 linear system ``A x = b``.
+
+    This uses a direct inverse, which is acceptable for small 3x3 systems. A
+    future implementation may replace this with a Cholesky-based solver.
+
+    Args:
+        a: 3x3 matrix in row-major form
+        b: Right-hand vector with length 3
+
+    Returns:
+        Solution vector ``x`` with length 3
+
+    Raises:
+        ValueError: If the matrix or vector sizes are invalid
+    """
+    _validate_mat3(a, "a")
+    _validate_vector_size(b, 3, "b")
+    inv: Matrix = mat3_inv(a)
+    return mat_vec_mul(inv, 3, 3, b)
+
+
+def quad_form_3(x: Vector, a: Matrix) -> float:
+    """Return the quadratic form ``x^T A x`` for 3D vectors.
+
+    Args:
+        x: Vector with length 3
+        a: 3x3 matrix in row-major form
+
+    Returns:
+        Scalar quadratic form
+
+    Raises:
+        ValueError: If sizes are invalid
+    """
+    _validate_vector_size(x, 3, "x")
+    _validate_mat3(a, "a")
+    ax: Vector = mat_vec_mul(a, 3, 3, x)
+    return x[0] * ax[0] + x[1] * ax[1] + x[2] * ax[2]
+
+
+def clamp_diag_3(a: Matrix, diag_min: float, diag_max: float) -> Matrix:
+    """Clamp the diagonal of a 3x3 matrix.
+
+    Off-diagonal terms are preserved. This is a weak safeguard and does not
+    guarantee positive definiteness.
+
+    Args:
+        a: 3x3 matrix in row-major form
+        diag_min: Minimum value for diagonal entries
+        diag_max: Maximum value for diagonal entries
+
+    Returns:
+        Matrix with clamped diagonal entries
+
+    Raises:
+        ValueError: If sizes are invalid or clamp bounds are invalid
+    """
+    _validate_mat3(a, "a")
+    if diag_max < diag_min:
+        raise ValueError("diag_max must be >= diag_min")
+    out: Matrix = list(a)
+    out[0] = min(max(out[0], diag_min), diag_max)
+    out[4] = min(max(out[4], diag_min), diag_max)
+    out[8] = min(max(out[8], diag_min), diag_max)
+    return out
+
+
+def project_to_symmetric_psd_3(a: Matrix, diag_min: float) -> Matrix:
+    """Project a 3x3 matrix to a symmetric PSD-like matrix.
+
+    This is a pragmatic approximation used for adaptive covariance updates. The
+    matrix is symmetrized, diagonal entries are clamped, and if the determinant
+    is negative or the inverse fails, the result falls back to a diagonal-only
+    matrix.
+
+    Args:
+        a: 3x3 matrix in row-major form
+        diag_min: Minimum value for diagonal entries
+
+    Returns:
+        Symmetric, PSD-like matrix
+
+    Raises:
+        ValueError: If size is invalid
+    """
+    _validate_mat3(a, "a")
+    symmetric: Matrix = symmetrize(a, 3)
+    clamped: Matrix = clamp_diag_3(symmetric, diag_min, math.inf)
+
+    # Note: det > 0 is not sufficient for SPD; this is a cheap heuristic
+    # paired with an invertibility check as a pragmatic safeguard.
+    det: float = mat3_det(clamped)
+
+    if det < 0.0:
+        return _diag_only_from_matrix(clamped, diag_min)
+    try:
+        mat3_inv(clamped)
+    except ValueError:
+        return _diag_only_from_matrix(clamped, diag_min)
+    return clamped
+
+
+def innovation_covariance(s_hat: Matrix, r: Matrix) -> Matrix:
+    """Return innovation covariance ``S = S_hat + R``.
+
+    Args:
+        s_hat: Predicted measurement covariance in row-major form
+        r: Measurement noise covariance in row-major form
+
+    Returns:
+        Innovation covariance in row-major form
+
+    Raises:
+        ValueError: If sizes do not match
+    """
+    return mat_add(s_hat, r)
+
+
+def mahalanobis_d2_3(nu: Vector, s: Matrix) -> float:
+    """Return the squared Mahalanobis distance for a 3D innovation.
+
+    Args:
+        nu: Innovation vector with length 3
+        s: Innovation covariance matrix (3x3)
+
+    Returns:
+        Squared Mahalanobis distance ``nu^T S^{-1} nu``
+
+    Raises:
+        ValueError: If sizes are invalid or ``S`` is singular
+    """
+    _validate_vector_size(nu, 3, "nu")
+    _validate_mat3(s, "s")
+    sol: Vector = mat3_solve(s, nu)
+    return nu[0] * sol[0] + nu[1] * sol[1] + nu[2] * sol[2]

--- a/oasis_control/oasis_control/localization/ahrs/ahrs_params.py
+++ b/oasis_control/oasis_control/localization/ahrs/ahrs_params.py
@@ -1,0 +1,171 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""
+ROS parameter helpers for the AHRS node
+"""
+
+from __future__ import annotations
+
+import rclpy.node
+
+from oasis_control.localization.ahrs.ahrs_config import AhrsConfig
+
+
+PARAM_WORLD_FRAME_ID: str = "world_frame_id"
+PARAM_ODOM_FRAME_ID: str = "odom_frame_id"
+PARAM_BODY_FRAME_ID: str = "body_frame_id"
+
+PARAM_T_BUFFER_SEC: str = "t_buffer_sec"
+PARAM_EPS_WALL_FUTURE_SEC: str = "epsilon_wall_future_sec"
+PARAM_DT_CLOCK_JUMP_MAX_SEC: str = "dt_clock_jump_max_sec"
+PARAM_DT_IMU_MAX_SEC: str = "dt_imu_max_sec"
+PARAM_GYRO_GATE_D2_THRESHOLD: str = "gyro_gate_d2_threshold"
+
+PARAM_MAG_ALPHA: str = "mag_alpha"
+PARAM_MAG_R_MIN: str = "mag_r_min"
+PARAM_MAG_R_MAX: str = "mag_r_max"
+PARAM_MAG_R0: str = "mag_r0"
+
+PARAM_Q_V: str = "q_v"
+PARAM_Q_W: str = "q_w"
+PARAM_Q_BG: str = "q_bg"
+PARAM_Q_BA: str = "q_ba"
+PARAM_Q_A: str = "q_a"
+PARAM_Q_BI: str = "q_bi"
+PARAM_Q_BM: str = "q_bm"
+PARAM_Q_G: str = "q_g"
+PARAM_Q_M: str = "q_m"
+
+DEFAULT_WORLD_FRAME_ID: str = "world"
+DEFAULT_ODOM_FRAME_ID: str = "odom"
+DEFAULT_BODY_FRAME_ID: str = "base_link"
+
+DEFAULT_T_BUFFER_SEC: float = 0.5
+DEFAULT_EPS_WALL_FUTURE_SEC: float = 0.1
+DEFAULT_DT_CLOCK_JUMP_MAX_SEC: float = 1.0
+DEFAULT_DT_IMU_MAX_SEC: float = 0.5
+DEFAULT_GYRO_GATE_D2_THRESHOLD: float = 9.0
+
+DEFAULT_MAG_ALPHA: float = 1.0
+DEFAULT_MAG_R_MIN: list[float] = [0.0] * 9
+DEFAULT_MAG_R_MAX: list[float] = [0.0] * 9
+DEFAULT_MAG_R0: list[float] = [0.0] * 9
+
+DEFAULT_Q_V: float = 0.0
+DEFAULT_Q_W: float = 0.0
+DEFAULT_Q_BG: float = 0.0
+DEFAULT_Q_BA: float = 0.0
+DEFAULT_Q_A: float = 0.0
+DEFAULT_Q_BI: float = 0.0
+DEFAULT_Q_BM: float = 0.0
+DEFAULT_Q_G: float = 0.0
+DEFAULT_Q_M: float = 0.0
+
+
+def declare_ahrs_params(node: rclpy.node.Node) -> None:
+    """
+    Declare AHRS ROS parameters with defaults
+    """
+
+    node.declare_parameter(PARAM_WORLD_FRAME_ID, DEFAULT_WORLD_FRAME_ID)
+    node.declare_parameter(PARAM_ODOM_FRAME_ID, DEFAULT_ODOM_FRAME_ID)
+    node.declare_parameter(PARAM_BODY_FRAME_ID, DEFAULT_BODY_FRAME_ID)
+
+    node.declare_parameter(PARAM_T_BUFFER_SEC, DEFAULT_T_BUFFER_SEC)
+    node.declare_parameter(PARAM_EPS_WALL_FUTURE_SEC, DEFAULT_EPS_WALL_FUTURE_SEC)
+    node.declare_parameter(PARAM_DT_CLOCK_JUMP_MAX_SEC, DEFAULT_DT_CLOCK_JUMP_MAX_SEC)
+    node.declare_parameter(PARAM_DT_IMU_MAX_SEC, DEFAULT_DT_IMU_MAX_SEC)
+    node.declare_parameter(
+        PARAM_GYRO_GATE_D2_THRESHOLD,
+        DEFAULT_GYRO_GATE_D2_THRESHOLD,
+    )
+
+    node.declare_parameter(PARAM_MAG_ALPHA, DEFAULT_MAG_ALPHA)
+    node.declare_parameter(PARAM_MAG_R_MIN, DEFAULT_MAG_R_MIN)
+    node.declare_parameter(PARAM_MAG_R_MAX, DEFAULT_MAG_R_MAX)
+    node.declare_parameter(PARAM_MAG_R0, DEFAULT_MAG_R0)
+
+    node.declare_parameter(PARAM_Q_V, DEFAULT_Q_V)
+    node.declare_parameter(PARAM_Q_W, DEFAULT_Q_W)
+    node.declare_parameter(PARAM_Q_BG, DEFAULT_Q_BG)
+    node.declare_parameter(PARAM_Q_BA, DEFAULT_Q_BA)
+    node.declare_parameter(PARAM_Q_A, DEFAULT_Q_A)
+    node.declare_parameter(PARAM_Q_BI, DEFAULT_Q_BI)
+    node.declare_parameter(PARAM_Q_BM, DEFAULT_Q_BM)
+    node.declare_parameter(PARAM_Q_G, DEFAULT_Q_G)
+    node.declare_parameter(PARAM_Q_M, DEFAULT_Q_M)
+
+
+def load_ahrs_config(node: rclpy.node.Node) -> AhrsConfig:
+    """
+    Load AHRS configuration from ROS parameters
+    """
+
+    world_frame_id: str = str(node.get_parameter(PARAM_WORLD_FRAME_ID).value)
+    odom_frame_id: str = str(node.get_parameter(PARAM_ODOM_FRAME_ID).value)
+    body_frame_id: str = str(node.get_parameter(PARAM_BODY_FRAME_ID).value)
+
+    t_buffer_sec: float = float(node.get_parameter(PARAM_T_BUFFER_SEC).value)
+    epsilon_wall_future_sec: float = float(
+        node.get_parameter(PARAM_EPS_WALL_FUTURE_SEC).value
+    )
+    dt_clock_jump_max_sec: float = float(
+        node.get_parameter(PARAM_DT_CLOCK_JUMP_MAX_SEC).value
+    )
+    dt_imu_max_sec: float = float(node.get_parameter(PARAM_DT_IMU_MAX_SEC).value)
+    gyro_gate_d2_threshold: float = float(
+        node.get_parameter(PARAM_GYRO_GATE_D2_THRESHOLD).value
+    )
+
+    mag_alpha: float = float(node.get_parameter(PARAM_MAG_ALPHA).value)
+    mag_r_min: list[float] = [
+        float(value) for value in node.get_parameter(PARAM_MAG_R_MIN).value
+    ]
+    mag_r_max: list[float] = [
+        float(value) for value in node.get_parameter(PARAM_MAG_R_MAX).value
+    ]
+    mag_r0: list[float] = [
+        float(value) for value in node.get_parameter(PARAM_MAG_R0).value
+    ]
+
+    q_v: float = float(node.get_parameter(PARAM_Q_V).value)
+    q_w: float = float(node.get_parameter(PARAM_Q_W).value)
+    q_bg: float = float(node.get_parameter(PARAM_Q_BG).value)
+    q_ba: float = float(node.get_parameter(PARAM_Q_BA).value)
+    q_a: float = float(node.get_parameter(PARAM_Q_A).value)
+    q_bi: float = float(node.get_parameter(PARAM_Q_BI).value)
+    q_bm: float = float(node.get_parameter(PARAM_Q_BM).value)
+    q_g: float = float(node.get_parameter(PARAM_Q_G).value)
+    q_m: float = float(node.get_parameter(PARAM_Q_M).value)
+
+    return AhrsConfig(
+        world_frame_id=world_frame_id,
+        odom_frame_id=odom_frame_id,
+        body_frame_id=body_frame_id,
+        t_buffer_sec=t_buffer_sec,
+        epsilon_wall_future_sec=epsilon_wall_future_sec,
+        dt_clock_jump_max_sec=dt_clock_jump_max_sec,
+        dt_imu_max_sec=dt_imu_max_sec,
+        gyro_gate_d2_threshold=gyro_gate_d2_threshold,
+        mag_alpha=mag_alpha,
+        mag_r_min=mag_r_min,
+        mag_r_max=mag_r_max,
+        mag_r0=mag_r0,
+        q_v=q_v,
+        q_w=q_w,
+        q_bg=q_bg,
+        q_ba=q_ba,
+        q_a=q_a,
+        q_bi=q_bi,
+        q_bm=q_bm,
+        q_g=q_g,
+        q_m=q_m,
+    )

--- a/oasis_control/oasis_control/localization/ahrs/ahrs_predict.py
+++ b/oasis_control/oasis_control/localization/ahrs/ahrs_predict.py
@@ -1,0 +1,267 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""
+Nominal and covariance propagation for the AHRS core
+
+The prediction layer advances the nominal state and covariance forward in
+time between measurement updates. The nominal state follows a simple kinematic
+model with zero-mean random-walk terms. The covariance uses a first-order
+discretization of the linearized error-state dynamics.
+
+Quaternion conventions:
+    * Quaternions are stored in wxyz order
+    * q_wb represents the rotation from world to body
+    * Composition uses q_new = q_wb ⊗ dq, where dq comes from Exp(omega * dt)
+"""
+
+from __future__ import annotations
+
+import math
+
+from oasis_control.localization.ahrs.ahrs_config import AhrsConfig
+from oasis_control.localization.ahrs.ahrs_error_state import AhrsErrorStateLayout
+from oasis_control.localization.ahrs.ahrs_linalg import mat_add
+from oasis_control.localization.ahrs.ahrs_linalg import mat_mul
+from oasis_control.localization.ahrs.ahrs_linalg import mat_transpose
+from oasis_control.localization.ahrs.ahrs_linalg import symmetrize
+from oasis_control.localization.ahrs.ahrs_state import AhrsNominalState
+
+
+def _quat_mul(q_left: list[float], q_right: list[float]) -> list[float]:
+    """
+    Multiply two quaternions in wxyz order
+    """
+
+    w1: float = q_left[0]
+    x1: float = q_left[1]
+    y1: float = q_left[2]
+    z1: float = q_left[3]
+
+    w2: float = q_right[0]
+    x2: float = q_right[1]
+    y2: float = q_right[2]
+    z2: float = q_right[3]
+
+    return [
+        w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2,
+        w1 * x2 + x1 * w2 + y1 * z2 - z1 * y2,
+        w1 * y2 - x1 * z2 + y1 * w2 + z1 * x2,
+        w1 * z2 + x1 * y2 - y1 * x2 + z1 * w2,
+    ]
+
+
+def _quat_normalize(q_wxyz: list[float]) -> list[float]:
+    """
+    Normalize a quaternion in wxyz order
+    """
+
+    norm: float = math.sqrt(
+        q_wxyz[0] * q_wxyz[0]
+        + q_wxyz[1] * q_wxyz[1]
+        + q_wxyz[2] * q_wxyz[2]
+        + q_wxyz[3] * q_wxyz[3]
+    )
+    if norm <= 0.0:
+        raise ValueError("Quaternion norm must be positive")
+    inv: float = 1.0 / norm
+    return [
+        q_wxyz[0] * inv,
+        q_wxyz[1] * inv,
+        q_wxyz[2] * inv,
+        q_wxyz[3] * inv,
+    ]
+
+
+def _quat_from_rotvec(rotvec: list[float]) -> list[float]:
+    """
+    Build a quaternion from a rotation vector using Exp(omega * dt)
+
+    The rotation vector magnitude is the rotation angle in radians. For small
+    angles, the series expansion keeps the result numerically stable. The
+    small-angle branch can drift slightly from unit length, so we normalize the
+    result before returning it.
+    """
+
+    rx: float = rotvec[0]
+    ry: float = rotvec[1]
+    rz: float = rotvec[2]
+    angle: float = math.sqrt(rx * rx + ry * ry + rz * rz)
+
+    # Rotation magnitude threshold in rad for small-angle series
+    small_angle_rad: float = 1.0e-12
+
+    if angle < small_angle_rad:
+        # Small-angle approximation for sin(theta/2) ~= theta/2
+        dq_wb: list[float] = [1.0, 0.5 * rx, 0.5 * ry, 0.5 * rz]
+        return _quat_normalize(dq_wb)
+
+    # Half-angle term used in quaternion exponential
+    half_angle: float = 0.5 * angle
+    sin_half: float = math.sin(half_angle)
+    inv_angle: float = 1.0 / angle
+    return [
+        math.cos(half_angle),
+        rx * inv_angle * sin_half,
+        ry * inv_angle * sin_half,
+        rz * inv_angle * sin_half,
+    ]
+
+
+def predict_nominal(state: AhrsNominalState, dt_sec: float) -> AhrsNominalState:
+    """
+    Propagate the nominal AHRS state forward in time
+
+    Position and velocity follow a constant-acceleration model using the
+    gravity vector from the nominal state. Orientation integrates the nominal
+    angular rate with a small-angle exponential map.
+    """
+
+    if dt_sec < 0.0:
+        raise ValueError("dt_sec must be non-negative")
+    if dt_sec == 0.0:
+        return AhrsNominalState(
+            p_wb_m=list(state.p_wb_m),
+            v_wb_mps=list(state.v_wb_mps),
+            q_wb_wxyz=list(state.q_wb_wxyz),
+            omega_wb_rps=list(state.omega_wb_rps),
+            b_g_rps=list(state.b_g_rps),
+            b_a_mps2=list(state.b_a_mps2),
+            a_a=list(state.a_a),
+            t_bi=state.t_bi,
+            t_bm=state.t_bm,
+            g_w_mps2=list(state.g_w_mps2),
+            m_w_t=list(state.m_w_t),
+        )
+
+    p_wb_m: list[float] = [
+        state.p_wb_m[0] + state.v_wb_mps[0] * dt_sec,
+        state.p_wb_m[1] + state.v_wb_mps[1] * dt_sec,
+        state.p_wb_m[2] + state.v_wb_mps[2] * dt_sec,
+    ]
+    v_wb_mps: list[float] = [
+        state.v_wb_mps[0] + state.g_w_mps2[0] * dt_sec,
+        state.v_wb_mps[1] + state.g_w_mps2[1] * dt_sec,
+        state.v_wb_mps[2] + state.g_w_mps2[2] * dt_sec,
+    ]
+
+    rotvec: list[float] = [
+        state.omega_wb_rps[0] * dt_sec,
+        state.omega_wb_rps[1] * dt_sec,
+        state.omega_wb_rps[2] * dt_sec,
+    ]
+    dq_wb: list[float] = _quat_from_rotvec(rotvec)
+    # Normalize after composition to remove any residual numerical drift
+    q_wb_wxyz: list[float] = _quat_normalize(_quat_mul(state.q_wb_wxyz, dq_wb))
+
+    return AhrsNominalState(
+        p_wb_m=p_wb_m,
+        v_wb_mps=v_wb_mps,
+        q_wb_wxyz=q_wb_wxyz,
+        omega_wb_rps=list(state.omega_wb_rps),
+        b_g_rps=list(state.b_g_rps),
+        b_a_mps2=list(state.b_a_mps2),
+        a_a=list(state.a_a),
+        t_bi=state.t_bi,
+        t_bm=state.t_bm,
+        g_w_mps2=list(state.g_w_mps2),
+        m_w_t=list(state.m_w_t),
+    )
+
+
+def _add_isotropic_noise(
+    q: list[float], dim: int, sl: slice, intensity: float, dt_sec: float
+) -> None:
+    """
+    Add isotropic random-walk noise to the diagonal of a block
+    """
+
+    if intensity <= 0.0 or dt_sec <= 0.0:
+        return
+
+    block_dim: int = sl.stop - sl.start
+    for i in range(block_dim):
+        idx: int = (sl.start + i) * dim + (sl.start + i)
+        q[idx] += intensity * dt_sec
+
+
+def predict_covariance(
+    layout: AhrsErrorStateLayout,
+    p: list[float],
+    dt_sec: float,
+    config: AhrsConfig,
+) -> list[float]:
+    """
+    Propagate covariance using a first-order error-state model
+
+    The discrete-time approximation uses
+        F = I + A * dt
+        P_next = F P F^T + Q
+    where Q is built from isotropic random-walk process noise blocks.
+    """
+
+    if dt_sec < 0.0:
+        raise ValueError("dt_sec must be non-negative")
+    if dt_sec == 0.0:
+        return list(p)
+
+    dim: int = layout.dim
+    if len(p) != dim * dim:
+        raise ValueError("p must have length dim * dim")
+
+    f: list[float] = [0.0] * (dim * dim)
+    for r in range(dim):
+        f[r * dim + r] = 1.0
+
+    sl_p: slice = layout.sl_p()
+    sl_v: slice = layout.sl_v()
+    sl_theta: slice = layout.sl_theta()
+    sl_omega: slice = layout.sl_omega()
+    sl_g: slice = layout.sl_g()
+
+    # Minimal model: p <- v, v <- g, theta <- omega, coupling deferred
+    for i in range(3):
+        f[(sl_p.start + i) * dim + (sl_v.start + i)] += dt_sec
+        f[(sl_v.start + i) * dim + (sl_g.start + i)] += dt_sec
+        f[(sl_theta.start + i) * dim + (sl_omega.start + i)] += dt_sec
+
+    temp: list[float] = mat_mul(f, dim, dim, p, dim, dim)
+    f_t: list[float] = mat_transpose(f, dim, dim)
+    p_next: list[float] = mat_mul(temp, dim, dim, f_t, dim, dim)
+
+    q: list[float] = [0.0] * (dim * dim)
+    _add_isotropic_noise(q, dim, layout.sl_v(), config.q_v, dt_sec)
+    _add_isotropic_noise(q, dim, layout.sl_omega(), config.q_w, dt_sec)
+    _add_isotropic_noise(q, dim, layout.sl_bg(), config.q_bg, dt_sec)
+    _add_isotropic_noise(q, dim, layout.sl_ba(), config.q_ba, dt_sec)
+    _add_isotropic_noise(q, dim, layout.sl_Aa(), config.q_a, dt_sec)
+    _add_isotropic_noise(q, dim, layout.sl_xi_bi(), config.q_bi, dt_sec)
+    _add_isotropic_noise(q, dim, layout.sl_xi_bm(), config.q_bm, dt_sec)
+    _add_isotropic_noise(q, dim, layout.sl_g(), config.q_g, dt_sec)
+    _add_isotropic_noise(q, dim, layout.sl_m(), config.q_m, dt_sec)
+
+    p_next = mat_add(p_next, q)
+    return symmetrize(p_next, dim)
+
+
+def predict_step(
+    layout: AhrsErrorStateLayout,
+    state: AhrsNominalState,
+    p: list[float],
+    dt_sec: float,
+    config: AhrsConfig,
+) -> tuple[AhrsNominalState, list[float]]:
+    """
+    Propagate nominal state and covariance over a time step
+    """
+
+    x_next: AhrsNominalState = predict_nominal(state, dt_sec)
+    p_next: list[float] = predict_covariance(layout, p, dt_sec, config)
+    return x_next, p_next

--- a/oasis_control/oasis_control/localization/ahrs/ahrs_predict.py
+++ b/oasis_control/oasis_control/localization/ahrs/ahrs_predict.py
@@ -24,95 +24,16 @@ Quaternion conventions:
 
 from __future__ import annotations
 
-import math
-
 from oasis_control.localization.ahrs.ahrs_config import AhrsConfig
 from oasis_control.localization.ahrs.ahrs_error_state import AhrsErrorStateLayout
 from oasis_control.localization.ahrs.ahrs_linalg import mat_add
 from oasis_control.localization.ahrs.ahrs_linalg import mat_mul
 from oasis_control.localization.ahrs.ahrs_linalg import mat_transpose
 from oasis_control.localization.ahrs.ahrs_linalg import symmetrize
+from oasis_control.localization.ahrs.ahrs_quat import quat_from_rotvec_wxyz
+from oasis_control.localization.ahrs.ahrs_quat import quat_mul_wxyz
+from oasis_control.localization.ahrs.ahrs_quat import quat_normalize_wxyz
 from oasis_control.localization.ahrs.ahrs_state import AhrsNominalState
-
-
-def _quat_mul(q_left: list[float], q_right: list[float]) -> list[float]:
-    """
-    Multiply two quaternions in wxyz order
-    """
-
-    w1: float = q_left[0]
-    x1: float = q_left[1]
-    y1: float = q_left[2]
-    z1: float = q_left[3]
-
-    w2: float = q_right[0]
-    x2: float = q_right[1]
-    y2: float = q_right[2]
-    z2: float = q_right[3]
-
-    return [
-        w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2,
-        w1 * x2 + x1 * w2 + y1 * z2 - z1 * y2,
-        w1 * y2 - x1 * z2 + y1 * w2 + z1 * x2,
-        w1 * z2 + x1 * y2 - y1 * x2 + z1 * w2,
-    ]
-
-
-def _quat_normalize(q_wxyz: list[float]) -> list[float]:
-    """
-    Normalize a quaternion in wxyz order
-    """
-
-    norm: float = math.sqrt(
-        q_wxyz[0] * q_wxyz[0]
-        + q_wxyz[1] * q_wxyz[1]
-        + q_wxyz[2] * q_wxyz[2]
-        + q_wxyz[3] * q_wxyz[3]
-    )
-    if norm <= 0.0:
-        raise ValueError("Quaternion norm must be positive")
-    inv: float = 1.0 / norm
-    return [
-        q_wxyz[0] * inv,
-        q_wxyz[1] * inv,
-        q_wxyz[2] * inv,
-        q_wxyz[3] * inv,
-    ]
-
-
-def _quat_from_rotvec(rotvec: list[float]) -> list[float]:
-    """
-    Build a quaternion from a rotation vector using Exp(omega * dt)
-
-    The rotation vector magnitude is the rotation angle in radians. For small
-    angles, the series expansion keeps the result numerically stable. The
-    small-angle branch can drift slightly from unit length, so we normalize the
-    result before returning it.
-    """
-
-    rx: float = rotvec[0]
-    ry: float = rotvec[1]
-    rz: float = rotvec[2]
-    angle: float = math.sqrt(rx * rx + ry * ry + rz * rz)
-
-    # Rotation magnitude threshold in rad for small-angle series
-    small_angle_rad: float = 1.0e-12
-
-    if angle < small_angle_rad:
-        # Small-angle approximation for sin(theta/2) ~= theta/2
-        dq_wb: list[float] = [1.0, 0.5 * rx, 0.5 * ry, 0.5 * rz]
-        return _quat_normalize(dq_wb)
-
-    # Half-angle term used in quaternion exponential
-    half_angle: float = 0.5 * angle
-    sin_half: float = math.sin(half_angle)
-    inv_angle: float = 1.0 / angle
-    return [
-        math.cos(half_angle),
-        rx * inv_angle * sin_half,
-        ry * inv_angle * sin_half,
-        rz * inv_angle * sin_half,
-    ]
 
 
 def predict_nominal(state: AhrsNominalState, dt_sec: float) -> AhrsNominalState:
@@ -157,9 +78,11 @@ def predict_nominal(state: AhrsNominalState, dt_sec: float) -> AhrsNominalState:
         state.omega_wb_rps[1] * dt_sec,
         state.omega_wb_rps[2] * dt_sec,
     ]
-    dq_wb: list[float] = _quat_from_rotvec(rotvec)
+    dq_wb: list[float] = quat_from_rotvec_wxyz(rotvec)
     # Normalize after composition to remove any residual numerical drift
-    q_wb_wxyz: list[float] = _quat_normalize(_quat_mul(state.q_wb_wxyz, dq_wb))
+    q_wb_wxyz: list[float] = quat_normalize_wxyz(
+        quat_mul_wxyz(state.q_wb_wxyz, dq_wb)
+    )
 
     return AhrsNominalState(
         p_wb_m=p_wb_m,

--- a/oasis_control/oasis_control/localization/ahrs/ahrs_publishers.py
+++ b/oasis_control/oasis_control/localization/ahrs/ahrs_publishers.py
@@ -1,0 +1,155 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""
+ROS publishers for AHRS localization
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import rclpy.node
+import rclpy.publisher
+from geometry_msgs.msg import PoseWithCovarianceStamped
+from geometry_msgs.msg import TransformStamped
+from nav_msgs.msg import Odometry as OdometryMsg
+from rclpy.qos import QoSProfile
+from tf2_ros import TransformBroadcaster
+
+from oasis_control.localization.ahrs.ahrs_config import AhrsConfig
+from oasis_control.localization.ahrs.ahrs_ros_msgs import to_diag_msg
+from oasis_control.localization.ahrs.ahrs_ros_msgs import to_odom_msg
+from oasis_control.localization.ahrs.ahrs_ros_msgs import to_pose_cov_msg
+from oasis_control.localization.ahrs.ahrs_ros_msgs import to_state_msg
+from oasis_control.localization.ahrs.ahrs_ros_msgs import to_tf_msgs
+from oasis_control.localization.ahrs.ahrs_ros_msgs import to_update_report_msg
+from oasis_control.localization.ahrs.ahrs_types import AhrsOutputs
+from oasis_control.localization.ahrs.ahrs_types import AhrsUpdateData
+from oasis_msgs.msg import AhrsDiagnostics as AhrsDiagnosticsMsg
+from oasis_msgs.msg import AhrsState as AhrsStateMsg
+from oasis_msgs.msg import EkfUpdateReport as EkfUpdateReportMsg
+
+
+ACCEL_UPDATE_TOPIC: str = "ahrs/updates/accel"
+GYRO_UPDATE_TOPIC: str = "ahrs/updates/gyro"
+MAG_UPDATE_TOPIC: str = "ahrs/updates/mag"
+
+EXTRINSICS_T_BI_TOPIC: str = "ahrs/extrinsics/t_bi"
+EXTRINSICS_T_BM_TOPIC: str = "ahrs/extrinsics/t_bm"
+
+ODOM_TOPIC: str = "ahrs/odom"
+WORLD_ODOM_TOPIC: str = "ahrs/world_odom"
+
+STATE_TOPIC: str = "ahrs/state"
+DIAG_TOPIC: str = "ahrs/diag"
+
+
+class AhrsPublishers:
+    """
+    ROS publisher wrapper for AHRS outputs
+    """
+
+    def __init__(
+        self, node: rclpy.node.Node, config: AhrsConfig, qos: QoSProfile
+    ) -> None:
+        self._node: rclpy.node.Node = node
+        self._config: AhrsConfig = config
+
+        self._tf_broadcaster: TransformBroadcaster = TransformBroadcaster(node)
+
+        self._odom_pub: rclpy.publisher.Publisher = node.create_publisher(
+            OdometryMsg, ODOM_TOPIC, qos
+        )
+        self._world_odom_pub: rclpy.publisher.Publisher = node.create_publisher(
+            OdometryMsg, WORLD_ODOM_TOPIC, qos
+        )
+        self._t_bi_pub: rclpy.publisher.Publisher = node.create_publisher(
+            PoseWithCovarianceStamped, EXTRINSICS_T_BI_TOPIC, qos
+        )
+        self._t_bm_pub: rclpy.publisher.Publisher = node.create_publisher(
+            PoseWithCovarianceStamped, EXTRINSICS_T_BM_TOPIC, qos
+        )
+        self._state_pub: rclpy.publisher.Publisher = node.create_publisher(
+            AhrsStateMsg, STATE_TOPIC, qos
+        )
+        self._diag_pub: rclpy.publisher.Publisher = node.create_publisher(
+            AhrsDiagnosticsMsg, DIAG_TOPIC, qos
+        )
+        self._gyro_update_pub: rclpy.publisher.Publisher = node.create_publisher(
+            EkfUpdateReportMsg, GYRO_UPDATE_TOPIC, qos
+        )
+        self._accel_update_pub: rclpy.publisher.Publisher = node.create_publisher(
+            EkfUpdateReportMsg, ACCEL_UPDATE_TOPIC, qos
+        )
+        self._mag_update_pub: rclpy.publisher.Publisher = node.create_publisher(
+            EkfUpdateReportMsg, MAG_UPDATE_TOPIC, qos
+        )
+
+    def publish_outputs(self, outputs: AhrsOutputs) -> None:
+        self._publish_update(outputs.gyro_update, self._gyro_update_pub)
+        self._publish_update(outputs.accel_update, self._accel_update_pub)
+        self._publish_update(outputs.mag_update, self._mag_update_pub)
+
+        if not outputs.frontier_advanced:
+            return
+
+        if outputs.t_filter is None:
+            return
+
+        if outputs.frame_transforms is not None:
+            tf_msgs: list[TransformStamped] = to_tf_msgs(
+                outputs.t_filter, outputs.frame_transforms, self._config
+            )
+            self._tf_broadcaster.sendTransform(tf_msgs)
+
+            odom_msg: OdometryMsg = to_odom_msg(
+                outputs.t_filter,
+                outputs.frame_transforms.t_odom_base,
+                frame_id=self._config.odom_frame_id,
+                child_frame_id=self._config.body_frame_id,
+            )
+            world_odom_msg: OdometryMsg = to_odom_msg(
+                outputs.t_filter,
+                outputs.frame_transforms.t_world_odom,
+                frame_id=self._config.world_frame_id,
+                child_frame_id=self._config.odom_frame_id,
+            )
+            self._odom_pub.publish(odom_msg)
+            self._world_odom_pub.publish(world_odom_msg)
+
+        if outputs.state is not None:
+            state_msg: AhrsStateMsg = to_state_msg(outputs.state)
+            self._state_pub.publish(state_msg)
+
+            t_bi_msg: PoseWithCovarianceStamped = to_pose_cov_msg(
+                outputs.t_filter, outputs.state.t_bi
+            )
+            t_bm_msg: PoseWithCovarianceStamped = to_pose_cov_msg(
+                outputs.t_filter, outputs.state.t_bm
+            )
+            self._t_bi_pub.publish(t_bi_msg)
+            self._t_bm_pub.publish(t_bm_msg)
+
+        if outputs.diagnostics is not None:
+            diag_msg: AhrsDiagnosticsMsg = to_diag_msg(outputs.diagnostics)
+            diag_msg.header.frame_id = self._config.world_frame_id
+            self._diag_pub.publish(diag_msg)
+
+    def _publish_update(
+        self,
+        update: Optional[AhrsUpdateData],
+        publisher: rclpy.publisher.Publisher,
+    ) -> None:
+        if update is None:
+            return
+
+        msg: EkfUpdateReportMsg = to_update_report_msg(update)
+        publisher.publish(msg)

--- a/oasis_control/oasis_control/localization/ahrs/ahrs_quat.py
+++ b/oasis_control/oasis_control/localization/ahrs/ahrs_quat.py
@@ -1,0 +1,99 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""
+Quaternion helpers for the AHRS core math layer
+
+Conventions:
+    * Quaternions are stored in wxyz order
+    * The nominal update uses q_new = q_nominal ⊗ Exp(delta_theta)
+    * delta_theta is a rotation vector with magnitude equal to the rotation
+      angle in radians
+    * The small-angle branch uses the series expansion and normalizes the
+      result for numerical stability
+"""
+
+from __future__ import annotations
+
+import math
+
+
+def quat_mul_wxyz(q_left: list[float], q_right: list[float]) -> list[float]:
+    """
+    Multiply two quaternions in wxyz order
+    """
+
+    w1: float = q_left[0]
+    x1: float = q_left[1]
+    y1: float = q_left[2]
+    z1: float = q_left[3]
+
+    w2: float = q_right[0]
+    x2: float = q_right[1]
+    y2: float = q_right[2]
+    z2: float = q_right[3]
+
+    return [
+        w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2,
+        w1 * x2 + x1 * w2 + y1 * z2 - z1 * y2,
+        w1 * y2 - x1 * z2 + y1 * w2 + z1 * x2,
+        w1 * z2 + x1 * y2 - y1 * x2 + z1 * w2,
+    ]
+
+
+def quat_normalize_wxyz(q_wxyz: list[float]) -> list[float]:
+    """
+    Normalize a quaternion in wxyz order
+    """
+
+    norm: float = math.sqrt(
+        q_wxyz[0] * q_wxyz[0]
+        + q_wxyz[1] * q_wxyz[1]
+        + q_wxyz[2] * q_wxyz[2]
+        + q_wxyz[3] * q_wxyz[3]
+    )
+    if norm <= 0.0:
+        raise ValueError("Quaternion norm must be positive")
+    inv: float = 1.0 / norm
+    return [
+        q_wxyz[0] * inv,
+        q_wxyz[1] * inv,
+        q_wxyz[2] * inv,
+        q_wxyz[3] * inv,
+    ]
+
+
+def quat_from_rotvec_wxyz(rotvec: list[float]) -> list[float]:
+    """
+    Build a quaternion from a rotation vector using Exp(delta_theta)
+    """
+
+    rx: float = rotvec[0]
+    ry: float = rotvec[1]
+    rz: float = rotvec[2]
+    angle: float = math.sqrt(rx * rx + ry * ry + rz * rz)
+
+    # Rotation magnitude threshold in rad for small-angle series
+    small_angle_rad: float = 1.0e-12
+
+    if angle < small_angle_rad:
+        dq_wb: list[float] = [1.0, 0.5 * rx, 0.5 * ry, 0.5 * rz]
+        return quat_normalize_wxyz(dq_wb)
+
+    # Half-angle term used in quaternion exponential
+    half_angle: float = 0.5 * angle
+    sin_half: float = math.sin(half_angle)
+    inv_angle: float = 1.0 / angle
+    return [
+        math.cos(half_angle),
+        rx * inv_angle * sin_half,
+        ry * inv_angle * sin_half,
+        rz * inv_angle * sin_half,
+    ]

--- a/oasis_control/oasis_control/localization/ahrs/ahrs_ros_clock.py
+++ b/oasis_control/oasis_control/localization/ahrs/ahrs_ros_clock.py
@@ -1,0 +1,33 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""
+ROS clock implementation for AHRS localization
+"""
+
+from __future__ import annotations
+
+import rclpy.node
+
+from oasis_control.localization.ahrs.ahrs_clock import AhrsClock
+from oasis_control.localization.ahrs.ahrs_ros_conversions import ahrs_time_from_ros
+from oasis_control.localization.ahrs.ahrs_types import AhrsTime
+
+
+class RosAhrsClock(AhrsClock):
+    """
+    ROS clock implementation backed by a node's time source
+    """
+
+    def __init__(self, node: rclpy.node.Node) -> None:
+        self._node: rclpy.node.Node = node
+
+    def now(self) -> AhrsTime:
+        return ahrs_time_from_ros(self._node.get_clock().now().to_msg())

--- a/oasis_control/oasis_control/localization/ahrs/ahrs_ros_conversions.py
+++ b/oasis_control/oasis_control/localization/ahrs/ahrs_ros_conversions.py
@@ -1,0 +1,74 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""
+Conversion helpers between ROS messages and AHRS types
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Protocol
+
+from builtin_interfaces.msg import Time as TimeMsg
+
+from oasis_control.localization.ahrs.ahrs_conversions import ahrs_time_from_pair
+from oasis_control.localization.ahrs.ahrs_conversions import cov3x3_from_seq
+from oasis_control.localization.ahrs.ahrs_conversions import normalize_ahrs_time
+from oasis_control.localization.ahrs.ahrs_conversions import vector3_from_xyz
+from oasis_control.localization.ahrs.ahrs_types import AhrsTime
+
+
+class Vector3Like(Protocol):
+    """
+    Protocol for geometry messages with x/y/z fields
+    """
+
+    x: float
+    y: float
+    z: float
+
+
+def ahrs_time_from_ros(stamp: TimeMsg) -> AhrsTime:
+    """
+    Convert a ROS time stamp into an AHRS time
+    """
+
+    return ahrs_time_from_pair(sec=int(stamp.sec), nanosec=int(stamp.nanosec))
+
+
+def ros_time_from_ahrs(t: AhrsTime) -> TimeMsg:
+    """
+    Convert an AHRS time into a ROS time stamp
+    """
+
+    normalized: AhrsTime = normalize_ahrs_time(t)
+
+    stamp: TimeMsg = TimeMsg()
+    stamp.sec = normalized.sec
+    stamp.nanosec = normalized.nanosec
+
+    return stamp
+
+
+def cov3x3_from_ros(cov: Sequence[float]) -> list[float]:
+    """
+    Convert a ROS covariance list into a validated 3x3 covariance
+    """
+
+    return cov3x3_from_seq(cov)
+
+
+def vector3_from_ros(msg: Vector3Like) -> list[float]:
+    """
+    Convert a ROS Vector3-like message into a list
+    """
+
+    return vector3_from_xyz(msg.x, msg.y, msg.z)

--- a/oasis_control/oasis_control/localization/ahrs/ahrs_ros_msgs.py
+++ b/oasis_control/oasis_control/localization/ahrs/ahrs_ros_msgs.py
@@ -1,0 +1,278 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""
+ROS message builders for AHRS localization
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from geometry_msgs.msg import Point
+from geometry_msgs.msg import Pose
+from geometry_msgs.msg import PoseWithCovariance
+from geometry_msgs.msg import PoseWithCovarianceStamped
+from geometry_msgs.msg import Quaternion
+from geometry_msgs.msg import Transform
+from geometry_msgs.msg import TransformStamped
+from geometry_msgs.msg import Twist
+from geometry_msgs.msg import TwistWithCovariance
+from geometry_msgs.msg import Vector3
+from nav_msgs.msg import Odometry as OdometryMsg
+
+from oasis_control.localization.ahrs.ahrs_config import AhrsConfig
+from oasis_control.localization.ahrs.ahrs_conversions import seconds_from_ahrs
+from oasis_control.localization.ahrs.ahrs_ros_conversions import ros_time_from_ahrs
+from oasis_control.localization.ahrs.ahrs_types import AhrsDiagnosticsData
+from oasis_control.localization.ahrs.ahrs_types import AhrsFrameOutputs
+from oasis_control.localization.ahrs.ahrs_types import AhrsFrameTransform
+from oasis_control.localization.ahrs.ahrs_types import AhrsMatrix
+from oasis_control.localization.ahrs.ahrs_types import AhrsSe3Transform
+from oasis_control.localization.ahrs.ahrs_types import AhrsStateData
+from oasis_control.localization.ahrs.ahrs_types import AhrsTime
+from oasis_control.localization.ahrs.ahrs_types import AhrsUpdateData
+from oasis_msgs.msg import AhrsDiagnostics as AhrsDiagnosticsMsg
+from oasis_msgs.msg import AhrsState as AhrsStateMsg
+from oasis_msgs.msg import EkfUpdateReport as EkfUpdateReportMsg
+from oasis_msgs.msg import Matrix as MatrixMsg
+
+
+def to_update_report_msg(update: AhrsUpdateData) -> EkfUpdateReportMsg:
+    msg: EkfUpdateReportMsg = EkfUpdateReportMsg()
+    msg.header.stamp = ros_time_from_ahrs(update.t_meas)
+    msg.sensor = update.sensor
+    msg.frame_id = update.frame_id
+    msg.update_seq = 0
+    msg.update_index_in_stamp = 0
+    msg.accepted = update.accepted
+    msg.reject_reason = update.reject_reason or ""
+    msg.z_dim = len(update.z)
+    msg.z = list(update.z)
+    msg.z_hat = list(update.z_hat)
+    msg.nu = list(update.nu)
+    msg.r = _to_matrix_msg(update.r)
+    msg.s_hat = _to_matrix_msg(update.s_hat)
+    msg.s = _to_matrix_msg(update.s)
+    msg.maha_d2 = update.maha_d2
+    msg.gate_d2_threshold = update.gate_threshold
+    msg.reproj_rms_px = 0.0
+
+    return msg
+
+
+def to_state_msg(state: AhrsStateData) -> AhrsStateMsg:
+    msg: AhrsStateMsg = AhrsStateMsg()
+    msg.header.stamp = ros_time_from_ahrs(state.t_filter)
+    msg.header.frame_id = state.world_frame_id
+    msg.world_frame_id = state.world_frame_id
+    msg.odom_frame_id = state.odom_frame_id
+    msg.body_frame_id = state.body_frame_id
+    msg.state_seq = state.state_seq
+    msg.initialized = state.initialized
+    msg.position_wb_m = _to_point(state.p_wb_m)
+    msg.velocity_wb_mps = _to_vector3(state.v_wb_mps)
+    msg.orientation_wb = _to_quaternion(state.q_wb_wxyz)
+    msg.gyro_bias = _to_vector3(state.b_g_rps)
+    msg.accel_bias = _to_vector3(state.b_a_mps2)
+    msg.accel_a = list(state.a_a)
+    msg.t_bi = _to_pose(state.t_bi)
+    msg.t_bm = _to_pose(state.t_bm)
+    msg.gravity_w_mps2 = _to_vector3(state.g_w_mps2)
+    msg.magnetic_field_w_t = _to_vector3(state.m_w_t)
+    msg.error_dim = state.p_cov.rows
+    msg.error_state_names = list(state.error_state_names)
+    msg.p = _to_matrix_msg(state.p_cov)
+
+    return msg
+
+
+def to_diag_msg(diag: AhrsDiagnosticsData) -> AhrsDiagnosticsMsg:
+    msg: AhrsDiagnosticsMsg = AhrsDiagnosticsMsg()
+    if diag.t_filter is not None:
+        msg.header.stamp = ros_time_from_ahrs(diag.t_filter)
+        msg.t_filter_sec = seconds_from_ahrs(diag.t_filter)
+    else:
+        msg.t_filter_sec = 0.0
+    msg.diag_seq = diag.diag_seq
+    msg.buffer_node_count = diag.buffer_node_count
+    msg.buffer_span_sec = diag.buffer_span_sec
+    msg.replay_happened = diag.replay_happened
+    msg.dropped_missing_stamp = diag.dropped_missing_stamp
+    msg.dropped_future_stamp = diag.dropped_future_stamp
+    msg.dropped_too_old = diag.dropped_too_old
+    msg.dropped_nan_cov = diag.dropped_nan_cov
+    msg.dropped_imu_coverage_gap = diag.dropped_imu_gap
+    msg.dropped_clock_jump_reset = diag.dropped_clock_jump_reset
+    msg.last_reset_reason = diag.last_reset_reason
+
+    return msg
+
+
+def to_pose_cov_msg(
+    t: AhrsTime,
+    t_se3: AhrsSe3Transform,
+    covariance_6x6: Optional[list[float]] = None,
+) -> PoseWithCovarianceStamped:
+    msg: PoseWithCovarianceStamped = PoseWithCovarianceStamped()
+    msg.header.stamp = ros_time_from_ahrs(t)
+    msg.header.frame_id = t_se3.parent_frame
+    msg.pose = _to_pose_covariance(t_se3, covariance_6x6)
+
+    return msg
+
+
+def to_odom_msg(
+    t: AhrsTime,
+    transform: AhrsFrameTransform,
+    frame_id: str,
+    child_frame_id: str,
+) -> OdometryMsg:
+    msg: OdometryMsg = OdometryMsg()
+    msg.header.stamp = ros_time_from_ahrs(t)
+    msg.header.frame_id = frame_id
+    msg.child_frame_id = child_frame_id
+    msg.pose = _to_pose_with_covariance(transform)
+    msg.twist = _zero_twist_with_covariance()
+
+    return msg
+
+
+def to_tf_msgs(
+    t: AhrsTime, frame_transforms: AhrsFrameOutputs, config: AhrsConfig
+) -> list[TransformStamped]:
+    t_world_odom: TransformStamped = _to_transform_stamped(
+        t,
+        frame_transforms.t_world_odom,
+        config,
+    )
+    t_odom_base: TransformStamped = _to_transform_stamped(
+        t,
+        frame_transforms.t_odom_base,
+        config,
+    )
+
+    return [t_world_odom, t_odom_base]
+
+
+def _to_transform_stamped(
+    t: AhrsTime,
+    transform: AhrsFrameTransform,
+    config: AhrsConfig,
+) -> TransformStamped:
+    msg: TransformStamped = TransformStamped()
+    msg.header.stamp = ros_time_from_ahrs(t)
+    msg.header.frame_id = _map_frame_id(transform.parent_frame, config)
+    msg.child_frame_id = _map_frame_id(transform.child_frame, config)
+    msg.transform = _to_transform(transform)
+
+    return msg
+
+
+def _map_frame_id(frame_id: str, config: AhrsConfig) -> str:
+    if frame_id == "world":
+        return config.world_frame_id
+    if frame_id == "odom":
+        return config.odom_frame_id
+    if frame_id == "base_link":
+        return config.body_frame_id
+
+    return frame_id
+
+
+def _to_matrix_msg(matrix: AhrsMatrix) -> MatrixMsg:
+    msg: MatrixMsg = MatrixMsg()
+    msg.rows = matrix.rows
+    msg.cols = matrix.cols
+    msg.data = list(matrix.data)
+
+    return msg
+
+
+def _to_pose(transform: AhrsSe3Transform) -> Pose:
+    pose: Pose = Pose()
+    pose.position = _to_point(transform.translation_m)
+    pose.orientation = _to_quaternion(transform.rotation_wxyz)
+
+    return pose
+
+
+def _to_pose_covariance(
+    transform: AhrsSe3Transform, covariance: Optional[list[float]]
+) -> PoseWithCovariance:
+    pose_cov: PoseWithCovariance = PoseWithCovariance()
+    pose_cov.pose = _to_pose(transform)
+    pose_cov.covariance = _to_covariance_6x6(covariance)
+
+    return pose_cov
+
+
+def _to_pose_with_covariance(transform: AhrsFrameTransform) -> PoseWithCovariance:
+    pose_cov: PoseWithCovariance = PoseWithCovariance()
+    pose_cov.pose.position = _to_point(transform.translation_m)
+    pose_cov.pose.orientation = _to_quaternion(transform.rotation_wxyz)
+    pose_cov.covariance = _to_covariance_6x6(None)
+
+    return pose_cov
+
+
+def _zero_twist_with_covariance() -> TwistWithCovariance:
+    twist_cov: TwistWithCovariance = TwistWithCovariance()
+    twist_cov.twist = Twist()
+    twist_cov.twist.linear = Vector3()
+    twist_cov.twist.angular = Vector3()
+    twist_cov.covariance = _to_covariance_6x6(None)
+
+    return twist_cov
+
+
+def _to_transform(transform: AhrsFrameTransform) -> Transform:
+    msg: Transform = Transform()
+    msg.translation = _to_vector3(transform.translation_m)
+    msg.rotation = _to_quaternion(transform.rotation_wxyz)
+
+    return msg
+
+
+def _to_point(values: list[float]) -> Point:
+    point: Point = Point()
+    point.x = values[0]
+    point.y = values[1]
+    point.z = values[2]
+
+    return point
+
+
+def _to_vector3(values: list[float]) -> Vector3:
+    vec: Vector3 = Vector3()
+    vec.x = values[0]
+    vec.y = values[1]
+    vec.z = values[2]
+
+    return vec
+
+
+def _to_quaternion(values_wxyz: list[float]) -> Quaternion:
+    quat: Quaternion = Quaternion()
+    quat.w = values_wxyz[0]
+    quat.x = values_wxyz[1]
+    quat.y = values_wxyz[2]
+    quat.z = values_wxyz[3]
+
+    return quat
+
+
+def _to_covariance_6x6(covariance: Optional[list[float]]) -> list[float]:
+    if covariance is None:
+        return [0.0] * 36
+    if len(covariance) != 36:
+        raise ValueError("Expected 36 covariance entries")
+
+    return list(covariance)

--- a/oasis_control/oasis_control/localization/ahrs/ahrs_state.py
+++ b/oasis_control/oasis_control/localization/ahrs/ahrs_state.py
@@ -1,0 +1,164 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""
+Nominal-state container for the AHRS core math
+
+The nominal state stores the best estimate of the physical system. The
+error-state lives alongside it in the covariance, tracking small deviations
+that are linearized around the nominal state. Keeping the nominal container
+separate makes the core math deterministic and ROS-agnostic.
+
+The nominal state includes an explicit angular rate term so that gyro
+measurements have a direct landing spot even before the full prediction
+model is implemented.
+"""
+
+from dataclasses import dataclass
+
+from oasis_control.localization.ahrs.ahrs_types import AhrsSe3Transform
+
+
+@dataclass(frozen=False)
+class AhrsNominalState:
+    """
+    Nominal AHRS state variables used for prediction and updates
+
+    Fields:
+        p_wb_m: Position of the body in world in meters, XYZ order
+        v_wb_mps: Velocity of the body in world in m/s, XYZ order
+        q_wb_wxyz: Orientation of the body in world, quaternion wxyz order
+        omega_wb_rps: Angular rate of the body in rad/s, XYZ order
+        b_g_rps: Gyro bias in rad/s, XYZ order
+        b_a_mps2: Accel bias in m/s^2, XYZ order
+        a_a: Accel scale/misalignment matrix, 3x3 row-major
+        t_bi: IMU -> body transform (T_BI)
+        t_bm: Magnetometer -> body transform (T_BM)
+        g_w_mps2: Gravity vector in world in m/s^2, XYZ order
+        m_w_t: Magnetic field vector in world in tesla, XYZ order
+    """
+
+    p_wb_m: list[float]
+    v_wb_mps: list[float]
+    q_wb_wxyz: list[float]
+    omega_wb_rps: list[float]
+    b_g_rps: list[float]
+    b_a_mps2: list[float]
+    a_a: list[float]
+    t_bi: AhrsSe3Transform
+    t_bm: AhrsSe3Transform
+    g_w_mps2: list[float]
+    m_w_t: list[float]
+
+
+def zero_vector3() -> list[float]:
+    """
+    Return a 3D zero vector
+    """
+
+    return [0.0, 0.0, 0.0]
+
+
+def identity_quaternion_wxyz() -> list[float]:
+    """
+    Return the identity quaternion in wxyz order
+    """
+
+    return [1.0, 0.0, 0.0, 0.0]
+
+
+def identity_mat3() -> list[float]:
+    """
+    Return a 3x3 identity matrix in row-major order
+    """
+
+    return [
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+    ]
+
+
+def default_extrinsic(parent_frame: str, child_frame: str) -> AhrsSe3Transform:
+    """
+    Build a default identity extrinsic transform for a sensor frame
+    """
+
+    return AhrsSe3Transform(
+        parent_frame=parent_frame,
+        child_frame=child_frame,
+        translation_m=zero_vector3(),
+        rotation_wxyz=identity_quaternion_wxyz(),
+    )
+
+
+def default_nominal_state(
+    *,
+    body_frame_id: str,
+    imu_frame_id: str,
+    mag_frame_id: str,
+) -> AhrsNominalState:
+    """
+    Create a default nominal state with zero motion and identity extrinsics
+
+    The default values assume the body starts at the world origin with zero
+    velocity, the identity orientation, zero biases, and sensor frames aligned
+    to the body frame. Gravity and magnetic field vectors are set to zero for
+    now and should be populated by initialization routines later on.
+    """
+
+    return AhrsNominalState(
+        p_wb_m=zero_vector3(),
+        v_wb_mps=zero_vector3(),
+        q_wb_wxyz=identity_quaternion_wxyz(),
+        omega_wb_rps=zero_vector3(),
+        b_g_rps=zero_vector3(),
+        b_a_mps2=zero_vector3(),
+        a_a=identity_mat3(),
+        t_bi=default_extrinsic(body_frame_id, imu_frame_id),
+        t_bm=default_extrinsic(body_frame_id, mag_frame_id),
+        g_w_mps2=zero_vector3(),
+        m_w_t=zero_vector3(),
+    )
+
+
+def validate_vector_length(name: str, v: list[float], n: int) -> None:
+    """
+    Validate that a vector has the expected length
+    """
+
+    if len(v) != n:
+        raise ValueError(f"{name} must be length {n}, got {len(v)}")
+
+
+def validate_nominal_state(state: AhrsNominalState) -> None:
+    """
+    Validate nominal state vector sizes for basic consistency
+    """
+
+    validate_vector_length("p_wb_m", state.p_wb_m, 3)
+    validate_vector_length("v_wb_mps", state.v_wb_mps, 3)
+    validate_vector_length("q_wb_wxyz", state.q_wb_wxyz, 4)
+    validate_vector_length("omega_wb_rps", state.omega_wb_rps, 3)
+    validate_vector_length("b_g_rps", state.b_g_rps, 3)
+    validate_vector_length("b_a_mps2", state.b_a_mps2, 3)
+    validate_vector_length("a_a", state.a_a, 9)
+    validate_vector_length("t_bi.translation_m", state.t_bi.translation_m, 3)
+    validate_vector_length("t_bi.rotation_wxyz", state.t_bi.rotation_wxyz, 4)
+    validate_vector_length("t_bm.translation_m", state.t_bm.translation_m, 3)
+    validate_vector_length("t_bm.rotation_wxyz", state.t_bm.rotation_wxyz, 4)
+    validate_vector_length("g_w_mps2", state.g_w_mps2, 3)
+    validate_vector_length("m_w_t", state.m_w_t, 3)

--- a/oasis_control/oasis_control/localization/ahrs/ahrs_timeline.py
+++ b/oasis_control/oasis_control/localization/ahrs/ahrs_timeline.py
@@ -1,0 +1,123 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""
+Time-ordered event buffer for AHRS localization
+"""
+
+from __future__ import annotations
+
+from bisect import bisect_left
+from dataclasses import dataclass
+from typing import Iterator
+
+from oasis_control.localization.ahrs.ahrs_conversions import seconds_from_ahrs
+from oasis_control.localization.ahrs.ahrs_types import AhrsEvent
+from oasis_control.localization.ahrs.ahrs_types import AhrsTime
+
+
+@dataclass(frozen=False)
+class AhrsTimeNode:
+    """
+    Time node containing events at a single timestamp
+
+    Fields:
+        t: Timestamp for this node
+        events: Events recorded at the timestamp
+    """
+
+    t: AhrsTime
+    events: list[AhrsEvent]
+
+
+class AhrsTimeBuffer:
+    """
+    Time-ordered buffer of AHRS events
+    """
+
+    def __init__(self) -> None:
+        self._nodes: list[AhrsTimeNode] = []
+
+    def get_or_create_node(self, t: AhrsTime) -> AhrsTimeNode:
+        """
+        Retrieve or create the node for the requested time
+        """
+
+        index: int = self._index_for_time(t)
+        if index < len(self._nodes) and self._same_time(self._nodes[index].t, t):
+            return self._nodes[index]
+
+        node: AhrsTimeNode = AhrsTimeNode(t=t, events=[])
+        self._nodes.insert(index, node)
+        return node
+
+    def insert_event(self, event: AhrsEvent) -> None:
+        """
+        Insert an event into the buffer at its timestamp
+        """
+
+        node: AhrsTimeNode = self.get_or_create_node(event.t_meas)
+        node.events.append(event)
+
+    def evict_older_than(self, t_min: AhrsTime) -> int:
+        """
+        Evict nodes older than the minimum time
+        """
+
+        index: int = self._index_for_time(t_min)
+        if index == 0:
+            return 0
+
+        del self._nodes[:index]
+        return index
+
+    def node_count(self) -> int:
+        """
+        Return the number of buffered time nodes
+        """
+
+        return len(self._nodes)
+
+    def span_sec(self) -> float:
+        """
+        Return the span in seconds between oldest and newest nodes
+        """
+
+        if len(self._nodes) < 2:
+            return 0.0
+
+        oldest: AhrsTime = self._nodes[0].t
+        newest: AhrsTime = self._nodes[-1].t
+        return seconds_from_ahrs(newest) - seconds_from_ahrs(oldest)
+
+    def iter_nodes(self) -> Iterator[AhrsTimeNode]:
+        """
+        Iterate over buffered nodes in time order
+        """
+
+        return iter(self._nodes)
+
+    def iter_nodes_from(self, t: AhrsTime) -> Iterator[AhrsTimeNode]:
+        """
+        Iterate over buffered nodes starting at a time
+        """
+
+        index: int = self._index_for_time(t)
+        return iter(self._nodes[index:])
+
+    def _index_for_time(self, t: AhrsTime) -> int:
+        keys: list[tuple[int, int]] = [self._time_key(node.t) for node in self._nodes]
+        return bisect_left(keys, self._time_key(t))
+
+    def _same_time(self, left: AhrsTime, right: AhrsTime) -> bool:
+        return self._time_key(left) == self._time_key(right)
+
+    def _time_key(self, t: AhrsTime) -> tuple[int, int]:
+        return (t.sec, t.nanosec)

--- a/oasis_control/oasis_control/localization/ahrs/ahrs_types.py
+++ b/oasis_control/oasis_control/localization/ahrs/ahrs_types.py
@@ -1,0 +1,371 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""
+Types and helpers for AHRS localization
+"""
+
+import enum
+from dataclasses import dataclass
+from typing import Literal
+from typing import Optional
+from typing import Union
+
+
+@dataclass(frozen=True)
+class AhrsTime:
+    """
+    AHRS timestamp stored as seconds and nanoseconds
+
+    Fields:
+        sec: Whole seconds since the AHRS time reference
+        nanosec: Sub-second remainder in nanoseconds [0, 1e9)
+    """
+
+    sec: int
+    nanosec: int
+
+
+AhrsFrameId = Literal["world", "odom", "base_link"]
+
+
+@dataclass(frozen=True)
+class AhrsFrameTransform:
+    """
+    Rigid transform between semantic frames
+
+    Fields:
+        parent_frame: Semantic parent frame
+        child_frame: Semantic child frame
+        translation_m: Translation in meters, XYZ order
+        rotation_wxyz: Quaternion rotation in wxyz order, unit length
+    """
+
+    parent_frame: AhrsFrameId
+    child_frame: AhrsFrameId
+    translation_m: list[float]
+    rotation_wxyz: list[float]
+
+
+@dataclass(frozen=True)
+class AhrsSe3Transform:
+    """
+    Rigid transform between arbitrary frames
+
+    Fields:
+        parent_frame: Parent frame name for the transform
+        child_frame: Child frame name for the transform
+        translation_m: Translation in meters, XYZ order
+        rotation_wxyz: Quaternion rotation in wxyz order, unit length
+    """
+
+    parent_frame: str
+    child_frame: str
+    translation_m: list[float]
+    rotation_wxyz: list[float]
+
+
+@dataclass(frozen=True)
+class AhrsFrameOutputs:
+    """
+    Frame outputs derived from the canonical odom state
+
+    Fields:
+        t_odom_base: Transform from odom to base
+        t_world_odom: Transform from world to odom
+        t_world_base: Transform from world to base derived by composition
+    """
+
+    t_odom_base: AhrsFrameTransform
+    t_world_odom: AhrsFrameTransform
+    t_world_base: AhrsFrameTransform
+
+
+class AhrsEventType(enum.Enum):
+    """
+    Enumerates the kinds of time-ordered AHRS events
+
+    Attributes:
+        IMU: Inertial sample or IMU packet event
+        MAG: Magnetometer measurement event
+    """
+
+    IMU = "imu"
+    MAG = "mag"
+
+
+@dataclass(frozen=True)
+class ImuCalibrationData:
+    """
+    Calibration prior data for IMU bias and scale parameters
+
+    Fields:
+        valid: True when the calibration payload is safe to apply
+        frame_id: IMU frame identifier expected to match the IMU sample frame
+        accel_bias_mps2: Accelerometer bias in m/s^2, XYZ order
+        accel_a: 3x3 accel scale/misalignment matrix, row-major
+        accel_param_cov: 12x12 covariance of accel calibration params
+        gyro_bias_rps: Gyroscope bias in rad/s, XYZ order
+        gyro_bias_cov: 3x3 covariance of gyro bias params, row-major
+        gravity_mps2: Gravity magnitude assumed during calibration in m/s^2
+        fit_sample_count: Number of samples used in the calibration fit
+        rms_residual_mps2: RMS gravity residual of the calibration in m/s^2
+        temperature_c: Mean calibration temperature in deg C
+        temperature_var_c2: Temperature variance in (deg C)^2
+    """
+
+    valid: bool
+    frame_id: str
+    accel_bias_mps2: list[float]
+    accel_a: list[float]
+    accel_param_cov: list[float]
+    gyro_bias_rps: list[float]
+    gyro_bias_cov: list[float]
+    gravity_mps2: float
+    fit_sample_count: int
+    rms_residual_mps2: float
+    temperature_c: float
+    temperature_var_c2: float
+
+
+@dataclass(frozen=True)
+class ImuSample:
+    """
+    IMU sample with raw motion data
+
+    Fields:
+        frame_id: IMU frame identifier for this sample
+        angular_velocity_rps: Angular velocity in rad/s, XYZ order
+        linear_acceleration_mps2: Linear acceleration in m/s^2, XYZ order
+        angular_velocity_cov: 3x3 gyro covariance, row-major
+        linear_acceleration_cov: 3x3 accel covariance, row-major
+    """
+
+    frame_id: str
+    angular_velocity_rps: list[float]
+    linear_acceleration_mps2: list[float]
+    angular_velocity_cov: list[float]
+    linear_acceleration_cov: list[float]
+
+
+@dataclass(frozen=True)
+class AhrsImuPacket:
+    """
+    IMU packet event payload
+
+    Fields:
+        imu: Raw IMU measurement sample
+        calibration: IMU calibration prior tied to the IMU frame
+    """
+
+    imu: ImuSample
+    calibration: ImuCalibrationData
+
+
+@dataclass(frozen=True)
+class MagSample:
+    """
+    Magnetometer sample data
+
+    Fields:
+        frame_id: Magnetometer frame identifier
+        magnetic_field_t: Magnetic field vector in tesla, XYZ order
+        magnetic_field_cov: 3x3 covariance in tesla^2, row-major
+    """
+
+    frame_id: str
+    magnetic_field_t: list[float]
+    magnetic_field_cov: list[float]
+
+
+AhrsEventPayload = Union[
+    AhrsImuPacket,
+    MagSample,
+]
+
+
+@dataclass(frozen=True)
+class AhrsEvent:
+    """
+    Time-stamped AHRS event in the common filter timeline
+
+    Fields:
+        t_meas: Measurement timestamp
+        topic: Topic name that produced the event
+        frame_id: Frame identifier from the event header
+        event_type: Event category for dispatching updates
+        payload: Event data payload for the selected type
+    """
+
+    t_meas: AhrsTime
+    topic: str
+    frame_id: str
+    event_type: AhrsEventType
+    payload: AhrsEventPayload
+
+
+@dataclass(frozen=True)
+class AhrsMatrix:
+    """
+    Row-major matrix data used by update reporting
+
+    Fields:
+        rows: Number of rows in the matrix
+        cols: Number of columns in the matrix
+        data: Row-major matrix entries
+    """
+
+    rows: int
+    cols: int
+    data: list[float]
+
+
+@dataclass(frozen=True)
+class AhrsUpdateData:
+    """
+    Generic update report payload
+
+    Fields:
+        sensor: Sensor name such as gyro, accel, or mag
+        frame_id: Measurement frame identifier
+        t_meas: Measurement timestamp
+        accepted: True when the update was accepted by the filter
+        reject_reason: Optional reason string when the update is rejected
+        z: Measurement vector in sensor units, as received
+        z_hat: Predicted measurement vector in sensor units
+        nu: Innovation vector (z - z_hat) in sensor units
+        r: Measurement covariance in sensor units, row-major
+        s_hat: Predicted innovation covariance, row-major
+        s: Innovation covariance after conditioning, row-major
+        maha_d2: Mahalanobis distance squared for gating
+        gate_threshold: Gate threshold for the Mahalanobis distance
+    """
+
+    sensor: str
+    frame_id: str
+    t_meas: AhrsTime
+    accepted: bool
+    reject_reason: Optional[str]
+    z: list[float]
+    z_hat: list[float]
+    nu: list[float]
+    r: AhrsMatrix
+    s_hat: AhrsMatrix
+    s: AhrsMatrix
+    maha_d2: float
+    gate_threshold: float
+
+
+@dataclass(frozen=True)
+class AhrsStateData:
+    """
+    Filter state output payload for AhrsState publication
+
+    Fields:
+        t_filter: Filter frontier timestamp for this state
+        state_seq: Monotonic state sequence identifier
+        initialized: True when the filter has a valid initial state
+        world_frame_id: World frame identifier for the state
+        odom_frame_id: Odometry frame identifier for the state
+        body_frame_id: Body frame identifier for the state
+        p_wb_m: Position of the body in world in meters, XYZ order
+        v_wb_mps: Velocity of the body in world in m/s, XYZ order
+        q_wb_wxyz: Orientation of the body in world, quaternion wxyz order
+        b_g_rps: Gyro bias in rad/s, XYZ order
+        b_a_mps2: Accel bias in m/s^2, XYZ order
+        a_a: Accel scale/misalignment matrix, 3x3 row-major
+        t_bi: IMU -> body transform (T_BI)
+        t_bm: Magnetometer -> body transform (T_BM)
+        g_w_mps2: Gravity vector in world in m/s^2, XYZ order
+        m_w_t: Magnetic field vector in world in tesla, XYZ order
+        error_state_names: Names of error-state entries in the covariance
+        p_cov: Full error-state covariance, row-major
+    """
+
+    t_filter: AhrsTime
+    state_seq: int
+    initialized: bool
+    world_frame_id: str
+    odom_frame_id: str
+    body_frame_id: str
+    p_wb_m: list[float]
+    v_wb_mps: list[float]
+    q_wb_wxyz: list[float]
+    b_g_rps: list[float]
+    b_a_mps2: list[float]
+    a_a: list[float]
+    t_bi: AhrsSe3Transform
+    t_bm: AhrsSe3Transform
+    g_w_mps2: list[float]
+    m_w_t: list[float]
+    error_state_names: list[str]
+    p_cov: AhrsMatrix
+
+
+@dataclass(frozen=True)
+class AhrsDiagnosticsData:
+    """
+    Diagnostics output payload for AhrsDiagnostics publication
+
+    Fields:
+        t_filter: Filter frontier timestamp if an output was published
+        diag_seq: Monotonic diagnostics sequence identifier
+        buffer_node_count: Number of time nodes currently buffered
+        buffer_span_sec: Time span of buffered events in seconds
+        replay_happened: True when a replay was triggered
+        dropped_missing_stamp: Count of updates dropped for missing stamps
+        dropped_future_stamp: Count of updates dropped for future stamps
+        dropped_too_old: Count of updates dropped for being too old
+        dropped_nan_cov: Count of updates dropped for NaN covariance entries
+        dropped_imu_gap: Count of updates dropped for IMU gap detection
+        dropped_clock_jump_reset: Count of updates dropped for clock jump reset
+        reset_count: Number of filter resets performed
+        last_reset_reason: Latest reset reason description
+    """
+
+    t_filter: Optional[AhrsTime]
+    diag_seq: int
+    buffer_node_count: int
+    buffer_span_sec: float
+    replay_happened: bool
+    dropped_missing_stamp: int
+    dropped_future_stamp: int
+    dropped_too_old: int
+    dropped_nan_cov: int
+    dropped_imu_gap: int
+    dropped_clock_jump_reset: int
+    reset_count: int
+    last_reset_reason: str
+
+
+@dataclass(frozen=True)
+class AhrsOutputs:
+    """
+    Outputs produced by AHRS event processing
+
+    Fields:
+        frontier_advanced: True when the filter frontier advanced on this event
+        t_filter: Frontier timestamp for the current estimate outputs
+        frame_transforms: Frame transforms derived from the AHRS state
+        state: State output payload for AhrsState publication
+        diagnostics: Diagnostics output payload for AhrsDiagnostics publication
+        gyro_update: Update report payload for gyro updates
+        accel_update: Update report payload for accel updates
+        mag_update: Update report payload for magnetometer updates
+    """
+
+    frontier_advanced: bool
+    t_filter: Optional[AhrsTime]
+    frame_transforms: Optional[AhrsFrameOutputs]
+    state: Optional[AhrsStateData]
+    diagnostics: Optional[AhrsDiagnosticsData]
+    gyro_update: Optional[AhrsUpdateData]
+    accel_update: Optional[AhrsUpdateData]
+    mag_update: Optional[AhrsUpdateData]

--- a/oasis_control/oasis_control/localization/ahrs/ahrs_update_core.py
+++ b/oasis_control/oasis_control/localization/ahrs/ahrs_update_core.py
@@ -1,0 +1,316 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""
+Core measurement update utilities for the AHRS error-state EKF
+
+This module implements the common EKF measurement update for the error-state
+filter using row-major list matrices. The innovation is defined as
+``nu = z - z_hat``. The measurement Jacobian ``H`` maps the stacked
+error-state to the measurement space, so the predicted innovation covariance
+is ``S_hat = H P H^T``. The total innovation covariance is
+``S = S_hat + R`` where ``R`` is the measurement noise covariance. The
+Kalman gain is ``K = P H^T S^{-1}`` and the correction is
+``delta_x = K nu``. Covariance is updated with the Joseph form
+``P_new = (I - K H) P (I - K H)^T + K R K^T`` to preserve symmetry.
+"""
+
+from __future__ import annotations
+
+from oasis_control.localization.ahrs.ahrs_error_state import AhrsErrorStateLayout
+from oasis_control.localization.ahrs.ahrs_linalg import is_finite_seq
+from oasis_control.localization.ahrs.ahrs_linalg import mat3_inv
+from oasis_control.localization.ahrs.ahrs_linalg import mat_mul
+from oasis_control.localization.ahrs.ahrs_linalg import mat_transpose
+from oasis_control.localization.ahrs.ahrs_linalg import mat_vec_mul
+from oasis_control.localization.ahrs.ahrs_linalg import symmetrize
+from oasis_control.localization.ahrs.ahrs_types import AhrsMatrix
+from oasis_control.localization.ahrs.ahrs_types import AhrsTime
+from oasis_control.localization.ahrs.ahrs_types import AhrsUpdateData
+
+
+Matrix = list[float]
+Vector = list[float]
+
+
+def _empty_matrix() -> AhrsMatrix:
+    return AhrsMatrix(rows=0, cols=0, data=[])
+
+
+def _matrix(rows: int, cols: int, data: list[float]) -> AhrsMatrix:
+    return AhrsMatrix(rows=rows, cols=cols, data=list(data))
+
+
+def _build_reject_report(
+    *,
+    sensor: str,
+    frame_id: str,
+    t_meas: AhrsTime,
+    reason: str,
+    z: list[float],
+    z_hat: list[float],
+    nu: list[float],
+    r: AhrsMatrix,
+    s_hat: AhrsMatrix,
+    s: AhrsMatrix,
+    maha_d2: float,
+    gate_threshold: float,
+) -> AhrsUpdateData:
+    return AhrsUpdateData(
+        sensor=sensor,
+        frame_id=frame_id,
+        t_meas=t_meas,
+        accepted=False,
+        reject_reason=reason,
+        z=z,
+        z_hat=z_hat,
+        nu=nu,
+        r=r,
+        s_hat=s_hat,
+        s=s,
+        maha_d2=maha_d2,
+        gate_threshold=gate_threshold,
+    )
+
+
+def _identity_matrix(dim: int) -> Matrix:
+    if dim <= 0:
+        raise ValueError("dim must be positive")
+    out: Matrix = [0.0] * (dim * dim)
+    for i in range(dim):
+        out[i * dim + i] = 1.0
+    return out
+
+
+def _mahalanobis_d2_3(nu: Vector, s_inv: Matrix) -> float:
+    nu_x: float = nu[0]
+    nu_y: float = nu[1]
+    nu_z: float = nu[2]
+    s00: float = s_inv[0]
+    s01: float = s_inv[1]
+    s02: float = s_inv[2]
+    s10: float = s_inv[3]
+    s11: float = s_inv[4]
+    s12: float = s_inv[5]
+    s20: float = s_inv[6]
+    s21: float = s_inv[7]
+    s22: float = s_inv[8]
+    sol0: float = s00 * nu_x + s01 * nu_y + s02 * nu_z
+    sol1: float = s10 * nu_x + s11 * nu_y + s12 * nu_z
+    sol2: float = s20 * nu_x + s21 * nu_y + s22 * nu_z
+    return nu_x * sol0 + nu_y * sol1 + nu_z * sol2
+
+
+def kalman_update(
+    layout: AhrsErrorStateLayout,
+    p: list[float],
+    *,
+    z: list[float],
+    z_hat: list[float],
+    nu: list[float],
+    h: list[float],
+    r: list[float],
+    gate_threshold: float,
+    sensor: str,
+    frame_id: str,
+    t_meas: AhrsTime,
+) -> tuple[list[float], AhrsUpdateData, bool, list[float]]:
+    """
+    Apply a measurement update to the covariance using the Joseph form
+    """
+
+    dim: int = layout.dim
+    if len(p) != dim * dim:
+        raise ValueError("p must have length dim * dim")
+
+    m: int = len(nu)
+    if m <= 0:
+        raise ValueError("nu must be non-empty")
+
+    if len(z) != m or len(z_hat) != m:
+        return (
+            list(p),
+            _build_reject_report(
+                sensor=sensor,
+                frame_id=frame_id,
+                t_meas=t_meas,
+                reason="invalid_measurement",
+                z=list(z),
+                z_hat=list(z_hat),
+                nu=list(nu),
+                r=_empty_matrix(),
+                s_hat=_empty_matrix(),
+                s=_empty_matrix(),
+                maha_d2=0.0,
+                gate_threshold=gate_threshold,
+            ),
+            False,
+            [0.0] * dim,
+        )
+
+    if len(h) != m * dim or len(r) != m * m:
+        raise ValueError("h or r size does not match measurement dimensions")
+
+    if not is_finite_seq(h) or not is_finite_seq(r) or not is_finite_seq(z):
+        return (
+            list(p),
+            _build_reject_report(
+                sensor=sensor,
+                frame_id=frame_id,
+                t_meas=t_meas,
+                reason="invalid_measurement",
+                z=list(z),
+                z_hat=list(z_hat),
+                nu=list(nu),
+                r=_matrix(m, m, r) if len(r) == m * m else _empty_matrix(),
+                s_hat=_empty_matrix(),
+                s=_empty_matrix(),
+                maha_d2=0.0,
+                gate_threshold=gate_threshold,
+            ),
+            False,
+            [0.0] * dim,
+        )
+
+    if not is_finite_seq(z_hat) or not is_finite_seq(nu):
+        return (
+            list(p),
+            _build_reject_report(
+                sensor=sensor,
+                frame_id=frame_id,
+                t_meas=t_meas,
+                reason="invalid_prediction",
+                z=list(z),
+                z_hat=list(z_hat),
+                nu=list(nu),
+                r=_matrix(m, m, r),
+                s_hat=_empty_matrix(),
+                s=_empty_matrix(),
+                maha_d2=0.0,
+                gate_threshold=gate_threshold,
+            ),
+            False,
+            [0.0] * dim,
+        )
+
+    if not is_finite_seq(p):
+        return (
+            list(p),
+            _build_reject_report(
+                sensor=sensor,
+                frame_id=frame_id,
+                t_meas=t_meas,
+                reason="invalid_prediction",
+                z=list(z),
+                z_hat=list(z_hat),
+                nu=list(nu),
+                r=_matrix(m, m, r),
+                s_hat=_empty_matrix(),
+                s=_empty_matrix(),
+                maha_d2=0.0,
+                gate_threshold=gate_threshold,
+            ),
+            False,
+            [0.0] * dim,
+        )
+
+    if m != 3:
+        raise NotImplementedError("only 3D measurements are supported")
+
+    h_t: Matrix = mat_transpose(h, m, dim)
+    hp: Matrix = mat_mul(h, m, dim, p, dim, dim)
+    s_hat_raw: Matrix = mat_mul(hp, m, dim, h_t, dim, m)
+    s_hat: Matrix = symmetrize(s_hat_raw, m)
+    r_sym: Matrix = symmetrize(r, m)
+    s: Matrix = symmetrize(
+        [s_hat[i] + r_sym[i] for i in range(m * m)],
+        m,
+    )
+
+    s_inv: Matrix
+    try:
+        s_inv = mat3_inv(s)
+    except ValueError:
+        return (
+            list(p),
+            _build_reject_report(
+                sensor=sensor,
+                frame_id=frame_id,
+                t_meas=t_meas,
+                reason="singular_innovation_covariance",
+                z=list(z),
+                z_hat=list(z_hat),
+                nu=list(nu),
+                r=_matrix(m, m, r_sym),
+                s_hat=_matrix(m, m, s_hat),
+                s=_matrix(m, m, s),
+                maha_d2=0.0,
+                gate_threshold=gate_threshold,
+            ),
+            False,
+            [0.0] * dim,
+        )
+
+    maha_d2: float = _mahalanobis_d2_3(nu, s_inv)
+    if gate_threshold > 0.0 and maha_d2 > gate_threshold:
+        return (
+            list(p),
+            _build_reject_report(
+                sensor=sensor,
+                frame_id=frame_id,
+                t_meas=t_meas,
+                reason="mahalanobis_gate",
+                z=list(z),
+                z_hat=list(z_hat),
+                nu=list(nu),
+                r=_matrix(m, m, r_sym),
+                s_hat=_matrix(m, m, s_hat),
+                s=_matrix(m, m, s),
+                maha_d2=maha_d2,
+                gate_threshold=gate_threshold,
+            ),
+            False,
+            [0.0] * dim,
+        )
+
+    p_h_t: Matrix = mat_mul(p, dim, dim, h_t, dim, m)
+    k: Matrix = mat_mul(p_h_t, dim, m, s_inv, m, m)
+    delta_x: Vector = mat_vec_mul(k, dim, m, nu)
+
+    kh: Matrix = mat_mul(k, dim, m, h, m, dim)
+    identity: Matrix = _identity_matrix(dim)
+    i_minus_kh: Matrix = [identity[i] - kh[i] for i in range(dim * dim)]
+
+    temp: Matrix = mat_mul(i_minus_kh, dim, dim, p, dim, dim)
+    temp = mat_mul(temp, dim, dim, mat_transpose(i_minus_kh, dim, dim), dim, dim)
+
+    k_r: Matrix = mat_mul(k, dim, m, r_sym, m, m)
+    k_r_kt: Matrix = mat_mul(k_r, dim, m, mat_transpose(k, dim, m), m, dim)
+
+    p_new: Matrix = [temp[i] + k_r_kt[i] for i in range(dim * dim)]
+    p_new = symmetrize(p_new, dim)
+
+    report: AhrsUpdateData = AhrsUpdateData(
+        sensor=sensor,
+        frame_id=frame_id,
+        t_meas=t_meas,
+        accepted=True,
+        reject_reason=None,
+        z=list(z),
+        z_hat=list(z_hat),
+        nu=list(nu),
+        r=_matrix(m, m, r_sym),
+        s_hat=_matrix(m, m, s_hat),
+        s=_matrix(m, m, s),
+        maha_d2=maha_d2,
+        gate_threshold=gate_threshold,
+    )
+
+    return p_new, report, True, delta_x

--- a/oasis_control/oasis_control/localization/ahrs/ahrs_update_core.py
+++ b/oasis_control/oasis_control/localization/ahrs/ahrs_update_core.py
@@ -124,6 +124,8 @@ def kalman_update(
 ) -> tuple[list[float], AhrsUpdateData, bool, list[float]]:
     """
     Apply a measurement update to the covariance using the Joseph form
+
+    Note: layout is used for layout.dim only
     """
 
     dim: int = layout.dim
@@ -135,6 +137,9 @@ def kalman_update(
         raise ValueError("nu must be non-empty")
 
     if len(z) != m or len(z_hat) != m:
+        r_report: AhrsMatrix = (
+            _matrix(m, m, r) if len(r) == m * m else _empty_matrix()
+        )
         return (
             list(p),
             _build_reject_report(
@@ -145,7 +150,7 @@ def kalman_update(
                 z=list(z),
                 z_hat=list(z_hat),
                 nu=list(nu),
-                r=_empty_matrix(),
+                r=r_report,
                 s_hat=_empty_matrix(),
                 s=_empty_matrix(),
                 maha_d2=0.0,

--- a/oasis_control/oasis_control/localization/ahrs/ahrs_update_gyro.py
+++ b/oasis_control/oasis_control/localization/ahrs/ahrs_update_gyro.py
@@ -1,0 +1,368 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""
+Gyro measurement update for the AHRS core
+
+Measurement model:
+    z: Gyro angular velocity in rad/s, IMU frame assumed aligned with body
+       and body frame for this update
+    z_hat: Predicted angular velocity from omega_wb_rps in the nominal state
+    nu: Innovation nu = z - z_hat
+    R: Gyro measurement covariance in (rad/s)^2, row-major 3x3
+    S_hat: Predicted innovation covariance H P H^T, row-major 3x3
+    S: Innovation covariance S = S_hat + R, row-major 3x3
+
+Gating:
+    Mahalanobis distance d^2 = nu^T S^{-1} nu is compared against the
+    configured gyro_gate_d2_threshold
+
+Error-state mapping:
+    The gyro update uses only the omega error-state block at layout.sl_omega
+    This v1 update corrects omega_wb_rps and the omega covariance block only
+    Cross-covariances are left unchanged and should be updated in a future
+    full-state correction pass
+"""
+
+from __future__ import annotations
+
+from oasis_control.localization.ahrs.ahrs_config import AhrsConfig
+from oasis_control.localization.ahrs.ahrs_error_state import AhrsErrorStateLayout
+from oasis_control.localization.ahrs.ahrs_linalg import innovation_covariance
+from oasis_control.localization.ahrs.ahrs_linalg import is_finite_seq
+from oasis_control.localization.ahrs.ahrs_linalg import mahalanobis_d2_3
+from oasis_control.localization.ahrs.ahrs_linalg import mat3_inv
+from oasis_control.localization.ahrs.ahrs_linalg import mat_mul
+from oasis_control.localization.ahrs.ahrs_linalg import mat_transpose
+from oasis_control.localization.ahrs.ahrs_linalg import mat_vec_mul
+from oasis_control.localization.ahrs.ahrs_linalg import symmetrize
+from oasis_control.localization.ahrs.ahrs_state import AhrsNominalState
+from oasis_control.localization.ahrs.ahrs_types import AhrsMatrix
+from oasis_control.localization.ahrs.ahrs_types import AhrsTime
+from oasis_control.localization.ahrs.ahrs_types import AhrsUpdateData
+from oasis_control.localization.ahrs.ahrs_types import ImuSample
+
+
+def _copy_state(state: AhrsNominalState) -> AhrsNominalState:
+    return AhrsNominalState(
+        p_wb_m=list(state.p_wb_m),
+        v_wb_mps=list(state.v_wb_mps),
+        q_wb_wxyz=list(state.q_wb_wxyz),
+        omega_wb_rps=list(state.omega_wb_rps),
+        b_g_rps=list(state.b_g_rps),
+        b_a_mps2=list(state.b_a_mps2),
+        a_a=list(state.a_a),
+        t_bi=state.t_bi,
+        t_bm=state.t_bm,
+        g_w_mps2=list(state.g_w_mps2),
+        m_w_t=list(state.m_w_t),
+    )
+
+
+def _empty_matrix() -> AhrsMatrix:
+    return AhrsMatrix(rows=0, cols=0, data=[])
+
+
+def _matrix3(data: list[float]) -> AhrsMatrix:
+    return AhrsMatrix(rows=3, cols=3, data=list(data))
+
+
+def _extract_block(
+    p: list[float], dim: int, sl_rows: slice, sl_cols: slice
+) -> list[float]:
+    rows: int = sl_rows.stop - sl_rows.start
+    cols: int = sl_cols.stop - sl_cols.start
+    if rows != 3 or cols != 3:
+        raise ValueError("gyro update expects a 3x3 block")
+    block: list[float] = [0.0] * (rows * cols)
+    for r in range(rows):
+        row_idx: int = sl_rows.start + r
+        base: int = row_idx * dim + sl_cols.start
+        for c in range(cols):
+            block[r * cols + c] = p[base + c]
+    return block
+
+
+def _set_block(
+    p: list[float],
+    dim: int,
+    sl_rows: slice,
+    sl_cols: slice,
+    block: list[float],
+) -> None:
+    rows: int = sl_rows.stop - sl_rows.start
+    cols: int = sl_cols.stop - sl_cols.start
+    if len(block) != rows * cols:
+        raise ValueError("block size does not match slice dimensions")
+    for r in range(rows):
+        row_idx: int = sl_rows.start + r
+        base: int = row_idx * dim + sl_cols.start
+        for c in range(cols):
+            p[base + c] = block[r * cols + c]
+
+
+def _build_reject_report(
+    *,
+    frame_id: str,
+    t_meas: AhrsTime,
+    reason: str,
+    z: list[float],
+    z_hat: list[float],
+    nu: list[float],
+    r: AhrsMatrix,
+    s_hat: AhrsMatrix,
+    s: AhrsMatrix,
+    maha_d2: float,
+    gate_threshold: float,
+) -> AhrsUpdateData:
+    return AhrsUpdateData(
+        sensor="gyro",
+        frame_id=frame_id,
+        t_meas=t_meas,
+        accepted=False,
+        reject_reason=reason,
+        z=z,
+        z_hat=z_hat,
+        nu=nu,
+        r=r,
+        s_hat=s_hat,
+        s=s,
+        maha_d2=maha_d2,
+        gate_threshold=gate_threshold,
+    )
+
+
+def update_gyro(
+    layout: AhrsErrorStateLayout,
+    state: AhrsNominalState,
+    p: list[float],
+    imu: ImuSample,
+    config: AhrsConfig,
+    *,
+    frame_id: str,
+    t_meas: AhrsTime,
+) -> tuple[AhrsNominalState, list[float], AhrsUpdateData]:
+    """
+    Apply a gyro update to the AHRS nominal state and covariance
+    """
+
+    dim: int = layout.dim
+    if len(p) != dim * dim:
+        raise ValueError("p must have length dim * dim")
+
+    z: list[float] = list(imu.angular_velocity_rps)
+    r_raw: list[float] = list(imu.angular_velocity_cov)
+
+    if len(z) != 3 or len(r_raw) != 9:
+        return (
+            state,
+            list(p),
+            _build_reject_report(
+                frame_id=frame_id,
+                t_meas=t_meas,
+                reason="invalid_measurement",
+                z=[],
+                z_hat=[],
+                nu=[],
+                r=_empty_matrix(),
+                s_hat=_empty_matrix(),
+                s=_empty_matrix(),
+                maha_d2=0.0,
+                gate_threshold=config.gyro_gate_d2_threshold,
+            ),
+        )
+
+    if not is_finite_seq(z) or not is_finite_seq(r_raw):
+        return (
+            state,
+            list(p),
+            _build_reject_report(
+                frame_id=frame_id,
+                t_meas=t_meas,
+                reason="invalid_measurement",
+                z=list(z),
+                z_hat=[],
+                nu=[],
+                r=_matrix3(r_raw),
+                s_hat=_empty_matrix(),
+                s=_empty_matrix(),
+                maha_d2=0.0,
+                gate_threshold=config.gyro_gate_d2_threshold,
+            ),
+        )
+
+    z_hat: list[float] = list(state.omega_wb_rps)
+    nu: list[float] = [
+        z[0] - z_hat[0],
+        z[1] - z_hat[1],
+        z[2] - z_hat[2],
+    ]
+
+    if not is_finite_seq(z_hat) or not is_finite_seq(nu):
+        return (
+            state,
+            list(p),
+            _build_reject_report(
+                frame_id=frame_id,
+                t_meas=t_meas,
+                reason="invalid_prediction",
+                z=list(z),
+                z_hat=list(z_hat),
+                nu=list(nu),
+                r=_matrix3(r_raw),
+                s_hat=_empty_matrix(),
+                s=_empty_matrix(),
+                maha_d2=0.0,
+                gate_threshold=config.gyro_gate_d2_threshold,
+            ),
+        )
+
+    sl_omega: slice = layout.sl_omega()
+    s_hat_raw: list[float] = _extract_block(p, dim, sl_omega, sl_omega)
+    s_hat: list[float] = symmetrize(s_hat_raw, 3)
+    r: list[float] = symmetrize(r_raw, 3)
+    s: list[float] = innovation_covariance(s_hat, r)
+    s = symmetrize(s, 3)
+
+    maha_d2: float
+    try:
+        maha_d2 = mahalanobis_d2_3(nu, s)
+    except ValueError:
+        return (
+            state,
+            list(p),
+            _build_reject_report(
+                frame_id=frame_id,
+                t_meas=t_meas,
+                reason="singular_innovation_covariance",
+                z=list(z),
+                z_hat=list(z_hat),
+                nu=list(nu),
+                r=_matrix3(r),
+                s_hat=_matrix3(s_hat),
+                s=_matrix3(s),
+                maha_d2=0.0,
+                gate_threshold=config.gyro_gate_d2_threshold,
+            ),
+        )
+
+    gate_threshold: float = config.gyro_gate_d2_threshold
+    if gate_threshold > 0.0 and maha_d2 > gate_threshold:
+        return (
+            state,
+            list(p),
+            _build_reject_report(
+                frame_id=frame_id,
+                t_meas=t_meas,
+                reason="mahalanobis_gate",
+                z=list(z),
+                z_hat=list(z_hat),
+                nu=list(nu),
+                r=_matrix3(r),
+                s_hat=_matrix3(s_hat),
+                s=_matrix3(s),
+                maha_d2=maha_d2,
+                gate_threshold=gate_threshold,
+            ),
+        )
+
+    s_inv: list[float]
+    try:
+        s_inv = mat3_inv(s)
+    except ValueError:
+        return (
+            state,
+            list(p),
+            _build_reject_report(
+                frame_id=frame_id,
+                t_meas=t_meas,
+                reason="singular_innovation_covariance",
+                z=list(z),
+                z_hat=list(z_hat),
+                nu=list(nu),
+                r=_matrix3(r),
+                s_hat=_matrix3(s_hat),
+                s=_matrix3(s),
+                maha_d2=maha_d2,
+                gate_threshold=gate_threshold,
+            ),
+        )
+
+    k: list[float] = mat_mul(s_hat, 3, 3, s_inv, 3, 3)
+    delta_omega: list[float] = mat_vec_mul(k, 3, 3, nu)
+
+    updated_state: AhrsNominalState = _copy_state(state)
+    updated_state.omega_wb_rps = [
+        state.omega_wb_rps[0] + delta_omega[0],
+        state.omega_wb_rps[1] + delta_omega[1],
+        state.omega_wb_rps[2] + delta_omega[2],
+    ]
+
+    identity: list[float] = [
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+    ]
+    i_minus_k: list[float] = [
+        identity[0] - k[0],
+        identity[1] - k[1],
+        identity[2] - k[2],
+        identity[3] - k[3],
+        identity[4] - k[4],
+        identity[5] - k[5],
+        identity[6] - k[6],
+        identity[7] - k[7],
+        identity[8] - k[8],
+    ]
+
+    temp: list[float] = mat_mul(i_minus_k, 3, 3, s_hat, 3, 3)
+    temp = mat_mul(temp, 3, 3, mat_transpose(i_minus_k, 3, 3), 3, 3)
+    k_r: list[float] = mat_mul(k, 3, 3, r, 3, 3)
+    k_r_kt: list[float] = mat_mul(k_r, 3, 3, mat_transpose(k, 3, 3), 3, 3)
+    p_omega_updated: list[float] = [
+        temp[0] + k_r_kt[0],
+        temp[1] + k_r_kt[1],
+        temp[2] + k_r_kt[2],
+        temp[3] + k_r_kt[3],
+        temp[4] + k_r_kt[4],
+        temp[5] + k_r_kt[5],
+        temp[6] + k_r_kt[6],
+        temp[7] + k_r_kt[7],
+        temp[8] + k_r_kt[8],
+    ]
+    p_omega_updated = symmetrize(p_omega_updated, 3)
+
+    updated_p: list[float] = list(p)
+    _set_block(updated_p, dim, sl_omega, sl_omega, p_omega_updated)
+    updated_p = symmetrize(updated_p, dim)
+
+    report: AhrsUpdateData = AhrsUpdateData(
+        sensor="gyro",
+        frame_id=frame_id,
+        t_meas=t_meas,
+        accepted=True,
+        reject_reason=None,
+        z=list(z),
+        z_hat=list(z_hat),
+        nu=list(nu),
+        r=_matrix3(r),
+        s_hat=_matrix3(s_hat),
+        s=_matrix3(s),
+        maha_d2=maha_d2,
+        gate_threshold=gate_threshold,
+    )
+
+    return updated_state, updated_p, report

--- a/oasis_control/oasis_control/nodes/ahrs_node.py
+++ b/oasis_control/oasis_control/nodes/ahrs_node.py
@@ -1,0 +1,201 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+import message_filters
+import rclpy.node
+import rclpy.publisher
+import rclpy.qos
+import rclpy.subscription
+from sensor_msgs.msg import Imu as ImuMsg
+from sensor_msgs.msg import MagneticField as MagneticFieldMsg
+
+from oasis_control.localization.ahrs.ahrs_filter import AhrsFilter
+from oasis_control.localization.ahrs.ahrs_params import declare_ahrs_params
+from oasis_control.localization.ahrs.ahrs_params import load_ahrs_config
+from oasis_control.localization.ahrs.ahrs_publishers import AhrsPublishers
+from oasis_control.localization.ahrs.ahrs_ros_clock import RosAhrsClock
+from oasis_control.localization.ahrs.ahrs_ros_conversions import ahrs_time_from_ros
+from oasis_control.localization.ahrs.ahrs_ros_conversions import cov3x3_from_ros
+from oasis_control.localization.ahrs.ahrs_ros_conversions import vector3_from_ros
+from oasis_control.localization.ahrs.ahrs_types import AhrsEvent
+from oasis_control.localization.ahrs.ahrs_types import AhrsEventType
+from oasis_control.localization.ahrs.ahrs_types import AhrsImuPacket
+from oasis_control.localization.ahrs.ahrs_types import ImuCalibrationData
+from oasis_control.localization.ahrs.ahrs_types import ImuSample
+from oasis_control.localization.ahrs.ahrs_types import MagSample
+from oasis_msgs.msg import ImuCalibration as ImuCalibrationMsg
+
+
+################################################################################
+# ROS parameters
+################################################################################
+
+
+NODE_NAME: str = "ahrs"
+
+# ROS topics
+IMU_RAW_TOPIC: str = "imu_raw"
+IMU_CAL_TOPIC: str = "imu_calibration"
+MAG_TOPIC: str = "magnetic_field"
+
+ACCEL_UPDATE_TOPIC: str = "ahrs/updates/accel"
+GYRO_UPDATE_TOPIC: str = "ahrs/updates/gyro"
+MAG_UPDATE_TOPIC: str = "ahrs/updates/mag"
+
+EXTRINSICS_T_BI_TOPIC: str = "ahrs/extrinsics/t_bi"
+EXTRINSICS_T_BM_TOPIC: str = "ahrs/extrinsics/t_bm"
+
+
+################################################################################
+# ROS node
+################################################################################
+
+
+class AhrsNode(rclpy.node.Node):
+    def __init__(self) -> None:
+        """
+        Initialize resources
+        """
+
+        super().__init__(NODE_NAME)
+
+        # Declare parameters
+        declare_ahrs_params(self)
+        config = load_ahrs_config(self)
+
+        # QoS profile
+        qos_profile: rclpy.qos.QoSProfile = (
+            rclpy.qos.QoSPresetProfiles.SENSOR_DATA.value
+        )
+
+        # ROS Publishers
+        self._publishers: AhrsPublishers = AhrsPublishers(self, config, qos_profile)
+
+        # AHRS filter
+        self._filter: AhrsFilter = AhrsFilter(config=config, clock=RosAhrsClock(self))
+
+        # ROS Subscribers
+        self._mag_sub: rclpy.subscription.Subscription = self.create_subscription(
+            msg_type=MagneticFieldMsg,
+            topic=MAG_TOPIC,
+            callback=self._handle_mag,
+            qos_profile=qos_profile,
+        )
+        self._imu_raw_filter_sub: message_filters.Subscriber = (
+            message_filters.Subscriber(
+                self,
+                ImuMsg,
+                IMU_RAW_TOPIC,
+                qos_profile=qos_profile,
+            )
+        )
+        self._imu_cal_filter_sub: message_filters.Subscriber = (
+            message_filters.Subscriber(
+                self,
+                ImuCalibrationMsg,
+                IMU_CAL_TOPIC,
+                qos_profile=qos_profile,
+            )
+        )
+
+        # ROS message synchronizers
+        self._imu_sync: message_filters.TimeSynchronizer = (
+            message_filters.TimeSynchronizer(
+                [self._imu_raw_filter_sub, self._imu_cal_filter_sub],
+                queue_size=20,
+            )
+        )
+        self._imu_sync.registerCallback(self._handle_imu_raw_with_calibration)
+
+        self.get_logger().info("AHRS node initialized")
+
+    def stop(self) -> None:
+        self.get_logger().info("AHRS node deinitialized")
+
+        self.destroy_node()
+
+    def _handle_imu_raw_with_calibration(
+        self, imu_msg: ImuMsg, cal_msg: ImuCalibrationMsg
+    ) -> None:
+        if (
+            imu_msg.header.stamp.sec != cal_msg.header.stamp.sec
+            or imu_msg.header.stamp.nanosec != cal_msg.header.stamp.nanosec
+        ):
+            self.get_logger().warning(
+                "IMU sample and calibration have mismatched timestamps"
+            )
+            return
+
+        try:
+            imu_sample: ImuSample = ImuSample(
+                frame_id=imu_msg.header.frame_id,
+                angular_velocity_rps=vector3_from_ros(imu_msg.angular_velocity),
+                linear_acceleration_mps2=vector3_from_ros(imu_msg.linear_acceleration),
+                angular_velocity_cov=cov3x3_from_ros(
+                    imu_msg.angular_velocity_covariance
+                ),
+                linear_acceleration_cov=cov3x3_from_ros(
+                    imu_msg.linear_acceleration_covariance
+                ),
+            )
+            calibration: ImuCalibrationData = ImuCalibrationData(
+                valid=bool(cal_msg.valid),
+                frame_id=cal_msg.header.frame_id,
+                accel_bias_mps2=vector3_from_ros(cal_msg.accel_bias),
+                accel_a=[float(value) for value in cal_msg.accel_a],
+                accel_param_cov=[float(value) for value in cal_msg.accel_param_cov],
+                gyro_bias_rps=vector3_from_ros(cal_msg.gyro_bias),
+                gyro_bias_cov=cov3x3_from_ros(cal_msg.gyro_bias_cov),
+                gravity_mps2=float(cal_msg.gravity_mps2),
+                fit_sample_count=int(cal_msg.fit_sample_count),
+                rms_residual_mps2=float(cal_msg.rms_residual_mps2),
+                temperature_c=float(cal_msg.temperature_c),
+                temperature_var_c2=float(cal_msg.temperature_var_c2),
+            )
+        except ValueError as exc:
+            self.get_logger().warning(f"Invalid IMU covariance data: {exc}")
+            return
+
+        packet: AhrsImuPacket = AhrsImuPacket(
+            imu=imu_sample,
+            calibration=calibration,
+        )
+        event: AhrsEvent = AhrsEvent(
+            t_meas=ahrs_time_from_ros(imu_msg.header.stamp),
+            topic=IMU_RAW_TOPIC,
+            frame_id=imu_msg.header.frame_id,
+            event_type=AhrsEventType.IMU,
+            payload=packet,
+        )
+
+        outputs = self._filter.handle_event(event)
+        self._publishers.publish_outputs(outputs)
+
+    def _handle_mag(self, message: MagneticFieldMsg) -> None:
+        try:
+            sample: MagSample = MagSample(
+                frame_id=message.header.frame_id,
+                magnetic_field_t=vector3_from_ros(message.magnetic_field),
+                magnetic_field_cov=cov3x3_from_ros(message.magnetic_field_covariance),
+            )
+        except ValueError as exc:
+            self.get_logger().warning(f"Invalid magnetometer covariance data: {exc}")
+            return
+
+        event: AhrsEvent = AhrsEvent(
+            t_meas=ahrs_time_from_ros(message.header.stamp),
+            topic=MAG_TOPIC,
+            frame_id=message.header.frame_id,
+            event_type=AhrsEventType.MAG,
+            payload=sample,
+        )
+
+        outputs = self._filter.handle_event(event)
+        self._publishers.publish_outputs(outputs)

--- a/oasis_control/setup.py
+++ b/oasis_control/setup.py
@@ -68,6 +68,7 @@ setuptools.setup(
     ],
     entry_points={
         "console_scripts": [
+            "ahrs = oasis_control.cli.ahrs_cli:main",
             "conductor_manager_firmata = oasis_control.cli.conductor_manager_firmata_cli:main",
             "conductor_manager_telemetrix = oasis_control.cli.conductor_manager_telemetrix_cli:main",
             "ekf_localizer = oasis_control.cli.ekf_localizer_cli:main",

--- a/oasis_control/test/test_ahrs_conversions.py
+++ b/oasis_control/test/test_ahrs_conversions.py
@@ -1,0 +1,48 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from oasis_control.localization.ahrs.ahrs_conversions import ahrs_time_from_pair
+from oasis_control.localization.ahrs.ahrs_conversions import cov3x3_from_seq
+from oasis_control.localization.ahrs.ahrs_conversions import normalize_ahrs_time
+from oasis_control.localization.ahrs.ahrs_types import AhrsTime
+
+
+def test_cov3x3_from_seq_rejects_length() -> None:
+    with pytest.raises(ValueError):
+        cov3x3_from_seq([0.0] * 8)
+
+
+def test_cov3x3_from_seq_rejects_nan() -> None:
+    cov: list[float] = [0.0] * 8 + [math.nan]
+
+    with pytest.raises(ValueError):
+        cov3x3_from_seq(cov)
+
+
+def test_normalize_ahrs_time_carries_nanoseconds() -> None:
+    t_raw: AhrsTime = AhrsTime(sec=123, nanosec=1_500_000_000)
+
+    normalized: AhrsTime = normalize_ahrs_time(t_raw)
+
+    assert normalized.sec == 124
+    assert normalized.nanosec == 500_000_000
+
+
+def test_ahrs_time_from_pair_normalizes_input() -> None:
+    normalized: AhrsTime = ahrs_time_from_pair(sec=10, nanosec=2_000_000_001)
+
+    assert normalized.sec == 12
+    assert normalized.nanosec == 1

--- a/oasis_control/test/test_ahrs_error_state_layout.py
+++ b/oasis_control/test/test_ahrs_error_state_layout.py
@@ -1,0 +1,66 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+from oasis_control.localization.ahrs.ahrs_error_state import AhrsErrorStateLayout
+from oasis_control.localization.ahrs.ahrs_error_state import ErrorBlock
+from oasis_control.localization.ahrs.ahrs_error_state import error_state_names
+from oasis_control.localization.ahrs.ahrs_state import AhrsNominalState
+from oasis_control.localization.ahrs.ahrs_state import default_nominal_state
+from oasis_control.localization.ahrs.ahrs_state import validate_nominal_state
+
+
+def test_layout_dim_matches_names_length() -> None:
+    layout: AhrsErrorStateLayout = AhrsErrorStateLayout()
+    names: list[str] = error_state_names(layout)
+
+    assert len(names) == layout.dim
+
+
+def test_layout_blocks_are_contiguous_and_non_overlapping() -> None:
+    layout: AhrsErrorStateLayout = AhrsErrorStateLayout()
+    current: int = 0
+
+    for key in layout.order:
+        block: ErrorBlock = layout.blocks[key]
+        assert block.start == current
+        current = block.start + block.dim
+
+    assert current == layout.dim
+
+
+def test_specific_block_dims() -> None:
+    layout: AhrsErrorStateLayout = AhrsErrorStateLayout()
+
+    assert layout.blocks["p"].dim == 3
+    assert layout.blocks["v"].dim == 3
+    assert layout.blocks["theta"].dim == 3
+    assert layout.blocks["omega"].dim == 3
+    assert layout.blocks["bg"].dim == 3
+    assert layout.blocks["ba"].dim == 3
+    assert layout.blocks["Aa"].dim == 9
+    assert layout.blocks["xi_bi"].dim == 6
+    assert layout.blocks["xi_bm"].dim == 6
+    assert layout.blocks["g"].dim == 3
+    assert layout.blocks["m"].dim == 3
+
+
+def test_default_nominal_state_shapes() -> None:
+    state: AhrsNominalState = default_nominal_state(
+        body_frame_id="base_link",
+        imu_frame_id="imu",
+        mag_frame_id="mag",
+    )
+
+    validate_nominal_state(state)
+
+    assert state.t_bi.parent_frame == "base_link"
+    assert state.t_bi.child_frame == "imu"
+    assert state.t_bm.parent_frame == "base_link"
+    assert state.t_bm.child_frame == "mag"

--- a/oasis_control/test/test_ahrs_filter_gyro_update.py
+++ b/oasis_control/test/test_ahrs_filter_gyro_update.py
@@ -1,0 +1,119 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+from __future__ import annotations
+
+from oasis_control.localization.ahrs.ahrs_clock import AhrsClock
+from oasis_control.localization.ahrs.ahrs_config import AhrsConfig
+from oasis_control.localization.ahrs.ahrs_filter import AhrsFilter
+from oasis_control.localization.ahrs.ahrs_types import AhrsEvent
+from oasis_control.localization.ahrs.ahrs_types import AhrsEventType
+from oasis_control.localization.ahrs.ahrs_types import AhrsImuPacket
+from oasis_control.localization.ahrs.ahrs_types import AhrsOutputs
+from oasis_control.localization.ahrs.ahrs_types import AhrsTime
+from oasis_control.localization.ahrs.ahrs_types import AhrsUpdateData
+from oasis_control.localization.ahrs.ahrs_types import ImuCalibrationData
+from oasis_control.localization.ahrs.ahrs_types import ImuSample
+
+
+class FixedClock(AhrsClock):
+    def __init__(self, now_sec: int, now_nanosec: int) -> None:
+        self._now_sec: int = now_sec
+        self._now_nanosec: int = now_nanosec
+
+    def now(self) -> AhrsTime:
+        return AhrsTime(sec=self._now_sec, nanosec=self._now_nanosec)
+
+
+def _config(*, gyro_gate_d2_threshold: float) -> AhrsConfig:
+    return AhrsConfig(
+        world_frame_id="world",
+        odom_frame_id="odom",
+        body_frame_id="base_link",
+        t_buffer_sec=0.5,
+        epsilon_wall_future_sec=1.0,
+        dt_clock_jump_max_sec=0.0,
+        dt_imu_max_sec=0.0,
+        gyro_gate_d2_threshold=gyro_gate_d2_threshold,
+        mag_alpha=1.0,
+        mag_r_min=[0.0] * 9,
+        mag_r_max=[0.0] * 9,
+        mag_r0=[0.0] * 9,
+        q_v=0.0,
+        q_w=0.0,
+        q_bg=0.0,
+        q_ba=0.0,
+        q_a=0.0,
+        q_bi=0.0,
+        q_bm=0.0,
+        q_g=0.0,
+        q_m=0.0,
+    )
+
+
+def _imu_event_at(sec: int, nanosec: int) -> AhrsEvent:
+    imu: ImuSample = ImuSample(
+        frame_id="imu",
+        angular_velocity_rps=[0.1, 0.0, 0.0],
+        linear_acceleration_mps2=[0.0, 0.0, 0.0],
+        angular_velocity_cov=[
+            0.01,
+            0.0,
+            0.0,
+            0.0,
+            0.01,
+            0.0,
+            0.0,
+            0.0,
+            0.01,
+        ],
+        linear_acceleration_cov=[0.0] * 9,
+    )
+    calibration: ImuCalibrationData = ImuCalibrationData(
+        valid=True,
+        frame_id="imu",
+        accel_bias_mps2=[0.0, 0.0, 0.0],
+        accel_a=[0.0] * 9,
+        accel_param_cov=[0.0] * 144,
+        gyro_bias_rps=[0.0, 0.0, 0.0],
+        gyro_bias_cov=[0.0] * 9,
+        gravity_mps2=9.81,
+        fit_sample_count=0,
+        rms_residual_mps2=0.0,
+        temperature_c=20.0,
+        temperature_var_c2=0.0,
+    )
+    packet: AhrsImuPacket = AhrsImuPacket(imu=imu, calibration=calibration)
+
+    return AhrsEvent(
+        t_meas=AhrsTime(sec=sec, nanosec=nanosec),
+        topic="imu",
+        frame_id="imu",
+        event_type=AhrsEventType.IMU,
+        payload=packet,
+    )
+
+
+def test_filter_reports_gyro_update() -> None:
+    clock: FixedClock = FixedClock(now_sec=10, now_nanosec=0)
+    filt: AhrsFilter = AhrsFilter(
+        config=_config(gyro_gate_d2_threshold=9.0),
+        clock=clock,
+    )
+
+    outputs: AhrsOutputs = filt.handle_event(_imu_event_at(1, 0))
+
+    gyro_update: AhrsUpdateData
+    assert outputs.gyro_update is not None
+    gyro_update = outputs.gyro_update
+    assert gyro_update.accepted is True
+    assert gyro_update.z == [0.1, 0.0, 0.0]
+    assert gyro_update.r.rows == 3
+    assert gyro_update.s.rows == 3

--- a/oasis_control/test/test_ahrs_filter_stub.py
+++ b/oasis_control/test/test_ahrs_filter_stub.py
@@ -1,0 +1,237 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+from __future__ import annotations
+
+import pytest
+
+from oasis_control.localization.ahrs.ahrs_clock import AhrsClock
+from oasis_control.localization.ahrs.ahrs_config import AhrsConfig
+from oasis_control.localization.ahrs.ahrs_filter import AhrsFilter
+from oasis_control.localization.ahrs.ahrs_types import AhrsEvent
+from oasis_control.localization.ahrs.ahrs_types import AhrsEventType
+from oasis_control.localization.ahrs.ahrs_types import AhrsImuPacket
+from oasis_control.localization.ahrs.ahrs_types import AhrsOutputs
+from oasis_control.localization.ahrs.ahrs_types import AhrsTime
+from oasis_control.localization.ahrs.ahrs_types import ImuCalibrationData
+from oasis_control.localization.ahrs.ahrs_types import ImuSample
+from oasis_control.localization.ahrs.ahrs_types import MagSample
+
+
+class FixedClock(AhrsClock):
+    def __init__(self, now_sec: int, now_nanosec: int) -> None:
+        self._now_sec: int = now_sec
+        self._now_nanosec: int = now_nanosec
+
+    def now(self) -> AhrsTime:
+        return AhrsTime(sec=self._now_sec, nanosec=self._now_nanosec)
+
+
+def _config(
+    *,
+    t_buffer_sec: float = 0.5,
+    dt_clock_jump_max_sec: float = 0.0,
+    dt_imu_max_sec: float = 0.0,
+) -> AhrsConfig:
+    return AhrsConfig(
+        world_frame_id="world",
+        odom_frame_id="odom",
+        body_frame_id="base_link",
+        t_buffer_sec=t_buffer_sec,
+        epsilon_wall_future_sec=1.0,
+        dt_clock_jump_max_sec=dt_clock_jump_max_sec,
+        dt_imu_max_sec=dt_imu_max_sec,
+        gyro_gate_d2_threshold=9.0,
+        mag_alpha=1.0,
+        mag_r_min=[0.0] * 9,
+        mag_r_max=[0.0] * 9,
+        mag_r0=[0.0] * 9,
+        q_v=0.0,
+        q_w=0.0,
+        q_bg=0.0,
+        q_ba=0.0,
+        q_a=0.0,
+        q_bi=0.0,
+        q_bm=0.0,
+        q_g=0.0,
+        q_m=0.0,
+    )
+
+
+def _event_at(sec: int, nanosec: int) -> AhrsEvent:
+    sample: MagSample = MagSample(
+        frame_id="mag",
+        magnetic_field_t=[0.0, 0.0, 0.0],
+        magnetic_field_cov=[0.0] * 9,
+    )
+
+    return AhrsEvent(
+        t_meas=AhrsTime(sec=sec, nanosec=nanosec),
+        topic="magnetic_field",
+        frame_id="mag",
+        event_type=AhrsEventType.MAG,
+        payload=sample,
+    )
+
+
+def _imu_event_at(sec: int, nanosec: int) -> AhrsEvent:
+    imu: ImuSample = ImuSample(
+        frame_id="imu",
+        angular_velocity_rps=[0.0, 0.0, 0.0],
+        linear_acceleration_mps2=[0.0, 0.0, 0.0],
+        angular_velocity_cov=[0.0] * 9,
+        linear_acceleration_cov=[0.0] * 9,
+    )
+    calibration: ImuCalibrationData = ImuCalibrationData(
+        valid=True,
+        frame_id="imu",
+        accel_bias_mps2=[0.0, 0.0, 0.0],
+        accel_a=[0.0] * 9,
+        accel_param_cov=[0.0] * 144,
+        gyro_bias_rps=[0.0, 0.0, 0.0],
+        gyro_bias_cov=[0.0] * 9,
+        gravity_mps2=9.81,
+        fit_sample_count=0,
+        rms_residual_mps2=0.0,
+        temperature_c=20.0,
+        temperature_var_c2=0.0,
+    )
+    packet: AhrsImuPacket = AhrsImuPacket(imu=imu, calibration=calibration)
+
+    return AhrsEvent(
+        t_meas=AhrsTime(sec=sec, nanosec=nanosec),
+        topic="imu",
+        frame_id="imu",
+        event_type=AhrsEventType.IMU,
+        payload=packet,
+    )
+
+
+def test_ahrs_filter_frontier_advance_publishes_state() -> None:
+    clock: FixedClock = FixedClock(now_sec=10, now_nanosec=0)
+    filt: AhrsFilter = AhrsFilter(config=_config(), clock=clock)
+
+    first: AhrsOutputs = filt.handle_event(_event_at(1, 0))
+    second: AhrsOutputs = filt.handle_event(_event_at(2, 0))
+
+    assert first.frontier_advanced is True
+    assert second.frontier_advanced is True
+    assert first.state is not None
+    assert second.state is not None
+    assert first.state.state_seq == 1
+    assert second.state.state_seq == 2
+
+
+def test_ahrs_filter_out_of_order_does_not_publish_state() -> None:
+    clock: FixedClock = FixedClock(now_sec=10, now_nanosec=0)
+    filt: AhrsFilter = AhrsFilter(config=_config(), clock=clock)
+
+    first: AhrsOutputs = filt.handle_event(_event_at(2, 0))
+    out_of_order: AhrsOutputs = filt.handle_event(_event_at(1, 0))
+    assert first.frontier_advanced is True
+    assert out_of_order.frontier_advanced is False
+    assert out_of_order.state is None
+    assert out_of_order.diagnostics is None
+    assert out_of_order.mag_update is not None
+
+
+def test_ahrs_filter_window_rejects_too_old() -> None:
+    clock: FixedClock = FixedClock(now_sec=20, now_nanosec=0)
+    filt: AhrsFilter = AhrsFilter(config=_config(t_buffer_sec=0.5), clock=clock)
+
+    advance: AhrsOutputs = filt.handle_event(_event_at(10, 0))
+    dropped: AhrsOutputs = filt.handle_event(_event_at(9, 0))
+
+    assert advance.frontier_advanced is True
+    assert dropped.frontier_advanced is False
+    assert dropped.state is None
+    assert dropped.t_filter == advance.t_filter
+
+
+def test_ahrs_filter_clock_jump_resets_on_large_abs_dt() -> None:
+    clock: FixedClock = FixedClock(now_sec=30, now_nanosec=0)
+    filt: AhrsFilter = AhrsFilter(
+        config=_config(dt_clock_jump_max_sec=1.0), clock=clock
+    )
+
+    initial: AhrsOutputs = filt.handle_event(_event_at(10, 0))
+    jumped: AhrsOutputs = filt.handle_event(_event_at(20, 500_000_000))
+
+    assert initial.frontier_advanced is True
+    assert jumped.frontier_advanced is False
+    assert filt._t_filter is None
+    assert filt._initialized is False
+    assert filt._reset_count == 1
+    assert filt._dropped_clock_jump_reset == 1
+
+
+def test_ahrs_filter_negative_dt_raises() -> None:
+    clock: FixedClock = FixedClock(now_sec=30, now_nanosec=0)
+    filt: AhrsFilter = AhrsFilter(config=_config(), clock=clock)
+    start_time: AhrsTime = AhrsTime(sec=2, nanosec=0)
+    earlier_time: AhrsTime = AhrsTime(sec=1, nanosec=0)
+
+    filt._reset_replay_state(start_time)
+
+    with pytest.raises(ValueError, match="dt_sec must be non-negative"):
+        filt._propagate_to(earlier_time)
+
+
+def test_buffer_node_count_and_span_reported() -> None:
+    clock: FixedClock = FixedClock(now_sec=10, now_nanosec=0)
+    filt: AhrsFilter = AhrsFilter(config=_config(t_buffer_sec=5.0), clock=clock)
+
+    first: AhrsOutputs = filt.handle_event(_event_at(1, 0))
+    second: AhrsOutputs = filt.handle_event(_event_at(2, 0))
+
+    assert first.frontier_advanced is True
+    assert second.diagnostics is not None
+    assert second.diagnostics.buffer_node_count == 2
+    assert second.diagnostics.buffer_span_sec == 1.0
+
+
+def test_replay_flag_set_after_out_of_order_event() -> None:
+    clock: FixedClock = FixedClock(now_sec=10, now_nanosec=0)
+    filt: AhrsFilter = AhrsFilter(config=_config(t_buffer_sec=5.0), clock=clock)
+
+    first: AhrsOutputs = filt.handle_event(_event_at(2, 0))
+    assert first.diagnostics is not None
+    assert first.diagnostics.replay_happened is False
+
+    out_of_order: AhrsOutputs = filt.handle_event(_event_at(1, 0))
+    assert out_of_order.frontier_advanced is False
+    assert out_of_order.diagnostics is None
+
+    second: AhrsOutputs = filt.handle_event(_event_at(3, 0))
+    assert second.diagnostics is not None
+    assert second.diagnostics.replay_happened is True
+
+    third: AhrsOutputs = filt.handle_event(_event_at(4, 0))
+    assert third.diagnostics is not None
+    assert third.diagnostics.replay_happened is False
+
+
+def test_imu_gap_detection_ignores_mag_only_nodes() -> None:
+    clock: FixedClock = FixedClock(now_sec=10, now_nanosec=0)
+    filt: AhrsFilter = AhrsFilter(
+        config=_config(t_buffer_sec=20.0, dt_imu_max_sec=0.15),
+        clock=clock,
+    )
+
+    first_imu: AhrsOutputs = filt.handle_event(_imu_event_at(1, 0))
+    second_imu: AhrsOutputs = filt.handle_event(_imu_event_at(1, 100_000_000))
+    mag_late: AhrsOutputs = filt.handle_event(_event_at(10, 0))
+    out_of_order_imu: AhrsOutputs = filt.handle_event(_imu_event_at(1, 200_000_000))
+
+    assert first_imu.frontier_advanced is True
+    assert second_imu.frontier_advanced is True
+    assert mag_late.frontier_advanced is True
+    assert out_of_order_imu.frontier_advanced is False
+    assert filt._dropped_imu_gap == 0

--- a/oasis_control/test/test_ahrs_inject_validation.py
+++ b/oasis_control/test/test_ahrs_inject_validation.py
@@ -1,0 +1,135 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from oasis_control.localization.ahrs.ahrs_inject import inject_error_state
+from oasis_control.localization.ahrs.ahrs_state import AhrsNominalState
+from oasis_control.localization.ahrs.ahrs_state import default_nominal_state
+
+
+@dataclass(frozen=True)
+class _LayoutStub:
+    dim: int
+    _sl_p: slice
+    _sl_v: slice
+    _sl_theta: slice
+    _sl_omega: slice
+    _sl_bg: slice
+    _sl_ba: slice
+    _sl_aa: slice
+    _sl_xi_bi: slice
+    _sl_xi_bm: slice
+    _sl_g: slice
+    _sl_m: slice
+
+    def sl_p(self) -> slice:
+        return self._sl_p
+
+    def sl_v(self) -> slice:
+        return self._sl_v
+
+    def sl_theta(self) -> slice:
+        return self._sl_theta
+
+    def sl_omega(self) -> slice:
+        return self._sl_omega
+
+    def sl_bg(self) -> slice:
+        return self._sl_bg
+
+    def sl_ba(self) -> slice:
+        return self._sl_ba
+
+    def sl_Aa(self) -> slice:
+        return self._sl_aa
+
+    def sl_xi_bi(self) -> slice:
+        return self._sl_xi_bi
+
+    def sl_xi_bm(self) -> slice:
+        return self._sl_xi_bm
+
+    def sl_g(self) -> slice:
+        return self._sl_g
+
+    def sl_m(self) -> slice:
+        return self._sl_m
+
+
+def _build_layout_stub(aa_len: int, xi_bi_len: int) -> _LayoutStub:
+    start: int = 0
+    sl_p: slice = slice(start, start + 3)
+    start += 3
+    sl_v: slice = slice(start, start + 3)
+    start += 3
+    sl_theta: slice = slice(start, start + 3)
+    start += 3
+    sl_omega: slice = slice(start, start + 3)
+    start += 3
+    sl_bg: slice = slice(start, start + 3)
+    start += 3
+    sl_ba: slice = slice(start, start + 3)
+    start += 3
+    sl_aa: slice = slice(start, start + aa_len)
+    start += aa_len
+    sl_xi_bi: slice = slice(start, start + xi_bi_len)
+    start += xi_bi_len
+    sl_xi_bm: slice = slice(start, start + 6)
+    start += 6
+    sl_g: slice = slice(start, start + 3)
+    start += 3
+    sl_m: slice = slice(start, start + 3)
+    start += 3
+
+    return _LayoutStub(
+        dim=start,
+        _sl_p=sl_p,
+        _sl_v=sl_v,
+        _sl_theta=sl_theta,
+        _sl_omega=sl_omega,
+        _sl_bg=sl_bg,
+        _sl_ba=sl_ba,
+        _sl_aa=sl_aa,
+        _sl_xi_bi=sl_xi_bi,
+        _sl_xi_bm=sl_xi_bm,
+        _sl_g=sl_g,
+        _sl_m=sl_m,
+    )
+
+
+def _default_state() -> AhrsNominalState:
+    return default_nominal_state(
+        body_frame_id="base_link",
+        imu_frame_id="imu",
+        mag_frame_id="mag",
+    )
+
+
+def test_inject_error_state_rejects_bad_aa_length() -> None:
+    layout: _LayoutStub = _build_layout_stub(aa_len=8, xi_bi_len=6)
+    state: AhrsNominalState = _default_state()
+    delta_x: list[float] = [0.0] * layout.dim
+
+    with pytest.raises(ValueError, match="delta_aa must have length 9"):
+        inject_error_state(layout, state, delta_x)
+
+
+def test_inject_error_state_rejects_bad_xi_length() -> None:
+    layout: _LayoutStub = _build_layout_stub(aa_len=9, xi_bi_len=5)
+    state: AhrsNominalState = _default_state()
+    delta_x: list[float] = [0.0] * layout.dim
+
+    with pytest.raises(ValueError, match="delta_xi_bi must have length 6"):
+        inject_error_state(layout, state, delta_x)

--- a/oasis_control/test/test_ahrs_linalg.py
+++ b/oasis_control/test/test_ahrs_linalg.py
@@ -1,0 +1,176 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+from __future__ import annotations
+
+import math
+
+from oasis_control.localization.ahrs.ahrs_linalg import is_finite_seq
+from oasis_control.localization.ahrs.ahrs_linalg import mahalanobis_d2_3
+from oasis_control.localization.ahrs.ahrs_linalg import mat3_inv
+from oasis_control.localization.ahrs.ahrs_linalg import mat3_solve
+from oasis_control.localization.ahrs.ahrs_linalg import mat_mul
+from oasis_control.localization.ahrs.ahrs_linalg import mat_transpose
+from oasis_control.localization.ahrs.ahrs_linalg import project_to_symmetric_psd_3
+from oasis_control.localization.ahrs.ahrs_linalg import symmetrize
+
+
+def test_transpose_roundtrip_2x3() -> None:
+    original: list[float] = [
+        1.0,
+        2.0,
+        3.0,
+        4.0,
+        5.0,
+        6.0,
+    ]
+    transposed: list[float] = mat_transpose(original, 2, 3)
+    roundtrip: list[float] = mat_transpose(transposed, 3, 2)
+
+    assert roundtrip == original
+
+
+def test_mat_mul_identity_3x3() -> None:
+    identity: list[float] = [
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+    ]
+    matrix: list[float] = [
+        2.0,
+        -1.0,
+        3.0,
+        0.5,
+        4.0,
+        2.0,
+        -2.0,
+        1.0,
+        0.25,
+    ]
+
+    product: list[float] = mat_mul(matrix, 3, 3, identity, 3, 3)
+
+    assert product == matrix
+
+
+def test_mat3_inv_identity() -> None:
+    identity: list[float] = [
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+    ]
+
+    inverted: list[float] = mat3_inv(identity)
+
+    assert inverted == identity
+
+
+def test_mat3_solve_known_system() -> None:
+    matrix: list[float] = [
+        2.0,
+        0.0,
+        0.0,
+        0.0,
+        3.0,
+        0.0,
+        0.0,
+        0.0,
+        4.0,
+    ]
+    b: list[float] = [2.0, 9.0, 8.0]
+
+    solution: list[float] = mat3_solve(matrix, b)
+
+    assert solution == [1.0, 3.0, 2.0]
+
+
+def test_symmetrize_makes_symmetric() -> None:
+    matrix: list[float] = [
+        1.0,
+        2.0,
+        3.0,
+        4.0,
+        5.0,
+        6.0,
+        7.0,
+        8.0,
+        9.0,
+    ]
+
+    symmetric: list[float] = symmetrize(matrix, 3)
+
+    assert symmetric[1] == symmetric[3]
+    assert symmetric[2] == symmetric[6]
+    assert symmetric[5] == symmetric[7]
+
+
+def test_mahalanobis_d2_matches_manual() -> None:
+    identity: list[float] = [
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+    ]
+    nu: list[float] = [1.0, 2.0, 3.0]
+
+    d2: float = mahalanobis_d2_3(nu, identity)
+
+    assert d2 == 14.0
+
+
+def test_project_to_symmetric_psd_3_fallback_on_bad_matrix() -> None:
+    matrix: list[float] = [
+        1.0,
+        2.0,
+        0.0,
+        2.0,
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+    ]
+
+    projected: list[float] = project_to_symmetric_psd_3(matrix, diag_min=0.1)
+
+    assert projected == [
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+    ]
+
+
+def test_is_finite_seq() -> None:
+    assert is_finite_seq([0.0, 1.0, -2.5])
+    assert not is_finite_seq([math.inf, 1.0])
+    assert not is_finite_seq([math.nan, 0.0])

--- a/oasis_control/test/test_ahrs_predict.py
+++ b/oasis_control/test/test_ahrs_predict.py
@@ -1,0 +1,142 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+from __future__ import annotations
+
+import math
+
+from oasis_control.localization.ahrs.ahrs_config import AhrsConfig
+from oasis_control.localization.ahrs.ahrs_error_state import AhrsErrorStateLayout
+from oasis_control.localization.ahrs.ahrs_predict import _quat_from_rotvec
+from oasis_control.localization.ahrs.ahrs_predict import predict_covariance
+from oasis_control.localization.ahrs.ahrs_predict import predict_nominal
+from oasis_control.localization.ahrs.ahrs_state import AhrsNominalState
+from oasis_control.localization.ahrs.ahrs_state import default_nominal_state
+
+
+def _config(**overrides: float) -> AhrsConfig:
+    values: dict[str, float] = {
+        "q_v": 0.0,
+        "q_w": 0.0,
+        "q_bg": 0.0,
+        "q_ba": 0.0,
+        "q_a": 0.0,
+        "q_bi": 0.0,
+        "q_bm": 0.0,
+        "q_g": 0.0,
+        "q_m": 0.0,
+    }
+    for key, value in overrides.items():
+        values[key] = value
+
+    return AhrsConfig(
+        world_frame_id="world",
+        odom_frame_id="odom",
+        body_frame_id="base_link",
+        t_buffer_sec=0.0,
+        epsilon_wall_future_sec=0.0,
+        dt_clock_jump_max_sec=0.0,
+        dt_imu_max_sec=0.0,
+        gyro_gate_d2_threshold=9.0,
+        mag_alpha=1.0,
+        mag_r_min=[0.0] * 9,
+        mag_r_max=[0.0] * 9,
+        mag_r0=[0.0] * 9,
+        q_v=values["q_v"],
+        q_w=values["q_w"],
+        q_bg=values["q_bg"],
+        q_ba=values["q_ba"],
+        q_a=values["q_a"],
+        q_bi=values["q_bi"],
+        q_bm=values["q_bm"],
+        q_g=values["q_g"],
+        q_m=values["q_m"],
+    )
+
+
+def test_ahrs_predict_nominal_integrates_p_v() -> None:
+    state: AhrsNominalState = default_nominal_state(
+        body_frame_id="base_link",
+        imu_frame_id="imu",
+        mag_frame_id="mag",
+    )
+    state.v_wb_mps = [1.0, 0.0, 0.0]
+    state.g_w_mps2 = [0.0, 0.0, -9.81]
+
+    predicted: AhrsNominalState = predict_nominal(state, dt_sec=1.0)
+
+    assert predicted.p_wb_m[0] == 1.0
+    assert predicted.v_wb_mps[2] == -9.81
+
+
+def test_ahrs_predict_quaternion_small_angle_normalized() -> None:
+    state: AhrsNominalState = default_nominal_state(
+        body_frame_id="base_link",
+        imu_frame_id="imu",
+        mag_frame_id="mag",
+    )
+    state.omega_wb_rps = [0.001, 0.0, 0.0]
+
+    predicted: AhrsNominalState = predict_nominal(state, dt_sec=0.01)
+
+    norm: float = math.sqrt(sum(value * value for value in predicted.q_wb_wxyz))
+    assert math.isclose(norm, 1.0, rel_tol=0.0, abs_tol=1.0e-12)
+
+
+def test_ahrs_predict_small_angle_exp_map_is_normalized() -> None:
+    dq_wb: list[float] = _quat_from_rotvec([1.0e-15, 0.0, 0.0])
+
+    norm: float = math.sqrt(sum(value * value for value in dq_wb))
+    assert math.isclose(norm, 1.0, rel_tol=0.0, abs_tol=1.0e-15)
+
+
+def test_ahrs_predict_covariance_zero_dt_returns_copy() -> None:
+    layout: AhrsErrorStateLayout = AhrsErrorStateLayout()
+    dim: int = layout.dim
+    p: list[float] = [0.0] * (dim * dim)
+    p[0] = 0.25
+    p[1] = -0.1
+    p[dim] = -0.1
+
+    predicted: list[float] = predict_covariance(layout, p, dt_sec=0.0, config=_config())
+
+    assert predicted == p
+    assert predicted is not p
+
+
+def test_ahrs_predict_covariance_symmetry() -> None:
+    layout: AhrsErrorStateLayout = AhrsErrorStateLayout()
+    dim: int = layout.dim
+    p: list[float] = [0.0] * (dim * dim)
+    p[0] = 1.0
+    p[1] = 0.2
+    p[dim] = 0.2
+
+    predicted: list[float] = predict_covariance(
+        layout, p, dt_sec=0.5, config=_config(q_v=0.1)
+    )
+
+    for r in range(dim):
+        for c in range(dim):
+            assert predicted[r * dim + c] == predicted[c * dim + r]
+
+
+def test_ahrs_predict_covariance_has_process_noise_on_expected_blocks() -> None:
+    layout: AhrsErrorStateLayout = AhrsErrorStateLayout()
+    dim: int = layout.dim
+    p: list[float] = [0.0] * (dim * dim)
+
+    predicted: list[float] = predict_covariance(
+        layout, p, dt_sec=0.5, config=_config(q_v=0.3)
+    )
+
+    sl_v: slice = layout.sl_v()
+    for i in range(sl_v.start, sl_v.stop):
+        assert predicted[i * dim + i] > 0.0

--- a/oasis_control/test/test_ahrs_quat.py
+++ b/oasis_control/test/test_ahrs_quat.py
@@ -1,0 +1,29 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+from __future__ import annotations
+
+import math
+
+from oasis_control.localization.ahrs.ahrs_quat import quat_from_rotvec_wxyz
+
+
+def test_quat_from_rotvec_small_angle_normalizes() -> None:
+    rotvec: list[float] = [1.0e-13, -2.0e-13, 0.5e-13]
+    quat: list[float] = quat_from_rotvec_wxyz(rotvec)
+
+    norm: float = math.sqrt(
+        quat[0] * quat[0]
+        + quat[1] * quat[1]
+        + quat[2] * quat[2]
+        + quat[3] * quat[3]
+    )
+
+    assert math.isclose(norm, 1.0, rel_tol=0.0, abs_tol=1.0e-12)

--- a/oasis_control/test/test_ahrs_timeline.py
+++ b/oasis_control/test/test_ahrs_timeline.py
@@ -1,0 +1,58 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+from __future__ import annotations
+
+from oasis_control.localization.ahrs.ahrs_timeline import AhrsTimeBuffer
+from oasis_control.localization.ahrs.ahrs_timeline import AhrsTimeNode
+from oasis_control.localization.ahrs.ahrs_types import AhrsEvent
+from oasis_control.localization.ahrs.ahrs_types import AhrsEventType
+from oasis_control.localization.ahrs.ahrs_types import AhrsTime
+from oasis_control.localization.ahrs.ahrs_types import MagSample
+
+
+def _event_at(sec: int, nanosec: int) -> AhrsEvent:
+    sample: MagSample = MagSample(
+        frame_id="mag",
+        magnetic_field_t=[0.0, 0.0, 0.0],
+        magnetic_field_cov=[0.0] * 9,
+    )
+
+    return AhrsEvent(
+        t_meas=AhrsTime(sec=sec, nanosec=nanosec),
+        topic="magnetic_field",
+        frame_id="mag",
+        event_type=AhrsEventType.MAG,
+        payload=sample,
+    )
+
+
+def test_time_buffer_orders_nodes() -> None:
+    buffer: AhrsTimeBuffer = AhrsTimeBuffer()
+
+    buffer.insert_event(_event_at(2, 0))
+    buffer.insert_event(_event_at(1, 0))
+    buffer.insert_event(_event_at(1, 500))
+
+    nodes: list[AhrsTimeNode] = list(buffer.iter_nodes())
+    times: list[tuple[int, int]] = [(node.t.sec, node.t.nanosec) for node in nodes]
+
+    assert times == [(1, 0), (1, 500), (2, 0)]
+
+
+def test_time_buffer_span_sec() -> None:
+    buffer: AhrsTimeBuffer = AhrsTimeBuffer()
+
+    buffer.insert_event(_event_at(1, 0))
+    buffer.insert_event(_event_at(3, 0))
+
+    span_sec: float = buffer.span_sec()
+
+    assert span_sec == 2.0

--- a/oasis_control/test/test_ahrs_update_core.py
+++ b/oasis_control/test/test_ahrs_update_core.py
@@ -1,0 +1,175 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+from __future__ import annotations
+
+import math
+
+from oasis_control.localization.ahrs.ahrs_error_state import AhrsErrorStateLayout
+from oasis_control.localization.ahrs.ahrs_inject import inject_error_state
+from oasis_control.localization.ahrs.ahrs_state import AhrsNominalState
+from oasis_control.localization.ahrs.ahrs_state import default_nominal_state
+from oasis_control.localization.ahrs.ahrs_types import AhrsTime
+from oasis_control.localization.ahrs.ahrs_types import AhrsUpdateData
+from oasis_control.localization.ahrs.ahrs_update_core import kalman_update
+
+
+def _diag_covariance(layout: AhrsErrorStateLayout) -> list[float]:
+    dim: int = layout.dim
+    p: list[float] = [0.0] * (dim * dim)
+    for i in range(dim):
+        p[i * dim + i] = 0.0
+    return p
+
+
+def _set_diag(p: list[float], dim: int, index: int, value: float) -> None:
+    p[index * dim + index] = value
+
+
+def test_ahrs_update_core_gyro_equivalence() -> None:
+    layout: AhrsErrorStateLayout = AhrsErrorStateLayout()
+    dim: int = layout.dim
+    p: list[float] = _diag_covariance(layout)
+
+    omega_var: float = 0.2
+    bg_var: float = 0.05
+    sl_omega: slice = layout.sl_omega()
+    sl_bg: slice = layout.sl_bg()
+    for i in range(3):
+        _set_diag(p, dim, sl_omega.start + i, omega_var)
+        _set_diag(p, dim, sl_bg.start + i, bg_var)
+
+    z: list[float] = [1.0, 0.0, 0.0]
+    z_hat: list[float] = [0.0, 0.0, 0.0]
+    nu: list[float] = [1.0, 0.0, 0.0]
+
+    h: list[float] = [0.0] * (3 * dim)
+    for i in range(3):
+        h[i * dim + sl_omega.start + i] = 1.0
+        h[i * dim + sl_bg.start + i] = 1.0
+
+    r: list[float] = [
+        0.1,
+        0.0,
+        0.0,
+        0.0,
+        0.1,
+        0.0,
+        0.0,
+        0.0,
+        0.1,
+    ]
+
+    updated_p: list[float]
+    report: AhrsUpdateData
+    accepted: bool
+    delta_x: list[float]
+    updated_p, report, accepted, delta_x = kalman_update(
+        layout,
+        p,
+        z=z,
+        z_hat=z_hat,
+        nu=nu,
+        h=h,
+        r=r,
+        gate_threshold=10.0,
+        sensor="gyro",
+        frame_id="imu",
+        t_meas=AhrsTime(sec=0, nanosec=0),
+    )
+
+    expected_s: float = omega_var + bg_var + r[0]
+    expected_gain_omega: float = omega_var / expected_s
+    expected_gain_bg: float = bg_var / expected_s
+
+    assert report is not None
+    assert accepted is True
+    assert math.isclose(
+        delta_x[sl_omega.start],
+        expected_gain_omega,
+        rel_tol=0.0,
+        abs_tol=1.0e-9,
+    )
+    assert math.isclose(
+        delta_x[sl_bg.start],
+        expected_gain_bg,
+        rel_tol=0.0,
+        abs_tol=1.0e-9,
+    )
+    assert updated_p[sl_omega.start * dim + sl_omega.start] < omega_var
+    assert updated_p[sl_bg.start * dim + sl_bg.start] < bg_var
+
+
+def test_inject_error_state_theta_updates_quaternion() -> None:
+    layout: AhrsErrorStateLayout = AhrsErrorStateLayout()
+    state: AhrsNominalState = default_nominal_state(
+        body_frame_id="base_link",
+        imu_frame_id="imu",
+        mag_frame_id="mag",
+    )
+
+    delta_x: list[float] = [0.0] * layout.dim
+    sl_theta: slice = layout.sl_theta()
+    delta_x[sl_theta.start] = 1.0e-3
+    delta_x[sl_theta.start + 1] = -2.0e-3
+    delta_x[sl_theta.start + 2] = 0.5e-3
+
+    updated_state: AhrsNominalState = inject_error_state(layout, state, delta_x)
+
+    rx: float = delta_x[sl_theta.start]
+    ry: float = delta_x[sl_theta.start + 1]
+    rz: float = delta_x[sl_theta.start + 2]
+    angle: float = math.sqrt(rx * rx + ry * ry + rz * rz)
+
+    half_angle: float = 0.5 * angle
+    if angle == 0.0:
+        expected_q: list[float] = [1.0, 0.0, 0.0, 0.0]
+    else:
+        sin_half: float = math.sin(half_angle)
+        inv_angle: float = 1.0 / angle
+        expected_q = [
+            math.cos(half_angle),
+            rx * inv_angle * sin_half,
+            ry * inv_angle * sin_half,
+            rz * inv_angle * sin_half,
+        ]
+
+    norm: float = math.sqrt(
+        updated_state.q_wb_wxyz[0] * updated_state.q_wb_wxyz[0]
+        + updated_state.q_wb_wxyz[1] * updated_state.q_wb_wxyz[1]
+        + updated_state.q_wb_wxyz[2] * updated_state.q_wb_wxyz[2]
+        + updated_state.q_wb_wxyz[3] * updated_state.q_wb_wxyz[3]
+    )
+
+    assert math.isclose(norm, 1.0, rel_tol=0.0, abs_tol=1.0e-9)
+    assert math.isclose(
+        updated_state.q_wb_wxyz[0],
+        expected_q[0],
+        rel_tol=0.0,
+        abs_tol=1.0e-9,
+    )
+    assert math.isclose(
+        updated_state.q_wb_wxyz[1],
+        expected_q[1],
+        rel_tol=0.0,
+        abs_tol=1.0e-9,
+    )
+    assert math.isclose(
+        updated_state.q_wb_wxyz[2],
+        expected_q[2],
+        rel_tol=0.0,
+        abs_tol=1.0e-9,
+    )
+    assert math.isclose(
+        updated_state.q_wb_wxyz[3],
+        expected_q[3],
+        rel_tol=0.0,
+        abs_tol=1.0e-9,
+    )

--- a/oasis_control/test/test_ahrs_update_gyro.py
+++ b/oasis_control/test/test_ahrs_update_gyro.py
@@ -1,0 +1,147 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+from __future__ import annotations
+
+import math
+
+from oasis_control.localization.ahrs.ahrs_config import AhrsConfig
+from oasis_control.localization.ahrs.ahrs_error_state import AhrsErrorStateLayout
+from oasis_control.localization.ahrs.ahrs_state import AhrsNominalState
+from oasis_control.localization.ahrs.ahrs_state import default_nominal_state
+from oasis_control.localization.ahrs.ahrs_types import AhrsTime
+from oasis_control.localization.ahrs.ahrs_types import AhrsUpdateData
+from oasis_control.localization.ahrs.ahrs_types import ImuSample
+from oasis_control.localization.ahrs.ahrs_update_gyro import update_gyro
+
+
+def _config(*, gyro_gate_d2_threshold: float) -> AhrsConfig:
+    return AhrsConfig(
+        world_frame_id="world",
+        odom_frame_id="odom",
+        body_frame_id="base_link",
+        t_buffer_sec=0.0,
+        epsilon_wall_future_sec=0.0,
+        dt_clock_jump_max_sec=0.0,
+        dt_imu_max_sec=0.0,
+        gyro_gate_d2_threshold=gyro_gate_d2_threshold,
+        mag_alpha=1.0,
+        mag_r_min=[0.0] * 9,
+        mag_r_max=[0.0] * 9,
+        mag_r0=[0.0] * 9,
+        q_v=0.0,
+        q_w=0.0,
+        q_bg=0.0,
+        q_ba=0.0,
+        q_a=0.0,
+        q_bi=0.0,
+        q_bm=0.0,
+        q_g=0.0,
+        q_m=0.0,
+    )
+
+
+def _imu_sample(omega_rps: list[float], cov: list[float]) -> ImuSample:
+    return ImuSample(
+        frame_id="imu",
+        angular_velocity_rps=list(omega_rps),
+        linear_acceleration_mps2=[0.0, 0.0, 0.0],
+        angular_velocity_cov=list(cov),
+        linear_acceleration_cov=[0.0] * 9,
+    )
+
+
+def _cov_diag(value: float) -> list[float]:
+    return [
+        value,
+        0.0,
+        0.0,
+        0.0,
+        value,
+        0.0,
+        0.0,
+        0.0,
+        value,
+    ]
+
+
+def _initial_covariance(layout: AhrsErrorStateLayout, value: float) -> list[float]:
+    dim: int = layout.dim
+    p: list[float] = [0.0] * (dim * dim)
+    for i in range(dim):
+        p[i * dim + i] = value
+    return p
+
+
+def test_gyro_update_accepts_and_updates_omega() -> None:
+    layout: AhrsErrorStateLayout = AhrsErrorStateLayout()
+    state: AhrsNominalState = default_nominal_state(
+        body_frame_id="base_link",
+        imu_frame_id="imu",
+        mag_frame_id="mag",
+    )
+    p: list[float] = _initial_covariance(layout, value=0.1)
+    imu: ImuSample = _imu_sample([1.0, 0.0, 0.0], _cov_diag(0.01))
+
+    updated_state: AhrsNominalState
+    updated_p: list[float]
+    update_report: AhrsUpdateData
+    updated_state, updated_p, update_report = update_gyro(
+        layout,
+        state,
+        p,
+        imu,
+        _config(gyro_gate_d2_threshold=10.0),
+        frame_id="imu",
+        t_meas=AhrsTime(sec=1, nanosec=0),
+    )
+
+    expected_gain: float = 0.1 / (0.1 + 0.01)
+    expected_omega: float = expected_gain
+    assert update_report.accepted is True
+    assert update_report.reject_reason is None
+    assert math.isclose(
+        updated_state.omega_wb_rps[0],
+        expected_omega,
+        rel_tol=0.0,
+        abs_tol=1.0e-6,
+    )
+    sl_omega: slice = layout.sl_omega()
+    omega_diag_index: int = sl_omega.start * layout.dim + sl_omega.start
+    assert updated_p[omega_diag_index] < 0.1
+
+
+def test_gyro_update_rejects_large_innovation() -> None:
+    layout: AhrsErrorStateLayout = AhrsErrorStateLayout()
+    state: AhrsNominalState = default_nominal_state(
+        body_frame_id="base_link",
+        imu_frame_id="imu",
+        mag_frame_id="mag",
+    )
+    p: list[float] = _initial_covariance(layout, value=0.1)
+    imu: ImuSample = _imu_sample([10.0, 0.0, 0.0], _cov_diag(0.01))
+
+    updated_state: AhrsNominalState
+    updated_p: list[float]
+    update_report: AhrsUpdateData
+    updated_state, updated_p, update_report = update_gyro(
+        layout,
+        state,
+        p,
+        imu,
+        _config(gyro_gate_d2_threshold=1.0),
+        frame_id="imu",
+        t_meas=AhrsTime(sec=1, nanosec=0),
+    )
+
+    assert update_report.accepted is False
+    assert update_report.reject_reason == "mahalanobis_gate"
+    assert updated_state.omega_wb_rps == state.omega_wb_rps
+    assert updated_p == p

--- a/oasis_control/test/test_ahrs_update_gyro.py
+++ b/oasis_control/test/test_ahrs_update_gyro.py
@@ -103,13 +103,22 @@ def test_gyro_update_accepts_and_updates_omega() -> None:
         t_meas=AhrsTime(sec=1, nanosec=0),
     )
 
-    expected_gain: float = 0.1 / (0.1 + 0.01)
-    expected_omega: float = expected_gain
+    expected_s: float = 0.1 + 0.1 + 0.01
+    expected_gain_omega: float = 0.1 / expected_s
+    expected_gain_bg: float = 0.1 / expected_s
+    expected_omega: float = expected_gain_omega
+    expected_bg: float = expected_gain_bg
     assert update_report.accepted is True
     assert update_report.reject_reason is None
     assert math.isclose(
         updated_state.omega_wb_rps[0],
         expected_omega,
+        rel_tol=0.0,
+        abs_tol=1.0e-6,
+    )
+    assert math.isclose(
+        updated_state.b_g_rps[0],
+        expected_bg,
         rel_tol=0.0,
         abs_tol=1.0e-6,
     )

--- a/oasis_msgs/CMakeLists.txt
+++ b/oasis_msgs/CMakeLists.txt
@@ -31,6 +31,8 @@ ament_export_dependencies(rosidl_default_runtime)
 rosidl_generate_interfaces(
   ${PROJECT_NAME}
     msg/Accelerometer.msg
+    msg/AhrsDiagnostics.msg
+    msg/AhrsState.msg
     msg/AirQuality.msg
     msg/AnalogButton.msg
     msg/AnalogReading.msg

--- a/oasis_msgs/msg/AhrsDiagnostics.msg
+++ b/oasis_msgs/msg/AhrsDiagnostics.msg
@@ -1,0 +1,55 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+#
+# Health / replay / drop diagnostics for the AHRS node.
+#
+# Conventions
+# - header.stamp = t_filter (frontier)
+# - header.frame_id = world frame_id
+#
+
+# Frontier timestamp and world frame_id
+std_msgs/Header header
+
+# Monotonic diagnostic sequence index
+uint64 diag_seq
+
+# The filter's current frontier timestamp in seconds (for convenience)
+float64 t_filter_sec
+
+#
+# Buffer / replay stats
+#
+
+# Number of time nodes currently retained
+uint32 buffer_node_count
+
+# Approximate time span covered by the buffer (s)
+float32 buffer_span_sec
+
+# True if an out-of-order message triggered replay on the most recent callback
+bool replay_happened
+
+#
+# Drop counters (monotonic since node start)
+#
+
+uint64 dropped_missing_stamp
+uint64 dropped_future_stamp
+uint64 dropped_too_old
+uint64 dropped_nan_cov
+uint64 dropped_imu_coverage_gap
+uint64 dropped_clock_jump_reset
+
+#
+# Most recent reset reason (empty if no reset yet)
+#
+string last_reset_reason

--- a/oasis_msgs/msg/AhrsState.msg
+++ b/oasis_msgs/msg/AhrsState.msg
@@ -1,0 +1,124 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+#
+# Full AHRS filter state snapshot at the current frontier time t_filter.
+#
+# This message exists so consumers can inspect ALL in-state parameters and
+# their FULL (non-diagonalized) covariance in a single place.
+#
+# Conventions
+# - header.stamp = t_filter (frontier)
+# - header.frame_id = world frame ("world") for all world-expressed vectors
+#
+# Frames
+# - {W}: world
+# - {B}: base_link (body)
+# - {I}: IMU frame
+# - {M}: magnetometer frame
+#
+
+# Frontier timestamp and world frame_id
+std_msgs/Header header
+
+#
+# Frame ids in use by the node (published contract)
+#
+string world_frame_id
+string odom_frame_id
+string body_frame_id
+
+#
+# Monotonic sequence index for state publications
+#
+uint64 state_seq
+
+#
+# True when the filter has consumed its initial priors and is running
+#
+bool initialized
+
+#
+# Navigation state
+#
+
+# Position of B expressed in W (m)
+geometry_msgs/Point position_wb_m
+
+# Velocity of B expressed in W (m/s)
+geometry_msgs/Vector3 velocity_wb_mps
+
+# Attitude (world -> body), unit quaternion
+geometry_msgs/Quaternion orientation_wb
+
+#
+# IMU systematic parameters (in-state)
+#
+
+# Gyroscope bias b_g (rad/s), expressed in IMU frame {I} unless otherwise specified by the node
+geometry_msgs/Vector3 gyro_bias
+
+# Accelerometer bias b_a (m/s^2), expressed in IMU frame {I} unless otherwise specified by the node
+geometry_msgs/Vector3 accel_bias
+
+# Accelerometer scale/misalignment matrix A_a
+# Units: unitless
+# Layout: 3x3 row-major
+float64[9] accel_a
+
+#
+# Extrinsics (sensor -> body)
+#
+
+# IMU -> body transform T_BI
+geometry_msgs/Pose t_bi
+
+# Magnetometer -> body transform T_BM
+geometry_msgs/Pose t_bm
+
+#
+# Environment / reference vectors (in-state)
+#
+
+# Gravity vector expressed in world (m/s^2)
+geometry_msgs/Vector3 gravity_w_mps2
+
+# Earth magnetic field vector expressed in world (tesla)
+geometry_msgs/Vector3 magnetic_field_w_t
+
+#
+# FULL covariance over the AHRS internal error-state.
+#
+# This is the single source of truth for "not diagonalized" covariance reporting.
+#
+# Matrix is row-major with dimensions error_dim x error_dim.
+#
+# IMPORTANT: error_state_names defines the exact ordering of this covariance.
+#
+
+# Error-state dimension (must match p.rows == p.cols == error_dim)
+uint32 error_dim
+
+# Names of each scalar error-state element, length = error_dim.
+# Example entries:
+# - "dp.x", "dp.y", "dp.z"
+# - "dv.x", "dv.y", "dv.z"
+# - "dtheta.x", "dtheta.y", "dtheta.z"
+# - "dbg.x", ...
+# - "dba.x", ...
+# - "dAa.0", ..., "dAa.8"
+# - "dT_BI.rho.x", ..., "dT_BI.theta.z"
+# - "dT_BM.rho.x", ..., "dT_BM.theta.z"
+# - "dg.x", ...
+# - "dm.x", ...
+string[] error_state_names
+
+# Full error-state covariance P
+oasis_msgs/Matrix p


### PR DESCRIPTION
### Motivation

- Reduce duplicated quaternion math and tighten contracts in the AHRS core by centralizing quaternion utilities. 
- Make error-state injection more explicit about expected block sizes to avoid silent mismatches when applying corrections. 
- Improve update diagnostics by including the measurement noise `R` in invalid-measurement reports when available.

### Description

- Add `oasis_control/localization/ahrs/ahrs_quat.py` with pure-math helpers `quat_mul_wxyz`, `quat_normalize_wxyz`, and `quat_from_rotvec_wxyz` and document wxyz / Exp(rotvec) conventions. 
- Refactor `ahrs_predict.py` and `ahrs_inject.py` to import and use the new quaternion helpers and normalize after composition. 
- Tighten `inject_error_state()` by validating each extracted block length (3 for vectors, 9 for accel matrix `A_a`, 6 for extrinsic `xi` blocks) and raising `ValueError` with clear messages; apply accel matrix correction using explicit `range(9)`. 
- Add a short docstring note to `kalman_update()` that `layout` is used for `layout.dim` only and change the invalid-measurement early-return path to include `R` in the report when `r` matches `m*m` (preserving prior empty `s_hat/s` behavior). 
- Keep the math layer ROS-free and add SPDX header and typing to new files per repo guidelines.

### Testing

- Added unit tests `oasis_control/test/test_ahrs_quat.py` and `oasis_control/test/test_ahrs_inject_validation.py` covering small-angle quaternion normalization and `inject_error_state` block-size validation. 
- Ran the new tests with `PYTHONPATH=/workspace/OASIS/oasis_control pytest oasis_control/test/test_ahrs_quat.py oasis_control/test/test_ahrs_inject_validation.py` and observed `3 passed` (all added tests passed). 
- Local collection initially failed without package path, but with the repository package path set the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d932561508326ba3257ae552b57c5)