### PR TITLE
Add AHRS core localization stubs

### DIFF
--- a/docs/AHRS.md
+++ b/docs/AHRS.md
@@ -1,0 +1,610 @@
+# AHRS Design Document
+
+This document defines the **state-space model** and **time-handling policy** for an AHRS that uses:
+
+- a continuous-time **process model**: kinematic evolution + slow parameter drift (priors), and
+- discrete-time **measurement models**:
+  - IMU gyro + accel measurements (`imu_raw`) and
+  - magnetometer measurements (`magnetic_field`),
+
+all applied on a common time axis with deterministic fixed-lag replay.
+
+---
+
+## World / Odom frame contract
+
+The AHRS publishes the standard TF chain:
+
+`world -> odom -> base_link`
+
+Policy (no teleports, no global correction):
+
+- `world` is initialized at startup to the origin (continuous).
+- `odom` is continuous and **drifts locally**.
+- There are no discontinuities because no global constraints exist.
+
+Recommended implementation contract:
+
+- Publish `TF: world -> odom` as identity for the entire session:
+  - `T_WO := I`
+- Publish `TF: odom -> base_link` as the AHRS estimate:
+  - `T_OB := T_WB` (since `world == odom` under the identity `T_WO`)
+
+This keeps the TF tree compatible with a future localization EKF that may later produce non-identity `T_WO`.
+
+---
+
+## 1. ROS Inputs
+
+### 1.1 Streams
+
+- Single `message_filters` combination (ExactTime) producing an **IMU packet**:
+  - `imu_raw` (`sensor_msgs/Imu`): inertial sample stream (time-stamped)
+  - `imu_calibration` (`oasis_msgs/ImuCalibration`): calibration priors + uncertainty
+    - **Semantic rule:** used **only once** to initialize in-state calibration parameters (initial prior).
+    - After initialization, `imu_calibration` contents are ignored (except diagnostics / consistency checks).
+- `magnetic_field` (`sensor_msgs/MagneticField`): magnetometer samples (time-stamped)
+
+---
+
+### 1.2 `imu_raw` — `sensor_msgs/Imu`
+
+Used fields:
+
+- `header.stamp` (`t_meas`)
+- `header.frame_id` → IMU frame `{I}`
+- `angular_velocity` `ω_raw` and **full** `angular_velocity_covariance` `Σ_ω_raw` (3×3)
+- `linear_acceleration` `a_raw` and **full** `linear_acceleration_covariance` `Σ_a_raw` (3×3)
+
+Ignored:
+
+- `orientation`, `orientation_covariance`
+
+Requirements:
+
+- Covariances are interpreted as **per-sample measurement noise**.
+- `ω_raw`, `a_raw` are expressed in `{I}`.
+- Do not diagonalize any provided covariance.
+
+---
+
+### 1.3 `imu_calibration` — `oasis_msgs/ImuCalibration`
+
+Role: **one-shot initialization prior** for systematic parameters that live in the shared state.
+
+Validity:
+
+- If `valid == false`, ignore.
+
+Frame:
+
+- `header.frame_id` must match `imu_raw.header.frame_id` (calibration is defined in `{I}`).
+
+Models (parameter meaning):
+
+- Accel: `a_corr = A_a (a_raw − b_a)` where `b_a, A_a` are **in-state**
+- Gyro: `ω_corr = ω_raw − b_g` where `b_g` is **in-state**
+
+Requirements:
+
+- Consume **only while uninitialized**:
+  - The **first** valid calibration observed is applied as an initial prior on `(b_a, A_a, b_g)` with its covariance.
+  - After initialization, ignore subsequent calibration messages (except diagnostics).
+- Calibration uncertainty is **systematic parameter uncertainty**, not per-sample noise.
+- Always use full covariance matrices when provided (do not diagonalize).
+
+---
+
+### 1.4 `magnetic_field` — `sensor_msgs/MagneticField`
+
+Used fields:
+
+- `header.stamp` (`t_meas`)
+- `header.frame_id` → mag frame `{M}`
+- `magnetic_field` `m_raw`
+- **full** `magnetic_field_covariance` `Σ_m_raw` (3×3)
+
+Measurement convention:
+
+- Form magnetometer residual in `{M}` (do not rotate the raw measurement into `{B}`):
+  - `z := m_raw` in `{M}`
+  - `z_hat := m̂_M` in `{M}`
+  - `ν := z - z_hat` in `{M}`
+
+Noise interpretation:
+
+- `Σ_m_raw` is the driver’s estimate of measurement noise covariance and is used as a prior / input to the
+  internally maintained `R_m(t)` (but not treated as per-sample truth).
+- Do not diagonalize any provided covariance.
+
+Adaptive noise policy (covariance matching):
+
+- Initialize `R_m0` from first valid `Σ_m_raw`, else default:
+  - `R_m0 = diag([4e-10, 4e-10, 4e-10])` (tesla²) (20 µT RMS per axis)
+- Maintain adaptive `R_m(t)` bounded SPD:
+  - `R_min = diag([1e-12, 1e-12, 1e-12])` (tesla²)
+  - `R_max = diag([2.5e-9, 2.5e-9, 2.5e-9])` (tesla²)
+- Update:
+  - Let innovation be `ν_k`, predicted innovation covariance excluding R be `Ŝ_k = HPHᵀ`
+  - `R_m ← clamp_SPD( (1-α) R_m + α (ν_k ν_kᵀ - Ŝ_k), R_min, R_max )`
+  - default `α = 0.01`
+
+---
+
+## 2. Frames and Extrinsics
+
+Frames:
+
+- `{W}`: world frame, ROS frame_id = `world`
+- `{O}`: odom frame, ROS frame_id = `odom`
+- `{B}`: body frame, ROS child_frame_id = `base_link`
+- `{I}`: IMU measurement frame (`imu_raw.header.frame_id`)
+- `{M}`: magnetometer frame (`magnetic_field.header.frame_id`)
+
+Estimated extrinsics (in-state):
+
+- `T_BI` (IMU → body)
+- `T_BM` (mag → body)
+
+Parameterization:
+
+- Poses in SE(3): quaternion rotation + 3-vector translation
+- Uncertainty: 6D tangent (δρ, δθ) for SE(3) quantities
+
+Initialization priors (broad but finite; full covariances allowed and recommended):
+
+- `T_BI` prior:
+  - mean: identity
+  - rotation stddev: `π` rad per axis (tangent)
+  - translation stddev: `1.0 m` per axis
+- `T_BM` prior:
+  - mean: identity
+  - rotation stddev: `π` rad per axis (tangent)
+  - translation stddev: `1.0 m` per axis
+
+---
+
+## 3. State, Process Model, and Measurement Models
+
+This AHRS is a **single optimizer** over a **shared state** with multiple models.
+
+### 3.1 State (full model)
+
+The AHRS maintains a full navigation + calibration + extrinsic state:
+
+Navigation (in `{W}` unless noted):
+
+- Position: `p_WB ∈ ℝ³`
+- Velocity: `v_WB ∈ ℝ³`
+- Attitude: `q_WB` (unit quaternion, world → body rotation)
+
+IMU systematic parameters:
+
+- Gyro bias: `b_g ∈ ℝ³`
+- Accel bias: `b_a ∈ ℝ³`
+- Accel scale/misalignment: `A_a ∈ ℝ^{3×3}` (full matrix)
+
+Extrinsics (sensor-to-body in SE(3)):
+
+- `T_BI ∈ SE(3)` (IMU → body)
+- `T_BM ∈ SE(3)` (mag → body)
+
+Environment / reference vectors (kept in-state, full covariance):
+
+- Gravity vector in world: `g_W ∈ ℝ³`
+- Earth magnetic field vector in world: `m_W ∈ ℝ³`
+
+Full covariance policy:
+
+- The AHRS maintains a single covariance `P` over its internal error-state.
+- Do not diagonalize:
+  - any incoming sensor covariance (`Σ_ω_raw`, `Σ_a_raw`, `Σ_m_raw`),
+  - any priors / initialization covariances,
+  - or internal state covariance blocks.
+
+---
+
+### 3.2 Error-state definition (for covariance)
+
+The AHRS uses an error-state EKF.
+
+Representative error coordinates:
+
+- `δp, δv ∈ ℝ³`
+- `δθ ∈ ℝ³` small-angle attitude error s.t. `q_WB ≈ Exp(δθ) ⊗ q̂_WB`
+- `δb_g, δb_a ∈ ℝ³`
+- `δA_a ∈ ℝ⁹` (row-major perturbation of `A_a`) or an equivalent minimal parameterization
+- `δξ_BI ∈ ℝ⁶`, `δξ_BM ∈ ℝ⁶` (SE(3) tangent: translation + rotation)
+- `δg_W, δm_W ∈ ℝ³`
+
+`P` is the covariance over the stacked error-state vector above (full matrix).
+
+---
+
+### 3.3 Continuous-time process model (kinematic prior + slow drift)
+
+The process model provides time evolution between measurements. Sensor data does **not** drive propagation in this option;
+IMU and mag are measurement updates.
+
+Define continuous-time dynamics:
+
+Navigation kinematics:
+
+- `ṗ_WB = v_WB`
+- `v̇_WB = g_W + w_v`
+- `q̇_WB = 1/2 * Ω(ω_WB) * q_WB`
+
+where:
+- `ω_WB` is the body angular rate (world → body) treated as **latent** (not directly measured in the process model),
+  modeled as:
+  - `ω_WB = w_ω`
+- `w_v`, `w_ω` are zero-mean white noises (continuous-time) representing smoothness priors.
+
+Systematic parameter drift (random walks):
+
+- `ḃ_g = w_bg`
+- `ḃ_a = w_ba`
+- `Ȧ_a = W_A` (element-wise random walk; `vec(Ȧ_a) = w_A`)
+- `Ṫ_BI = W_BI` (SE(3) random walk in tangent; `δξ̇_BI = w_BI`)
+- `Ṫ_BM = W_BM` (SE(3) random walk in tangent; `δξ̇_BM = w_BM`)
+
+Reference vector drift (slow):
+
+- `ġ_W = w_g`
+- `ṁ_W = w_m`
+
+Notes:
+
+- This process is intentionally **weak**: it encodes “motion is smooth” and “parameters drift slowly”.
+- The IMU measurements will strongly constrain the state at high rate.
+
+Process noise covariance:
+
+- Continuous-time noise intensities:
+  - `Q_c = cov([w_v, w_ω, w_bg, w_ba, w_A, w_BI, w_BM, w_g, w_m])`
+- `Q_c` may be block-diagonal by default, but the **state covariance P is full** and will develop cross-terms through
+  Jacobians and updates.
+- If you have known cross-correlations (e.g., coupled accel axes), you may encode them in `Q_c` (full blocks permitted).
+
+Discretization:
+
+- Over interval `Δt`, compute discrete `F_k` and `Q_k` using a standard EKF discretization
+  (e.g., first-order: `Q_k ≈ G Q_c Gᵀ Δt`, with `F_k ≈ I + AΔt`),
+  keeping full matrices.
+
+---
+
+### 3.4 IMU measurement model (discrete-time)
+
+At each `imu_raw` timestamp `t_k`, treat IMU outputs as measurements.
+
+#### 3.4.1 Frame handling for IMU
+
+- IMU raw signals are in `{I}`.
+- Use the estimated extrinsic `T_BI` to relate `{I}` and `{B}`:
+  - Let `R_BI` be the rotation from IMU to body from `T_BI`.
+  - Then body-to-IMU rotation is `R_IB = R_BIᵀ`.
+
+#### 3.4.2 Gyro measurement
+
+Measurement:
+
+- `z_ω := ω_raw` in `{I}` with covariance `R_ω := Σ_ω_raw` (full 3×3)
+
+Prediction:
+
+- Predict IMU-frame angular rate as:
+  - `ω̂_I = R_IB * ω_WB + b_g`
+
+Residual:
+
+- `ν_ω = z_ω - ω̂_I` (in `{I}`)
+
+#### 3.4.3 Accelerometer measurement
+
+Measurement:
+
+- `z_a := a_raw` in `{I}` with covariance `R_a := Σ_a_raw` (full 3×3)
+
+Specific-force prediction:
+
+- Compute world-frame acceleration of the body origin from kinematics:
+  - `a_WB := v̇_WB` (from process state; in the mean model, `v̇_WB ≈ g_W`, but this is refined by measurements)
+- Specific force in body frame is:
+  - `f_B = R_BW * (a_WB - g_W)` where `R_BW` is world → body rotation from `q_WB`
+- Convert to IMU frame:
+  - `f_I = R_IB * f_B`
+
+Apply accel systematic model (as defined by calibration semantics):
+
+- The measurement model uses:
+  - `a_corr = A_a (a_raw − b_a)`
+- Equivalently, the predicted raw measurement is:
+  - `â_raw = A_a^{-1} * f_I + b_a`
+
+Prediction:
+
+- `â_I = A_a^{-1} * f_I + b_a`
+
+Residual:
+
+- `ν_a = z_a - â_I` (in `{I}`)
+
+Notes:
+
+- The above uses a full 3×3 `A_a`. If `A_a` is near-singular, the state/prior must prevent it (bounded parameterization
+  recommended). The covariance remains full regardless of parameterization.
+- `R_a` is always taken as the provided full covariance (or a configured fallback if invalid).
+
+---
+
+### 3.5 Magnetometer measurement model (discrete-time)
+
+At each `magnetic_field` timestamp `t_k`:
+
+- Measurement: `z_m := m_raw` in `{M}`
+- Covariance input: `Σ_m_raw` (full 3×3), used to initialize / inform the adaptive `R_m(t)`.
+
+Prediction (in `{M}`; residual always formed in `{M}`):
+
+- Let `R_BM` be the rotation of `T_BM` (mag → body), so body→mag is `R_MB = R_BMᵀ`.
+- Let `R_BW` be world → body rotation from `q_WB`.
+- Predict:
+  - `m̂_M = R_MB * R_BW * m_W`
+
+Residual:
+
+- `ν_m = z_m - m̂_M` in `{M}`
+
+Measurement noise used:
+
+- `R_m(t)` (adaptive, bounded SPD; full 3×3)
+
+---
+
+## 4. Time Axis, Buffer, and Deterministic Replay (Fixed-lag)
+
+This AHRS uses the same deterministic fixed-lag design as the EKF spec.
+
+### 4.1 Time definitions
+
+- `t_meas`: `header.stamp` from the incoming message (authoritative event time)
+- `t_now`: receipt time (diagnostics only)
+- `t_filter`: max `t_meas` among **accepted** messages (frontier)
+
+Event-driven: each accepted message attaches at `t_meas`. Out-of-order messages are supported via fixed-lag replay.
+
+### 4.2 Message roles
+
+- **Measurement updates (high-rate):** `imu_raw` (gyro + accel updates)
+- **Initialization prior (one-shot):** `imu_calibration`
+- **Measurement updates:** `magnetic_field`
+- **Process model:** runs continuously between time nodes as the kinematic prior and slow parameter drift.
+
+### 4.3 IMU packet synchronization contract
+
+The AHRS consumes IMU as a synchronized pair:
+
+- `imu_pkt = (imu_raw, imu_calibration)` produced by `message_filters` using **ExactTime**.
+
+Timestamp policy:
+
+- Packet time: `t_meas := imu_raw.header.stamp`
+- Require `imu_calibration.header.stamp == imu_raw.header.stamp`; reject packet if not.
+
+Semantic policy:
+
+- `imu_calibration` is used **only before initialization** to set priors on `(b_a, A_a, b_g)` with full covariance.
+- After initialization, `imu_calibration` is ignored (except diagnostics).
+- `imu_raw` always produces measurement updates (gyro + accel) when accepted.
+
+### 4.4 Buffer model
+
+Maintain a time-ordered ring buffer of time nodes over fixed lag `T_buffer_sec`.
+
+Each node at `t_k` stores:
+
+- state mean `x_k`, covariance `P_k`
+- messages attached at `t_k` (IMU packet, mag)
+- sufficient metadata to re-run deterministic replay
+
+Node rules:
+
+- One node per distinct timestamp.
+- Multiple messages may attach to the same node.
+- Evict nodes older than `t_filter - T_buffer_sec` (with diagnostics).
+
+### 4.5 Propagation convention
+
+Between time nodes, propagate with the continuous-time process model (Section 3.3), discretized over each interval.
+
+Strict coverage rule:
+
+- For deterministic replay, the AHRS must be able to propagate across any interval used in replay.
+- If there is a timestamp gap larger than `Δt_imu_max` between consecutive nodes required to cover replay,
+  reject replay across that gap and emit diagnostics.
+
+### 4.6 Insertion + replay (deterministic)
+
+On message arrival:
+
+1. Validate timestamp
+   - reject missing/invalid
+   - reject `t_meas > t_now + ε_wall_future`
+
+2. Fixed-lag window
+   - if `t_filter` exists and `t_meas < t_filter - T_buffer_sec`, reject as too old
+
+3. Attach
+   - insert/attach message to node `t_meas` (create node if needed)
+
+4. Update frontier / replay
+   - if `t_meas > t_filter`: advance `t_filter` and propagate forward
+   - else: apply update at `t_meas`, then replay forward to `t_filter`
+
+Per-node application order (stable):
+
+1. Apply any priors/parameter constraints at `t_k` (including one-shot calibration prior if first valid)
+2. Apply measurement updates at `t_k` in stable tie-break order:
+   - lexicographic `(message_type, topic, frame_id)`
+   - Within IMU: apply gyro update then accel update (fixed order)
+
+Replay must never depend on arrival order.
+
+### 4.7 Drop / reset rules
+
+Reject and emit diagnostics if:
+
+- missing timestamp
+- required covariance contains NaN/Inf
+- message outside fixed-lag window
+- propagation coverage insufficient (`Δt_imu_max` violated)
+- clock discontinuity detected: reset filter + buffer if `|t_meas - t_filter| > Δt_clock_jump_max`
+  - Reset effects (explicit):
+    - clear the time buffer and set `t_filter` to unset
+    - set `initialized = false`
+    - allow consumption of the next valid `imu_calibration` as a new initialization prior
+    - reset adaptive `R_m(t)` to `R_m0`
+
+---
+
+### 4.8 Output publish trigger (explicit)
+
+The AHRS publishes "current estimate" outputs **only when the frontier advances**.
+
+- Let `t_filter_prev` be the frontier before processing an incoming message.
+- After processing a message:
+  - If `t_meas > t_filter_prev` (frontier advance), the filter propagates to `t_meas`, applies updates at `t_meas`,
+    sets `t_filter := t_meas`, and **publishes**:
+      - TF (`world -> odom`, `odom -> base_link`) stamped `t_filter`
+      - odometry outputs stamped `t_filter`
+      - `oasis_msgs/AhrsState` stamped `t_filter`
+      - `oasis_msgs/AhrsDiagnostics` stamped `t_filter`
+  - If `t_meas <= t_filter_prev` (out-of-order insertion), the filter may replay internally to maintain consistency at
+    `t_filter`, but **does not republish** TF/odometry/state/diagnostics (to avoid emitting past timestamps).
+
+Per-measurement update reports (`oasis_msgs/EkfUpdateReport`) are published at the measurement timestamp `t_meas` for
+every accepted/rejected update, regardless of whether the frontier advanced.
+
+---
+
+## 5. Outputs (poses + covariances + measurement stats)
+
+The AHRS publishes:
+
+1. state estimates in ROS-standard frames (`world`, `odom`, `base_link`)
+2. full covariances for those estimates (not diagonalized)
+3. per-measurement innovation / gating statistics (so “all measurements” have covariances too)
+
+### 5.1 TF
+
+- Broadcast `TF: odom -> base_link` from `T_OB` (`stamp = t_filter`)
+- Broadcast `TF: world -> odom` as identity (`stamp = t_filter`)
+
+TF is published on `/tf` (standard tf2 broadcaster).
+
+### 5.2 Odometry messages
+
+**(A) `nav_msgs/Odometry` in `odom`**
+
+- Topic: `ahrs/odom`
+- `header.stamp = t_filter`
+- `header.frame_id = "odom"`
+- `child_frame_id = "base_link"`
+- Pose: `T_OB` (translation from `p_WB`, rotation from `q_WB`)
+- Twist: derived from state (e.g., linear from `v_WB`, angular from `ω_WB` estimate as implied by IMU updates)
+- Covariance: derived from `P` (full covariance propagation, mapped into ROS odom convention)
+
+**(B) `nav_msgs/Odometry` in `world`**
+
+- Topic: `ahrs/world_odom`
+- Same values as (A) under `T_WO = I` contract; covariances derived from the same `P`.
+
+### 5.3 Extrinsic outputs
+
+- `geometry_msgs/PoseWithCovarianceStamped`:
+  - Topic: `ahrs/extrinsics/t_bi` for `T_BI`
+  - Topic: `ahrs/extrinsics/t_bm` for `T_BM`
+  - `header.stamp = t_filter`
+  - `header.frame_id = "base_link"`
+  - Covariance derived from `P` (full 6×6, not diagonalized)
+  - Publish: **on frontier advance** (Section 4.8)
+
+### 5.4 Covariance transformation rules
+
+The AHRS maintains a single covariance `P` over its internal error-state. Published covariances are obtained by:
+
+`Σ_y = J * P * Jᵀ`, with `J = ∂g/∂x` evaluated at `x̂`.
+
+For SE(3) pose errors in tangent (δρ, δθ), use the adjoint:
+
+`Σ_A = Ad_{T_AB} * Σ_B * Ad_{T_AB}ᵀ`
+
+All covariance matrices are full and must remain symmetric positive definite (or PSD as appropriate).
+
+### 5.5 Per-measurement reports
+
+Publish one report entry for every accepted/rejected update:
+
+- `ahrs/updates/accel`
+- `ahrs/updates/gyro`
+- `ahrs/updates/mag`
+
+Contents (recommended):
+
+- `header.stamp = t_meas`
+- `z`, `z_hat`, innovation `ν`
+- measurement noise used `R` (full)
+- predicted innovation covariance excluding R: `Ŝ = HPHᵀ`
+- total innovation covariance `S = Ŝ + R`
+- Mahalanobis distance `d² = νᵀ S^{-1} ν`
+- gating threshold + accept/reject flag
+
+Each per-measurement topic publishes `oasis_msgs/EkfUpdateReport` stamped at `t_meas` for every accepted/rejected update.
+
+### 5.6 `oasis_msgs/AhrsState` (full state + full covariance)
+
+- Topic: `ahrs/state`
+- Publish: **on frontier advance** (Section 4.8)
+- `header.stamp = t_filter`
+- Contents: full mean state (navigation + calibration + extrinsics + `g_W`, `m_W`) and full error-state covariance `P`
+  with explicit ordering (`error_state_names`). No diagonalization.
+
+### 5.7 `oasis_msgs/AhrsDiagnostics` (buffer + drop/replay stats)
+
+- Topic: `ahrs/diag`
+- Publish: **on frontier advance** (Section 4.8)
+- `header.stamp = t_filter`
+- Contents: buffer size/span, replay flag, and monotonic drop/reset counters.
+
+---
+
+## 6. Config Parameters
+
+Frames:
+
+- `world_frame_id` (default `"world"`)
+- `odom_frame_id` (default `"odom"`)
+- `body_frame_id` (default `"base_link"`)
+
+Time / buffering:
+
+- `T_buffer_sec`
+- `ε_wall_future`
+- `Δt_clock_jump_max`
+- `Δt_imu_max`
+
+Process noise intensities (continuous-time):
+
+- `Q_v` (for `w_v`)
+- `Q_ω` (for `w_ω`)
+- `Q_bg`, `Q_ba`
+- `Q_A` (for `vec(A_a)` drift)
+- `Q_BI`, `Q_BM` (for extrinsic drift in SE(3) tangent)
+- `Q_g`, `Q_m` (for `g_W`, `m_W` drift)
+
+Magnetometer adaptive noise:
+
+- `α`
+- `R_min`, `R_max`
+- default `R_m0` (if no valid `Σ_m_raw` observed)

--- a/docs/AHRS_Structure.md
+++ b/docs/AHRS_Structure.md
@@ -1,0 +1,608 @@
+# AHRS Structure Specification
+
+This document defines the target structure, component boundaries, and
+mathematical specification for a full rewrite of the AHRS implementation.
+It is intended to be implemented in small, verifiable steps where each
+component has explicit inputs/outputs and documented math.
+
+The goal is to move from a flat, function-centric layout to a class-based,
+modular system. The core algorithms must be ROS-agnostic. ROS-specific
+integration must be thin and localized.
+
+---
+
+## 1. Directory layout (target)
+
+Create a new AHRS package layout under `oasis_control/oasis_control`, with
+subdirectories to separate core math, estimation, and ROS integration.
+Suggested structure (names are flexible but should follow the intent):
+
+```
+oasis_control/oasis_control/localization/ahrs/
+  math/
+    quat.py
+    se3.py
+    linalg.py
+    stats.py
+    units.py
+
+  models/
+    imu_model.py
+    mag_model.py
+    process_model.py
+    noise_adaptation.py
+    extrinsics_model.py
+
+  state/
+    ahrs_state.py
+    error_state.py
+    covariance.py
+    state_mapping.py
+
+  filter/
+    ekf.py
+    update_step.py
+    predict_step.py
+
+  time/
+    time_base.py
+    timeline.py
+    ring_buffer.py
+    replay_engine.py
+
+  config/
+    ahrs_config.py
+    ahrs_params.py
+
+  io/
+    imu_packet.py
+    mag_packet.py
+    diagnostics.py
+    update_report.py
+
+oasis_control/oasis_control/nodes/ahrs/
+  ahrs_node.py
+  ros_params.py
+  ros_conversions.py
+  ros_publishers.py
+  ros_time.py
+
+oasis_control/test/ahrs/
+  math/
+  models/
+  state/
+  filter/
+  time/
+```
+
+All modules under `oasis_control/oasis_control/` should have `__init__.py` files.
+
+**Key rules**:
+
+- `oasis_control/oasis_control/localization/ahrs/` contains all math, state, and estimation logic.
+- `oasis_control/oasis_control/nodes/ahrs/` contains all ROS types, parameter handling, logging, QoS, and topic
+  wiring.
+- `oasis_control/test/ahrs/` should avoid numpy and depend only on standard library + core code.
+
+---
+
+## 2. Shared math conventions
+
+### 2.1 Frames and symbols
+
+- `{W}`: world frame (`world`)
+- `{O}`: odom frame (`odom`)
+- `{B}`: body frame (`base_link`)
+- `{I}`: IMU measurement frame
+- `{M}`: magnetometer frame
+
+Vectors are columns. Rotations use quaternions and rotation matrices.
+
+### 2.2 Quaternion conventions
+
+- Quaternion `q_WB` rotates vectors from `{W}` to `{B}` (world → body).
+- Rotation matrix `R_WB` is the 3×3 matrix corresponding to `q_WB` such that:
+  - `v_B = R_WB * v_W`
+- The inverse rotation is:
+  - `R_BW = R_WBᵀ`
+- Quaternion action is defined by: `v_B = R(q_AB) * v_A`.
+- Composition (apply `q_AC` then `q_CB`) is: `q_AB = q_CB ⊗ q_AC` (Hamilton product),
+  consistent with: `R(q_CB ⊗ q_AC) = R(q_CB) * R(q_AC)`.
+
+### 2.3 SE(3) perturbations
+
+For any transform `T_AB = (R_AB, p_AB)`:
+
+- Small perturbation is represented by a 6D vector:
+  - `δξ = [δρ; δθ]` (translation, rotation)
+- For rotation perturbation:
+  - `R ≈ Exp(δθ) * R_hat`
+
+Implement standard `Exp`/`Log` and `Adjoint` operators in
+`oasis_control/oasis_control/localization/ahrs/math/se3.py`.
+
+### 2.4 Covariances
+
+- Covariances are full matrices, never diagonalized.
+- Any covariance output to ROS must be generated as:
+  - `Σ_y = J * P * Jᵀ`
+- For SE(3) poses in tangent coordinates:
+  - `Σ_A = Ad_{T_AB} * Σ_B * Ad_{T_AB}ᵀ`
+
+---
+
+## 3. Core state definition
+
+Implement a **single shared state** representing navigation, calibration,
+extrinsics, and environment reference vectors.
+
+### 3.1 Mean state (`AhrsState`)
+
+- `p_WB ∈ ℝ³` Position of body in world
+- `v_WB ∈ ℝ³` Velocity of body in world
+- `q_WB` Unit quaternion (world → body)
+- `ω_WB ∈ ℝ³` Body angular rate (world → body), expressed in `{B}`
+- `b_g ∈ ℝ³` Gyro bias (in `{I}`)
+- `b_a ∈ ℝ³` Accel bias (in `{I}`)
+- `A_a ∈ ℝ^{3×3}` Accel scale/misalignment matrix (acts in `{I}`)
+- `T_BI ∈ SE(3)` IMU → body
+- `T_BM ∈ SE(3)` Mag → body
+- `g_W ∈ ℝ³` Gravity vector in world
+- `m_W ∈ ℝ³` Magnetic field vector in world
+
+### 3.2 Error state (`AhrsErrorState`)
+
+The covariance `P` is defined over this stacked vector:
+
+- `δp, δv, δθ ∈ ℝ³`
+- `δω ∈ ℝ³` angular-rate error for `ω_WB` (in `{B}`)
+- `δb_g, δb_a ∈ ℝ³`
+- `δA_a ∈ ℝ⁹` (row-major perturbation)
+- `δξ_BI, δξ_BM ∈ ℝ⁶` (SE(3) tangent)
+- `δg_W, δm_W ∈ ℝ³`
+
+`state_mapping.py` must provide deterministic ordering and mapping between
+mean state, error state, and covariance blocks.
+
+---
+
+## 4. Process model (continuous-time)
+
+The process model encodes **smooth motion** and **slow parameter drift**.
+It does not integrate raw IMU measurements as inputs. IMU gyro, accel, and
+magnetometer are applied as **measurement updates**.
+
+### 4.1 Continuous dynamics
+
+Navigation kinematics:
+
+- `ṗ_WB = v_WB`
+- `v̇_WB = w_v`
+
+Interpretation:
+
+- `w_v` is a zero-mean smoothness prior on world-frame linear acceleration (units: m/s²).
+  In the mean propagation, `v̇_WB` is typically integrated with `E[w_v] = 0`.
+
+Attitude kinematics (driven by latent angular rate):
+
+- `q̇_WB = 0.5 * Ω(ω_WB) * q_WB`
+- `ω̇_WB = w_ω`
+- `w_ω` is a zero-mean smoothness prior on angular-rate change (units: rad/s²).
+
+Definition of `Ω(ω)`:
+
+`ω_WB` is expressed in `{B}`. We use quaternion kinematics consistent with the
+action `v_B = R(q_WB) v_W`, with `q` stored as `[w, x, y, z]ᵀ`:
+
+Let `ω = [ωx, ωy, ωz]ᵀ` and define the 4×4 matrix:
+
+Ω(ω) =
+[ 0   -ωx  -ωy  -ωz
+  ωx   0    ωz  -ωy
+  ωy  -ωz   0    ωx
+  ωz   ωy  -ωx   0  ]
+
+Then `q̇ = 0.5 * Ω(ω) * q`.
+
+Systematic parameter drift (random walks):
+
+- `ḃ_g = w_bg`
+- `ḃ_a = w_ba`
+- `Ȧ_a = W_A` where `vec(Ȧ_a) = w_A`
+- `δξ̇_BI = w_BI`
+- `δξ̇_BM = w_BM`
+- `ġ_W = w_g`
+- `ṁ_W = w_m`
+
+Notes:
+
+- This process is intentionally weak: it encodes “motion is smooth” and “rate is
+  smooth”. The gyro measurement update provides the primary constraint on `ω_WB`
+  (and indirectly on `q_WB` through propagation).
+
+### 4.2 Noise intensities
+
+Let `Q_c` be the continuous-time noise covariance for:
+
+`[w_v, w_ω, w_bg, w_ba, w_A, w_BI, w_BM, w_g, w_m]`
+
+Rules:
+
+- Default `Q_c` can be block-diagonal but full blocks are allowed.
+- `P` must remain full and can develop cross-covariance through EKF updates.
+
+### 4.3 Discretization
+
+For each interval `Δt` between time nodes:
+
+- `F ≈ I + AΔt`
+- `Q ≈ G Q_c Gᵀ Δt`
+
+These are first-order approximations suitable for replay. The design must
+allow upgrading to higher-order methods without changing interfaces.
+
+---
+
+## 5. Measurement models
+
+### 5.1 IMU measurement (gyro)
+
+Measurement in `{I}`:
+
+- `z_ω = ω_raw`
+- `R_ω = Σ_ω_raw`
+
+Prediction:
+
+- Let `R_BI` be IMU → body rotation from `T_BI`, and `R_IB = R_BIᵀ`.
+- The estimated body angular rate is `ω_WB` expressed in `{B}`.
+- Predicted IMU-frame angular rate:
+  - `ω̂_I = R_IB * ω_WB + b_g`
+
+Residual:
+
+- `ν_ω = z_ω - ω̂_I`
+
+### 5.2 IMU measurement (accel)
+
+Measurement in `{I}`:
+
+- `z_a = a_raw`
+- `R_a = Σ_a_raw`
+
+Convention:
+
+`imu_raw.linear_acceleration` is treated as the raw accelerometer measurement
+of specific force (i.e., it measures `a - g`, so at rest it measures approximately `-g`
+in the sensor frame, up to calibration and noise).
+
+- `a_WB ≈ 0`
+- `f_B ≈ R_WB * (0 - g_W)`
+- `z_a` measures `f_I` (up to calibration and noise)
+
+Definitions:
+
+- Let `R_BI` be IMU → body rotation from `T_BI`, and `R_IB = R_BIᵀ`.
+
+Compute specific force:
+
+- `a_WB = v̇_WB`
+- `f_B = R_WB * (a_WB - g_W)`
+- `f_I = R_IB * f_B`
+
+Apply accel calibration model:
+
+- `a_corr = A_a (a_raw - b_a)`
+- Predicted raw accel:
+  - `â_I = A_a^{-1} * f_I + b_a`
+
+Residual:
+
+- `ν_a = z_a - â_I`
+
+### 5.3 Magnetometer measurement
+
+Measurement in `{M}`:
+
+- `z_m = m_raw`
+- `R_m(t)` adaptive, initialized from `Σ_m_raw`
+
+Definitions:
+
+- Let `R_BM` be the mag → body rotation from `T_BM`.
+- Then body → mag rotation is `R_MB = R_BMᵀ`.
+
+Prediction:
+
+- `m̂_M = R_MB * R_WB * m_W`
+
+Residual:
+
+- `ν_m = z_m - m̂_M`
+
+### 5.4 Adaptive magnetometer covariance
+
+Let `Ŝ = HPHᵀ` be the predicted innovation covariance without `R_m`.
+Update `R_m` using:
+
+- `R_m ← clamp_SPD( (1-α) R_m + α (ν νᵀ - Ŝ), R_min, R_max )`
+
+Default values:
+
+- `α = 0.01`
+- `R_min = diag([1e-12, 1e-12, 1e-12])` tesla²
+- `R_max = diag([2.5e-9, 2.5e-9, 2.5e-9])` tesla²
+- `R_m0` from first valid `Σ_m_raw` else
+  `diag([4e-10, 4e-10, 4e-10])` tesla²
+
+---
+
+## 6. Filter structure (EKF)
+
+### 6.1 Predict step
+
+- Input: current mean `x_k`, covariance `P_k`, time step `Δt`
+- Output: predicted mean `x_{k+1|k}`, covariance `P_{k+1|k}`
+
+Responsibilities:
+
+- Integrate process model for the mean
+- Compute `F` and `Q` for covariance propagation
+
+### 6.2 Update step
+
+Each measurement update is independent and uses the standard EKF update:
+
+- `S = H P Hᵀ + R`
+- `K = P Hᵀ S^{-1}`
+- `δx = K ν`
+- `x ← x ⊕ δx`
+- `P ← (I - K H) P (I - K H)ᵀ + K R Kᵀ`
+
+`⊕` denotes applying a perturbation to the mean state, including quaternion
+and SE(3) updates.
+
+### 6.3 Measurement ordering
+
+At a single timestamp:
+
+1. Apply priors (e.g., initial calibration) once
+2. Gyro update (from IMU packet, if present)
+3. Accel update (from IMU packet, if present)
+4. Mag update (from magnetometer sample, if present)
+
+Ordering must be deterministic and independent of arrival order.
+
+#### Same-timestamp attachment policy
+
+If an IMU packet and a magnetometer sample share the same `t_meas`, they attach
+to the same node and are both applied using the fixed ordering above.
+
+If a second measurement of the same type arrives for an existing node
+(same `t_meas`), it must be rejected (or replace-with-diagnostics) according to
+an explicit policy. Default: reject as a duplicate and emit diagnostics.
+
+---
+
+## 7. Time handling and replay
+
+Implement a fixed-lag deterministic replay system.
+
+### 7.1 Buffer model
+
+Maintain a time-ordered ring buffer of nodes. Each node stores:
+
+- mean state and covariance at that time
+- attached measurements and metadata
+
+Nodes are keyed by timestamp. Messages with the same timestamp attach to the
+same node.
+
+Rules:
+
+- A node may contain **multiple measurement types** at the same timestamp
+  (e.g., an IMU packet and a magnetometer sample with identical `t_meas`).
+- By contract, each node stores at most one instance per measurement type:
+  - `imu_pkt` slot: ≤ 1 IMU packet per `t_meas`
+  - `mag` slot: ≤ 1 magnetometer sample per `t_meas`
+- If a message arrives for a type slot that is already occupied at that `t_meas`,
+  it is treated as a duplicate per Section 6.3 (default: reject + diagnostics).
+
+### 7.2 Replay rules
+
+On insertion of a message:
+
+1. Validate timestamp
+2. Reject if older than `t_filter - T_buffer_sec`
+3. Attach to node (create if missing); if the node already exists, attach the
+   measurement into its type slot (IMU packet or mag sample). Reject duplicates
+   per Section 6.3.
+4. If inserted into the past, replay forward to the frontier
+
+Replay must be deterministic and not depend on arrival order.
+
+### 7.3 Frontier publish
+
+Only publish the estimate when the frontier time advances. Out-of-order
+updates do not republish.
+
+---
+
+## 8. ROS integration contract
+
+The ROS layer should be thin and only translate to/from messages, handle
+parameters, QoS, and logging. All math and state logic must reside in
+`oasis_control/oasis_control/localization/ahrs/`.
+
+### 8.1 Inputs
+
+- `imu_raw` (`sensor_msgs/Imu`)
+- `imu_calibration` (`oasis_msgs/ImuCalibration`)
+- `magnetic_field` (`sensor_msgs/MagneticField`)
+
+### 8.2 Outputs
+
+- TF (`world -> odom`, `odom -> base_link`)
+- `nav_msgs/Odometry` (`ahrs/odom`, `ahrs/world_odom`)
+- `oasis_msgs/AhrsState`
+- `oasis_msgs/AhrsDiagnostics`
+- `oasis_msgs/EkfUpdateReport` for each measurement update
+
+### 8.3 Frames and TF contract (world / odom)
+
+The AHRS publishes the standard TF chain:
+
+`world -> odom -> base_link`
+
+Policy (continuous, no teleports):
+
+- The AHRS does not apply global corrections. All outputs must be continuous in
+  time (no discontinuities/teleports).
+- The `odom` frame is the locally drifting frame used for smooth motion.
+
+Recommended implementation contract:
+
+- Publish `TF: world -> odom` as identity for the entire session:
+  - `T_WO := I`
+- Publish `TF: odom -> base_link` as the AHRS estimate:
+  - `T_OB := T_WB` (numerically equivalent under `T_WO := I`)
+
+Relationship: `T_WB = T_WO ∘ T_OB`, so under `T_WO := I`, `T_WB == T_OB`.
+
+This keeps the TF tree compatible with a future localization system that may
+later publish a non-identity `T_WO` (global correction), without changing
+`odom -> base_link`.
+
+---
+
+## 9. Component specs
+
+This section defines the main classes. Each class should be implemented in
+small steps, with tests before integration.
+
+### 9.1 `state/ahrs_state.py`
+
+**Responsibilities**:
+
+- Owns the mean state values
+- Provides serialization to plain dict/struct for testing
+
+**Key methods**:
+
+- `copy()`
+- `apply_error_state(delta)`
+
+### 9.2 `state/error_state.py`
+
+**Responsibilities**:
+
+- Defines the error-state vector layout
+- Provides mapping between index ranges and named blocks
+
+### 9.3 `state/covariance.py`
+
+**Responsibilities**:
+
+- Stores `P` and provides block access
+- Ensures symmetry (e.g., force `P = 0.5 * (P + Pᵀ)` after updates)
+
+### 9.4 `models/process_model.py`
+
+**Responsibilities**:
+
+- Integrates mean state for `Δt`
+- Computes continuous-time Jacobians `A`, `G`
+- Computes discrete `F`, `Q`
+
+**Math**:
+
+- Use Section 4 equations
+- Document every parameter in code with units and meaning
+
+### 9.5 `models/imu_model.py`
+
+**Responsibilities**:
+
+- Implements gyro and accel measurement functions
+- Computes residuals, Jacobians, and expected measurements
+
+**Math**:
+
+- Use Section 5.1 and 5.2
+
+### 9.6 `models/mag_model.py`
+
+**Responsibilities**:
+
+- Implements magnetometer measurement function
+- Computes residuals, Jacobians, and expected measurements
+
+**Math**:
+
+- Use Section 5.3
+
+### 9.7 `models/noise_adaptation.py`
+
+**Responsibilities**:
+
+- Maintains adaptive `R_m` using covariance matching
+- Applies `clamp_SPD` to bound eigenvalues
+
+**Math**:
+
+- Use Section 5.4
+
+### 9.8 `filter/ekf.py`
+
+**Responsibilities**:
+
+- Orchestrates predict and update
+- Owns state and covariance
+- Exposes a stable API: `predict(dt)`, `update_gyro(...)`,
+  `update_accel(...)`, `update_mag(...)`
+
+### 9.9 `time/replay_engine.py`
+
+**Responsibilities**:
+
+- Manages buffer and deterministic replay
+- Provides `insert_measurement(...)` and `advance_frontier(...)`
+
+### 9.10 `nodes/ahrs/ahrs_node.py`
+
+**Responsibilities**:
+
+- Subscribes to ROS topics
+- Converts incoming messages into core measurements
+- Publishes state and diagnostics
+
+---
+
+## 10. Implementation order (recommended)
+
+1. Math primitives (`quat`, `se3`, `linalg`, `stats`)
+2. State definitions and mappings
+3. Process model
+4. IMU measurement model
+5. Magnetometer model + adaptive noise
+6. EKF core
+7. Time buffer + replay engine
+8. ROS integration
+
+---
+
+## 11. Required documentation in code
+
+- Every public struct/enum must include field docs with units and meaning
+- Every constant must have a comment describing its derivation or units
+- Comments should wrap at 80 chars
+
+---
+
+## 12. Non-goals
+
+- No GPS or global corrections
+- No external localization fusion in this component
+- No direct dependence on ROS inside `oasis_control/oasis_control/localization/ahrs/`
+  (ROS types and wiring live only under `oasis_control/oasis_control/nodes/ahrs/`).

--- a/oasis_control/oasis_control/localization/ahrs/__init__.py
+++ b/oasis_control/oasis_control/localization/ahrs/__init__.py
@@ -1,0 +1,11 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""AHRS localization package."""

--- a/oasis_control/oasis_control/localization/ahrs/config/__init__.py
+++ b/oasis_control/oasis_control/localization/ahrs/config/__init__.py
@@ -1,0 +1,11 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""AHRS localization package."""

--- a/oasis_control/oasis_control/localization/ahrs/config/ahrs_config.py
+++ b/oasis_control/oasis_control/localization/ahrs/config/ahrs_config.py
@@ -1,0 +1,20 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""AHRS ahrs config definitions."""
+
+class AhrsConfig:
+    """
+    Configuration values for the AHRS core.
+
+    Includes time-buffer parameters, frame identifiers, and process-noise
+    intensities used by the continuous-time model.
+    """
+    pass

--- a/oasis_control/oasis_control/localization/ahrs/config/ahrs_params.py
+++ b/oasis_control/oasis_control/localization/ahrs/config/ahrs_params.py
@@ -1,0 +1,21 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""AHRS ahrs params definitions."""
+
+class AhrsParams:
+    """
+    Parameter bundle for AHRS runtime configuration.
+
+    This class documents the parameters required by the ROS layer, including
+    fixed-lag window sizes, time validation thresholds, and magnetometer noise
+    adaptation bounds.
+    """
+    pass

--- a/oasis_control/oasis_control/localization/ahrs/filter/__init__.py
+++ b/oasis_control/oasis_control/localization/ahrs/filter/__init__.py
@@ -1,0 +1,11 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""AHRS localization package."""

--- a/oasis_control/oasis_control/localization/ahrs/filter/ekf.py
+++ b/oasis_control/oasis_control/localization/ahrs/filter/ekf.py
@@ -1,0 +1,32 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""AHRS ekf definitions."""
+
+class AhrsEkf:
+    """
+    Extended Kalman filter orchestrator for the AHRS.
+
+    Core API:
+
+    - predict(Δt): propagate the mean and covariance via the process model
+    - update_gyro(...): apply gyro measurement update
+    - update_accel(...): apply accelerometer update
+    - update_mag(...): apply magnetometer update
+
+    The update step uses the standard EKF equations:
+
+        S = H P Hᵀ + R
+        K = P Hᵀ S⁻¹
+        δx = K ν
+        x ← x ⊕ δx
+        P ← (I - K H) P (I - K H)ᵀ + K R Kᵀ
+    """
+    pass

--- a/oasis_control/oasis_control/localization/ahrs/filter/predict_step.py
+++ b/oasis_control/oasis_control/localization/ahrs/filter/predict_step.py
@@ -1,0 +1,24 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""AHRS predict step definitions."""
+
+class PredictStep:
+    """
+    Reusable EKF predict step for continuous-time dynamics.
+
+    Given Jacobians A and G and noise intensity Q_c, the discrete propagation is:
+
+        F ≈ I + AΔt
+        Q ≈ G Q_c Gᵀ Δt
+
+    The mean state is integrated using the process model equations.
+    """
+    pass

--- a/oasis_control/oasis_control/localization/ahrs/filter/update_step.py
+++ b/oasis_control/oasis_control/localization/ahrs/filter/update_step.py
@@ -1,0 +1,24 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""AHRS update step definitions."""
+
+class UpdateStep:
+    """
+    Reusable EKF update step for a single measurement.
+
+    Inputs include the innovation ν, Jacobian H, and measurement covariance R.
+    Outputs include the state perturbation δx and updated covariance following:
+
+        S = H P Hᵀ + R
+        K = P Hᵀ S⁻¹
+        δx = K ν
+    """
+    pass

--- a/oasis_control/oasis_control/localization/ahrs/io/__init__.py
+++ b/oasis_control/oasis_control/localization/ahrs/io/__init__.py
@@ -1,0 +1,11 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""AHRS localization package."""

--- a/oasis_control/oasis_control/localization/ahrs/io/diagnostics.py
+++ b/oasis_control/oasis_control/localization/ahrs/io/diagnostics.py
@@ -1,0 +1,20 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""AHRS diagnostics definitions."""
+
+class AhrsDiagnostics:
+    """
+    Diagnostics container for buffer and replay statistics.
+
+    Tracks buffer size, replay status, and drop/reset counters used to populate
+    runtime diagnostics outputs.
+    """
+    pass

--- a/oasis_control/oasis_control/localization/ahrs/io/imu_packet.py
+++ b/oasis_control/oasis_control/localization/ahrs/io/imu_packet.py
@@ -1,0 +1,21 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""AHRS imu packet definitions."""
+
+class ImuPacket:
+    """
+    Synchronized IMU packet data for AHRS updates.
+
+    Contains imu_raw and imu_calibration measurements with a shared timestamp.
+    The packet is validated for frame agreement and is used to apply gyro and
+    accelerometer updates in a fixed order.
+    """
+    pass

--- a/oasis_control/oasis_control/localization/ahrs/io/mag_packet.py
+++ b/oasis_control/oasis_control/localization/ahrs/io/mag_packet.py
@@ -1,0 +1,20 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""AHRS mag packet definitions."""
+
+class MagPacket:
+    """
+    Magnetometer sample container for AHRS updates.
+
+    Stores the raw magnetic field measurement and covariance in frame {M} with
+    its measurement timestamp.
+    """
+    pass

--- a/oasis_control/oasis_control/localization/ahrs/io/update_report.py
+++ b/oasis_control/oasis_control/localization/ahrs/io/update_report.py
@@ -1,0 +1,21 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""AHRS update report definitions."""
+
+class UpdateReport:
+    """
+    Per-measurement update report for innovation statistics.
+
+    Stores measurement z, prediction z_hat, innovation ν, noise covariance R,
+    innovation covariance S, and gating decisions. The report is published for
+    both accepted and rejected updates.
+    """
+    pass

--- a/oasis_control/oasis_control/localization/ahrs/math/__init__.py
+++ b/oasis_control/oasis_control/localization/ahrs/math/__init__.py
@@ -1,0 +1,11 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""AHRS localization package."""

--- a/oasis_control/oasis_control/localization/ahrs/math/linalg.py
+++ b/oasis_control/oasis_control/localization/ahrs/math/linalg.py
@@ -1,0 +1,25 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""AHRS linalg definitions."""
+
+class LinearAlgebra:
+    """
+    Linear-algebra helpers for full covariance handling.
+
+    All covariance matrices are maintained as full, symmetric matrices. When a
+    numerical operation produces minor asymmetry, the result is symmetrized:
+
+        P_sym = 0.5 * (P + Pᵀ)
+
+    This class documents the contract for matrix operations used by the AHRS
+    without binding to a specific numerical backend.
+    """
+    pass

--- a/oasis_control/oasis_control/localization/ahrs/math/quat.py
+++ b/oasis_control/oasis_control/localization/ahrs/math/quat.py
@@ -1,0 +1,35 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""AHRS quat definitions."""
+
+class Quaternion:
+    """
+    Quaternion math utilities for world-to-body rotations.
+
+    The AHRS uses quaternions that rotate vectors from frame {W} to {B}:
+
+        v_B = R(q_WB) * v_W
+
+    Composition follows Hamilton product with the convention:
+
+        q_AB = q_CB ⊗ q_AC
+        R(q_AB) = R(q_CB) * R(q_AC)
+
+    The continuous-time attitude kinematics use the angular-rate matrix:
+
+        Ω(ω) = [ 0   -ωx  -ωy  -ωz
+                 ωx   0    ωz  -ωy
+                 ωy  -ωz   0    ωx
+                 ωz   ωy  -ωx   0 ]
+
+        q̇ = 0.5 * Ω(ω) * q
+    """
+    pass

--- a/oasis_control/oasis_control/localization/ahrs/math/se3.py
+++ b/oasis_control/oasis_control/localization/ahrs/math/se3.py
@@ -1,0 +1,34 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""AHRS se3 definitions."""
+
+class Se3:
+    """
+    SE(3) utilities for extrinsics and pose perturbations.
+
+    Each transform T_AB = (R_AB, p_AB) maps vectors via:
+
+        p_A = R_AB * p_B + p_AB
+
+    Perturbations are represented in the tangent space:
+
+        δξ = [δρ; δθ]
+
+    The perturbed rotation uses the exponential map:
+
+        R ≈ Exp(δθ) * R_hat
+
+    The adjoint operator transforms covariance blocks:
+
+        Ad_T = [[R, [p]× R], [0, R]]
+        Σ_A = Ad_T * Σ_B * Ad_Tᵀ
+    """
+    pass

--- a/oasis_control/oasis_control/localization/ahrs/math/stats.py
+++ b/oasis_control/oasis_control/localization/ahrs/math/stats.py
@@ -1,0 +1,25 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""AHRS stats definitions."""
+
+class Statistics:
+    """
+    Statistical utilities for EKF innovation bookkeeping.
+
+    Innovation statistics follow:
+
+        S = H P Hᵀ + R
+        d² = νᵀ S⁻¹ ν
+
+    Where ν is the innovation residual in the measurement frame. The interface
+    captures the formulas and expected outputs used for update reporting.
+    """
+    pass

--- a/oasis_control/oasis_control/localization/ahrs/math/units.py
+++ b/oasis_control/oasis_control/localization/ahrs/math/units.py
@@ -1,0 +1,26 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""AHRS units definitions."""
+
+class Units:
+    """
+    Unit conventions for AHRS state, noise, and measurements.
+
+    Key units:
+
+    - Position: meters
+    - Velocity: meters per second
+    - Angular rate: radians per second
+    - Acceleration: meters per second squared
+    - Magnetic field: tesla
+    - Covariances: squared units of the underlying signals
+    """
+    pass

--- a/oasis_control/oasis_control/localization/ahrs/models/__init__.py
+++ b/oasis_control/oasis_control/localization/ahrs/models/__init__.py
@@ -1,0 +1,11 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""AHRS localization package."""

--- a/oasis_control/oasis_control/localization/ahrs/models/extrinsics_model.py
+++ b/oasis_control/oasis_control/localization/ahrs/models/extrinsics_model.py
@@ -1,0 +1,25 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""AHRS extrinsics model definitions."""
+
+class ExtrinsicsModel:
+    """
+    Extrinsic calibration model for IMU and magnetometer frames.
+
+    Extrinsics are stored as SE(3) transforms:
+
+        T_BI: IMU → body
+        T_BM: mag → body
+
+    Perturbations use a 6D tangent vector δξ = [δρ; δθ], and covariance blocks are
+    updated using SE(3) adjoint mappings.
+    """
+    pass

--- a/oasis_control/oasis_control/localization/ahrs/models/imu_model.py
+++ b/oasis_control/oasis_control/localization/ahrs/models/imu_model.py
@@ -1,0 +1,33 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""AHRS imu model definitions."""
+
+class ImuModel:
+    """
+    IMU measurement model for gyro and accelerometer updates.
+
+    Gyro measurement in frame {I}:
+
+        z_ω = ω_raw
+        ω̂_I = R_IB * ω_WB + b_g
+        ν_ω = z_ω - ω̂_I
+
+    Accelerometer measurement in frame {I}:
+
+        z_a = a_raw
+        f_B = R_WB * (a_WB - g_W)
+        f_I = R_IB * f_B
+        â_I = A_a⁻¹ * f_I + b_a
+        ν_a = z_a - â_I
+
+    All measurement covariances are full 3×3 matrices and are not diagonalized.
+    """
+    pass

--- a/oasis_control/oasis_control/localization/ahrs/models/mag_model.py
+++ b/oasis_control/oasis_control/localization/ahrs/models/mag_model.py
@@ -1,0 +1,25 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""AHRS mag model definitions."""
+
+class MagModel:
+    """
+    Magnetometer measurement model in the magnetometer frame {M}.
+
+    Prediction and residual are formed directly in {M}:
+
+        m̂_M = R_MB * R_WB * m_W
+        ν_m = z_m - m̂_M
+
+    The model uses an adaptive measurement covariance R_m(t) and does not rotate
+    raw measurements into the body frame.
+    """
+    pass

--- a/oasis_control/oasis_control/localization/ahrs/models/noise_adaptation.py
+++ b/oasis_control/oasis_control/localization/ahrs/models/noise_adaptation.py
@@ -1,0 +1,24 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""AHRS noise adaptation definitions."""
+
+class NoiseAdaptation:
+    """
+    Adaptive magnetometer noise model using covariance matching.
+
+    The update uses the innovation ν and predicted covariance without noise Ŝ:
+
+        R_m ← clamp_SPD((1-α) R_m + α (ν νᵀ - Ŝ), R_min, R_max)
+
+    The covariance is kept symmetric positive definite by clamping eigenvalues
+    between R_min and R_max.
+    """
+    pass

--- a/oasis_control/oasis_control/localization/ahrs/models/process_model.py
+++ b/oasis_control/oasis_control/localization/ahrs/models/process_model.py
@@ -1,0 +1,42 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""AHRS process model definitions."""
+
+class ProcessModel:
+    """
+    Continuous-time process model for smooth motion and drift.
+
+    Navigation kinematics:
+
+        ṗ_WB = v_WB
+        v̇_WB = w_v
+
+    Attitude kinematics:
+
+        q̇_WB = 0.5 * Ω(ω_WB) * q_WB
+        ω̇_WB = w_ω
+
+    Systematic drift terms are random walks:
+
+        ḃ_g = w_bg
+        ḃ_a = w_ba
+        vec(Ȧ_a) = w_A
+        δξ̇_BI = w_BI
+        δξ̇_BM = w_BM
+        ġ_W = w_g
+        ṁ_W = w_m
+
+    Discretization over Δt uses first-order approximations:
+
+        F ≈ I + AΔt
+        Q ≈ G Q_c Gᵀ Δt
+    """
+    pass

--- a/oasis_control/oasis_control/localization/ahrs/state/__init__.py
+++ b/oasis_control/oasis_control/localization/ahrs/state/__init__.py
@@ -1,0 +1,11 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""AHRS localization package."""

--- a/oasis_control/oasis_control/localization/ahrs/state/ahrs_state.py
+++ b/oasis_control/oasis_control/localization/ahrs/state/ahrs_state.py
@@ -1,0 +1,31 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""AHRS ahrs state definitions."""
+
+class AhrsState:
+    """
+    Mean AHRS state for navigation, calibration, and environment.
+
+    State components:
+
+    - p_WB: position of the body in world (meters)
+    - v_WB: velocity of the body in world (m/s)
+    - q_WB: unit quaternion rotating world → body
+    - ω_WB: body angular rate in {B} (rad/s)
+    - b_g: gyro bias in {I} (rad/s)
+    - b_a: accel bias in {I} (m/s²)
+    - A_a: accel scale/misalignment (unitless 3×3)
+    - T_BI: IMU → body extrinsic (SE(3))
+    - T_BM: mag → body extrinsic (SE(3))
+    - g_W: gravity vector in world (m/s²)
+    - m_W: magnetic field in world (tesla)
+    """
+    pass

--- a/oasis_control/oasis_control/localization/ahrs/state/covariance.py
+++ b/oasis_control/oasis_control/localization/ahrs/state/covariance.py
@@ -1,0 +1,24 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""AHRS covariance definitions."""
+
+class AhrsCovariance:
+    """
+    Covariance container for the AHRS error state.
+
+    The covariance P is a full matrix over the error-state ordering. After each
+    update, P is symmetrized as:
+
+        P ← 0.5 * (P + Pᵀ)
+
+    Block access uses the error-state layout defined by the mapping utilities.
+    """
+    pass

--- a/oasis_control/oasis_control/localization/ahrs/state/error_state.py
+++ b/oasis_control/oasis_control/localization/ahrs/state/error_state.py
@@ -1,0 +1,25 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""AHRS error state definitions."""
+
+class AhrsErrorState:
+    """
+    Error-state definition for the AHRS covariance.
+
+    The stacked error vector is ordered as:
+
+        [δp, δv, δθ, δω, δb_g, δb_a, δA_a,
+         δξ_BI, δξ_BM, δg_W, δm_W]
+
+    Each block is expressed in the same frame as its corresponding mean state
+    component. The δA_a block stores a row-major perturbation of the 3×3 matrix.
+    """
+    pass

--- a/oasis_control/oasis_control/localization/ahrs/state/state_mapping.py
+++ b/oasis_control/oasis_control/localization/ahrs/state/state_mapping.py
@@ -1,0 +1,20 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""AHRS state mapping definitions."""
+
+class StateMapping:
+    """
+    Mapping utilities between mean state and error-state blocks.
+
+    This class defines deterministic index ranges for each error-state block and
+    provides the ordering required to serialize covariances into ROS messages.
+    """
+    pass

--- a/oasis_control/oasis_control/localization/ahrs/time/__init__.py
+++ b/oasis_control/oasis_control/localization/ahrs/time/__init__.py
@@ -1,0 +1,11 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""AHRS localization package."""

--- a/oasis_control/oasis_control/localization/ahrs/time/replay_engine.py
+++ b/oasis_control/oasis_control/localization/ahrs/time/replay_engine.py
@@ -1,0 +1,21 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""AHRS replay engine definitions."""
+
+class ReplayEngine:
+    """
+    Deterministic replay engine for out-of-order measurements.
+
+    Insertion of a measurement attaches it to its time node. If inserted in the
+    past, the engine replays the process and updates forward to the frontier in a
+    stable measurement order.
+    """
+    pass

--- a/oasis_control/oasis_control/localization/ahrs/time/ring_buffer.py
+++ b/oasis_control/oasis_control/localization/ahrs/time/ring_buffer.py
@@ -1,0 +1,20 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""AHRS ring buffer definitions."""
+
+class RingBuffer:
+    """
+    Fixed-lag ring buffer storing time nodes for replay.
+
+    Nodes older than t_filter - T_buffer_sec are evicted. Duplicate measurement
+    slots at the same timestamp are rejected to preserve determinism.
+    """
+    pass

--- a/oasis_control/oasis_control/localization/ahrs/time/time_base.py
+++ b/oasis_control/oasis_control/localization/ahrs/time/time_base.py
@@ -1,0 +1,25 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""AHRS time base definitions."""
+
+class TimeBase:
+    """
+    Time and timestamp utilities for fixed-lag replay.
+
+    Time definitions:
+
+    - t_meas: timestamp from the message header
+    - t_now: receipt time for diagnostics
+    - t_filter: current frontier time
+
+    Messages are accepted based on deterministic ordering on t_meas.
+    """
+    pass

--- a/oasis_control/oasis_control/localization/ahrs/time/timeline.py
+++ b/oasis_control/oasis_control/localization/ahrs/time/timeline.py
@@ -1,0 +1,20 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""AHRS timeline definitions."""
+
+class Timeline:
+    """
+    Ordered time line of AHRS nodes for fixed-lag replay.
+
+    Each node is keyed by a unique timestamp and stores the mean state,
+    covariance, and attached measurements for deterministic reprocessing.
+    """
+    pass

--- a/oasis_msgs/CMakeLists.txt
+++ b/oasis_msgs/CMakeLists.txt
@@ -31,6 +31,8 @@ ament_export_dependencies(rosidl_default_runtime)
 rosidl_generate_interfaces(
   ${PROJECT_NAME}
     msg/Accelerometer.msg
+    msg/AhrsDiagnostics.msg
+    msg/AhrsState.msg
     msg/AirQuality.msg
     msg/AnalogButton.msg
     msg/AnalogReading.msg

--- a/oasis_msgs/msg/AhrsDiagnostics.msg
+++ b/oasis_msgs/msg/AhrsDiagnostics.msg
@@ -1,0 +1,55 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+#
+# Health / replay / drop diagnostics for the AHRS node.
+#
+# Conventions
+# - header.stamp = t_filter (frontier)
+# - header.frame_id = world frame_id
+#
+
+# Frontier timestamp and world frame_id
+std_msgs/Header header
+
+# Monotonic diagnostic sequence index
+uint64 diag_seq
+
+# The filter's current frontier timestamp in seconds (for convenience)
+float64 t_filter_sec
+
+#
+# Buffer / replay stats
+#
+
+# Number of time nodes currently retained
+uint32 buffer_node_count
+
+# Approximate time span covered by the buffer (s)
+float32 buffer_span_sec
+
+# True if an out-of-order message triggered replay on the most recent callback
+bool replay_happened
+
+#
+# Drop counters (monotonic since node start)
+#
+
+uint64 dropped_missing_stamp
+uint64 dropped_future_stamp
+uint64 dropped_too_old
+uint64 dropped_nan_cov
+uint64 dropped_imu_coverage_gap
+uint64 dropped_clock_jump_reset
+
+#
+# Most recent reset reason (empty if no reset yet)
+#
+string last_reset_reason

--- a/oasis_msgs/msg/AhrsState.msg
+++ b/oasis_msgs/msg/AhrsState.msg
@@ -1,0 +1,124 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+#
+# Full AHRS filter state snapshot at the current frontier time t_filter.
+#
+# This message exists so consumers can inspect ALL in-state parameters and
+# their FULL (non-diagonalized) covariance in a single place.
+#
+# Conventions
+# - header.stamp = t_filter (frontier)
+# - header.frame_id = world frame ("world") for all world-expressed vectors
+#
+# Frames
+# - {W}: world
+# - {B}: base_link (body)
+# - {I}: IMU frame
+# - {M}: magnetometer frame
+#
+
+# Frontier timestamp and world frame_id
+std_msgs/Header header
+
+#
+# Frame ids in use by the node (published contract)
+#
+string world_frame_id
+string odom_frame_id
+string body_frame_id
+
+#
+# Monotonic sequence index for state publications
+#
+uint64 state_seq
+
+#
+# True when the filter has consumed its initial priors and is running
+#
+bool initialized
+
+#
+# Navigation state
+#
+
+# Position of B expressed in W (m)
+geometry_msgs/Point position_wb_m
+
+# Velocity of B expressed in W (m/s)
+geometry_msgs/Vector3 velocity_wb_mps
+
+# Attitude (world -> body), unit quaternion
+geometry_msgs/Quaternion orientation_wb
+
+#
+# IMU systematic parameters (in-state)
+#
+
+# Gyroscope bias b_g (rad/s), expressed in IMU frame {I} unless otherwise specified by the node
+geometry_msgs/Vector3 gyro_bias
+
+# Accelerometer bias b_a (m/s^2), expressed in IMU frame {I} unless otherwise specified by the node
+geometry_msgs/Vector3 accel_bias
+
+# Accelerometer scale/misalignment matrix A_a
+# Units: unitless
+# Layout: 3x3 row-major
+float64[9] accel_a
+
+#
+# Extrinsics (sensor -> body)
+#
+
+# IMU -> body transform T_BI
+geometry_msgs/Pose t_bi
+
+# Magnetometer -> body transform T_BM
+geometry_msgs/Pose t_bm
+
+#
+# Environment / reference vectors (in-state)
+#
+
+# Gravity vector expressed in world (m/s^2)
+geometry_msgs/Vector3 gravity_w_mps2
+
+# Earth magnetic field vector expressed in world (tesla)
+geometry_msgs/Vector3 magnetic_field_w_t
+
+#
+# FULL covariance over the AHRS internal error-state.
+#
+# This is the single source of truth for "not diagonalized" covariance reporting.
+#
+# Matrix is row-major with dimensions error_dim x error_dim.
+#
+# IMPORTANT: error_state_names defines the exact ordering of this covariance.
+#
+
+# Error-state dimension (must match p.rows == p.cols == error_dim)
+uint32 error_dim
+
+# Names of each scalar error-state element, length = error_dim.
+# Example entries:
+# - "dp.x", "dp.y", "dp.z"
+# - "dv.x", "dv.y", "dv.z"
+# - "dtheta.x", "dtheta.y", "dtheta.z"
+# - "dbg.x", ...
+# - "dba.x", ...
+# - "dAa.0", ..., "dAa.8"
+# - "dT_BI.rho.x", ..., "dT_BI.theta.z"
+# - "dT_BM.rho.x", ..., "dT_BM.theta.z"
+# - "dg.x", ...
+# - "dm.x", ...
+string[] error_state_names
+
+# Full error-state covariance P
+oasis_msgs/Matrix p


### PR DESCRIPTION
### Motivation
- Introduce a structured, ROS-agnostic core layout for the AHRS as specified by the AHRS design document to separate math, estimation, time/replay, and ROS integration boundaries. 
- Provide documented class scaffolding so subsequent work can implement algorithms in small, well-scoped steps following the spec (math → state → models → filter → time → io). 
- Ensure new source files include the project SPDX/copyright header and package `__init__` modules for predictable imports.

### Description
- Create the `oasis_control/oasis_control/localization/ahrs` package with subpackages `math`, `models`, `state`, `filter`, `time`, `config`, and `io`, and add `__init__.py` files for each namespace. 
- Add detailed stub classes and module docstrings for the core components: math primitives (`quat`, `se3`, `linalg`, `stats`, `units`), models (`imu_model`, `mag_model`, `process_model`, `noise_adaptation`, `extrinsics_model`), state (`ahrs_state`, `error_state`, `covariance`, `state_mapping`), filter/predict/update steps and EKF orchestrator, time/replay/ring buffer/timeline utilities, config/params, and IO containers (`ImuPacket`, `MagPacket`, `UpdateReport`, `AhrsDiagnostics`). 
- All new files include the project copyright/SPDX header and thorough docstrings capturing the required math, units, and interface contracts from the design spec; implementations are intentionally left as stubs to keep the core API ROS-agnostic.

### Testing
- No automated tests were executed for this change; these are documentation-first stub additions intended to establish package layout and interfaces. 
- Static checks or unit tests have not yet been run against the new modules and will be added as implementations are developed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696eb060b0b083268f75443495849265)