### PR TITLE
Mounting YAML storage: schema, serialization, and persistence

### DIFF
--- a/docs/AHRS_Mounting.md
+++ b/docs/AHRS_Mounting.md
@@ -1,0 +1,894 @@
+# AHRS Mounting Calibration
+
+This document specifies **AHRS Mounting Calibration**: a ROS 2 node that estimates only the **mounting transforms** (TF) for the IMU and magnetometer relative to the robot body (`base_link`), then **saves** those transforms for use by the AHRS node.
+
+This exists because the AHRS EKF can be poorly conditioned at boot (especially when stationary) if the IMU/mag-to-body rotations are wrong or unknown. The mount-calibration node learns those rotations first so the AHRS node starts from a physically consistent TF chain.
+
+---
+
+## 1. Goals and non-goals
+
+### 1.1 Goals
+
+- Estimate rigid transforms:
+  - `T_BI`: IMU frame `{I}` to body `{B}` (`base_link`)
+  - `T_BM`: magnetometer frame `{M}` to body `{B}` (`base_link`)
+- Publish those transforms as TF (and/or on dedicated topics) while calibrating.
+- Persist the result to disk in a deterministic format (YAML/JSON) that the AHRS node can load.
+- Work with **limited motion** (e.g., can’t invert fully; can tilt up to ~80°).
+
+### 1.2 Non-goals
+
+- This node is **not** a navigation filter. It does not estimate `p_WB`, `v_WB`, or drift-free world pose.
+- It does **not** permanently calibrate accel `A_a` / biases for the AHRS state. (It may estimate nuisance parameters internally to make the mount solve well, but it only _outputs_ mount TF.)
+- It does **not** do hard/soft-iron magnetometer calibration beyond what is required to make a stable mount estimate (optional nuisance).
+
+---
+
+## 2. ROS Inputs
+
+### 2.1 Streams
+
+- Single `message_filters` combination (ExactTime) producing an **IMU packet**:
+  - `imu_raw` (`sensor_msgs/Imu`): inertial sample stream (time-stamped)
+  - `imu_calibration` (`oasis_msgs/ImuCalibration`): calibration priors + uncertainty
+    - **Deterministic contract:** IMU processing requires ExactTime pairing of
+      `(imu_raw, imu_calibration)` at identical `t_meas_ns`. Any `imu_raw`
+      without a matching `imu_calibration` at the exact same timestamp MUST be
+      rejected/dropped. This is intentional even if calibration is static.
+    - `imu_calibration` will not change over the time taken to calibrate mounting parameters
+    - **Semantic rule:** used **only once** to initialize in-state calibration
+      parameters (initial prior).
+    - After initialization, `imu_calibration` does NOT modify in-state
+      parameters.
+- `magnetic_field` (`sensor_msgs/MagneticField`): magnetometer samples (time-stamped)
+
+---
+
+### 2.2 `imu_raw` — `sensor_msgs/Imu`
+
+Used fields:
+
+- `header.stamp` (`t_meas_ns`)
+- `header.frame_id` → IMU frame `{I}`
+- `angular_velocity` `ω_raw` and **full** `angular_velocity_covariance` `Σ_ω_raw` (3×3)
+- `linear_acceleration` `a_raw` and **full** `linear_acceleration_covariance` `Σ_a_raw` (3×3)
+
+Ignored:
+
+- `orientation`, `orientation_covariance`
+
+Requirements:
+
+- Covariances are interpreted as **per-sample measurement noise**.
+- `ω_raw`, `a_raw` are expressed in `{I}`.
+- Do not diagonalize any provided covariance.
+
+---
+
+### 2.3 `imu_calibration` — `oasis_msgs/ImuCalibration`
+
+Role: **one-shot initialization prior** for systematic parameters that live in
+the shared state.
+
+Validity:
+
+- If `valid == false`, ignore.
+
+Frame:
+
+- `header.frame_id` must match `imu_raw.header.frame_id` (calibration is defined in `{I}`).
+
+Models (parameter meaning):
+
+- Accel: `a_corr = A_a (a_raw − b_a)` where `b_a, A_a` are **in-state**
+- Gyro: `ω_corr = ω_raw − b_g` where `b_g` is **in-state**
+
+Requirements:
+
+- IMU processing requires ExactTime pairing of `(imu_raw, imu_calibration)` at
+  identical `t_meas_ns`. Any `imu_raw` without a matching `imu_calibration` at
+  the exact same timestamp MUST be rejected/dropped, even when calibration is
+  static and unchanged.
+- Consume **only while uninitialized**:
+  - The **first** valid calibration observed is applied as an initial prior on
+    `(b_a, A_a, b_g)` with its covariance.
+  - After initialization, do not modify in-state parameters from subsequent
+    calibration messages. Still record diagnostics/consistency checks and allow
+    a future policy hook for re-init or reset on calibration change (TODO,
+    policy only).
+- Calibration uncertainty is **systematic parameter uncertainty**, not per-sample noise.
+- Always use full covariance matrices when provided (do not diagonalize).
+
+---
+
+### 2.4 `magnetic_field` — `sensor_msgs/MagneticField`
+
+Used fields:
+
+- `header.stamp` (`t_meas_ns`)
+- `header.frame_id` → mag frame `{M}`
+- `magnetic_field` `m_raw`
+- **full** `magnetic_field_covariance` `Σ_m_raw` (3×3, tesla²)
+
+Measurement convention (mount solve):
+
+- The mount solver uses **direction-only** mag factors (consistent with §6):
+  - `m̂_M := normalize(m_raw)` in `{M}`
+  - predicted `m̂̂_M` is also a unit vector in `{M}`
+  - direction residual: `r_m := m̂_M × m̂̂_M` (unitless; ≈ radians for small errors)
+
+Noise interpretation:
+
+- The solver maintains a direction-residual noise model `R_m(t)` with units **unitless²** (≈ rad²).
+- The driver-provided `Σ_m_raw` (tesla²) is used only as an _optional prior_ by converting it to a direction covariance:
+  - Let `u := normalize(m_raw)` and `s := ||m_raw||`.
+  - Require `s > s_min` for covariance conversion (default `s_min = 1e-6` T) to avoid numerical blow-up.
+  - Jacobian of normalization: `J := (I - u uᵀ) / s`
+  - Direction covariance prior: `Σ_dir ≈ J Σ_m_raw Jᵀ` (unitless²; approximately angular variance on the unit sphere)
+
+- If `Σ_m_raw` is missing/invalid or `s` is too small, fall back to defaults.
+
+Adaptive noise policy (covariance matching on direction residuals):
+
+- Initialize:
+  - `R_m0 := Σ_dir` if available else `diag([1e-3, 1e-3, 1e-3])` (unitless²)
+- Maintain adaptive `R_m(t)` bounded SPD:
+  - `R_min = diag([1e-5, 1e-5, 1e-5])`
+  - `R_max = diag([1e-1, 1e-1, 1e-1])`
+- Update:
+  - Let innovation be `r_m,k`, predicted innovation covariance excluding `R_m` be `Ŝ_k = HPHᵀ`
+  - `R_m ← clamp_SPD( (1-α) R_m + α (r_m,k r_m,kᵀ - Ŝ_k), R_min, R_max )`
+  - default `α = 0.01`
+
+---
+
+## 3. Frames and TF contract
+
+Frames:
+
+- `{W}`: world (`world`) — only used internally as an abstract reference during calibration
+- `{B}`: body (`base_link`)
+- `{I}`: IMU sensor frame (from `imu_raw.header.frame_id`, e.g., `imu_link`)
+- `{M}`: magnetometer sensor frame (from `magnetic_field.header.frame_id`, e.g., `mag_link`)
+
+Estimated transforms:
+
+- `T_BI = (R_BI, p_BI)` : IMU → body
+- `T_BM = (R_BM, p_BM)` : mag → body
+
+### 3.1 TF direction convention
+
+We use TF2 parent/child semantics.
+
+- Published TF:
+  - parent: `base_link` (`{B}`)
+  - child: IMU frame `{I}` and mag frame `{M}`
+
+Therefore:
+
+- `T_BI` maps IMU-frame coordinates into body-frame coordinates:
+  - `v_B = R_BI v_I`
+  - `p_B = R_BI p_I + p_BI`
+- `T_BM` maps mag-frame coordinates into body-frame coordinates:
+  - `v_B = R_BM v_M`
+  - `p_B = R_BM p_M + p_BM`
+
+Quaternions in persisted files MUST declare their ordering explicitly (e.g. `quaternion_wxyz`).
+
+### 3.2 Translation policy
+
+Mount translation is usually weakly observable from only IMU + mag.
+Default policy:
+
+- Estimate **rotation only** and set translation to configured priors (often `0,0,0`), unless you later add a sensor that makes translation observable.
+- Output:
+  - `p_BI := params.p_BI_prior` (default `[0,0,0]`)
+  - `p_BM := params.p_BM_prior` (default `[0,0,0]`)
+- The optimizer may include translations but should keep them heavily regularized.
+
+#### 3.2.1 IMU–mag baseline hard constraint (optional)
+
+If the physical distance between the IMU and magnetometer is known (measured with a ruler), the system SHALL enforce a **hard baseline constraint** between the two sensor origins.
+
+Let:
+
+- `p_BI` be the IMU translation in `{B}`
+- `p_BM` be the magnetometer translation in `{B}`
+- `d_IM_m` be the measured IMU–mag distance in meters
+
+Constraint:
+
+\[
+\|p_{BM} - p_{BI}\| = d_{IM}
+\]
+
+Notes:
+
+- This is a **hard constraint** (not a soft prior) and MUST be enforced throughout the solving process.
+- If translations are otherwise treated as priors/constant, enabling this constraint promotes `(p_BI, p_BM)` to explicit variables (with one scalar constraint).
+- The baseline constraint provides **scale/geometry coupling** between the sensors even when translation is weakly observable from IMU+mag alone.
+- The direction of the baseline is not assumed known (only its magnitude).
+
+---
+
+## 4. ROS Interface
+
+### 4.1 Node name
+
+- Node: `ahrs_mounting`
+
+### 4.2 Inputs (subscriptions)
+
+#### 4.2.1 IMU
+
+- Topic: `imu_raw` (`sensor_msgs/Imu`)
+- Used fields:
+  - `header.stamp`
+  - `header.frame_id` → IMU frame `{I}`
+  - `angular_velocity` and `angular_velocity_covariance` (3×3 full)
+  - `linear_acceleration` and `linear_acceleration_covariance` (3×3 full)
+- Ignored:
+  - `orientation`, `orientation_covariance`
+
+#### 4.2.2 IMU calibration prior
+
+- Topic: `imu_calibration` (`oasis_msgs/ImuCalibration`)
+- Role: **one-shot initialization prior** for in-state nuisance parameters (per §2.3)
+- Contract:
+  - MUST be ExactTime paired with `imu_raw` at identical `t_meas_ns` (deterministic; `imu_raw` without a match is dropped) even after initialization.
+  - Content is consumed **only while uninitialized** to set the initial prior on `(b_a, A_a, b_g)`.
+  - After initialization, calibration messages are still paired for determinism/diagnostics, but **do not update** parameters.
+
+#### 4.2.3 Magnetometer
+
+- Topic: `magnetic_field` (`sensor_msgs/MagneticField`)
+- Used fields:
+  - `header.stamp`
+  - `header.frame_id` → mag frame `{M}`
+  - `magnetic_field` and `magnetic_field_covariance` (3×3 full)
+
+### 4.3 Outputs (publishers)
+
+#### 4.3.1 TF output
+
+- Publish `base_link -> imu_link` and `base_link -> mag_link` as TF2 transforms.
+- While the solution is changing, publish to `/tf` at the optimizer update rate.
+- Once stable enough, publish to `/tf_static` (latched). If the saved calibration file changes later, **republish the full static transforms** on `/tf_static` (do not stream `/tf_static` continuously).
+
+“Stable enough” is when both:
+
+- `||Δθ_BI|| < stable_rot_thresh_rad` and `||Δθ_BM|| < stable_rot_thresh_rad` over the last `stable_window_sec`
+- and solver reports `need_more_tilt == false` (and `need_more_yaw == false` when mag is being used)
+
+#### 4.3.2 Result topics
+
+**Primary structured result**
+
+- Topic: `ahrs_mount` (`oasis_msgs/AhrsMount`)
+- Publish rate: on optimizer update (and at least once per `save_period_sec`)
+- Contents:
+  - `header.stamp`: time of the current estimate
+  - Frames:
+    - `base_frame` (`base_link`)
+    - `imu_frame` (from `imu_raw.header.frame_id`)
+    - `mag_frame` (from `magnetic_field.header.frame_id`)
+  - Transforms:
+    - `T_BI` (rotation + translation)
+    - `T_BM` (rotation + translation)
+  - Covariances:
+    - `cov_R_BI` (3×3 tangent-space, full)
+    - `cov_R_BM` (3×3 tangent-space, full)
+    - `cov_p_BI` (3×3, full) (may be prior-only)
+    - `cov_p_BM` (3×3, full) (may be prior-only)
+  - Nuisance snapshot (refined online):
+    - `b_a`, `A_a`, `b_g`
+    - optional `b_m`
+    - current `R_m(t)` (3×3)
+  - Quality / status:
+    - `anchored` (bool)
+    - `mag_reference_invalid` (bool)
+    - `mag_disturbance_detected` (bool)
+    - counts: `raw_samples`, `steady_segments`, `keyframes`
+    - residual RMS: `accel_residual_rms`, `mag_residual_rms`
+    - diversity: `gravity_max_angle_deg`, `mag_proj_max_angle_deg`
+
+**Convenience transform stream**
+
+- Topic: `ahrs_mount_transform` (`geometry_msgs/TransformStamped`)
+- Publish: `T_BI` as a TF-style message for easy plotting/debugging
+  - `header.frame_id = base_link`
+  - `child_frame_id = imu_frame`
+  - `transform = T_BI`
+
+(Optional: publish a second `TransformStamped` for `T_BM` on `ahrs_transform_mag` if useful.)
+
+#### 4.3.3 Diagnostics
+
+- Topic: `ahrs_mount_diagnostics` (`diagnostic_msgs/DiagnosticArray`)
+- Publish rate: 1–5 Hz (and on state transitions)
+
+Report the following keys (at minimum):
+
+- Timing / drops:
+  - `imu_raw_dropped_no_calibration` (count)
+  - `mag_dropped_bad_cov` (count)
+  - `time_sync_slop_max_ns` (if tracked)
+- Bootstrap / state:
+  - `bootstrap_active` (bool)
+  - `bootstrap_remaining_sec` (float)
+  - `anchored` (bool)
+- Steady/keyframe pipeline:
+  - `steady_detected` (bool)
+  - `steady_segments` (count)
+  - `keyframes` (count)
+  - `need_more_tilt` (bool)
+  - `need_more_yaw` (bool)
+- Magnetometer health:
+  - `mag_reference_invalid` (bool)
+  - `mag_disturbance_detected` (bool)
+  - `R_m_trace` (float)
+  - `mag_factors_dropped` (count)
+- Solver health:
+  - `optimizer_iterations_last` (int)
+  - `optimizer_step_norm_last` (float)
+  - `accel_residual_rms` (float)
+  - `mag_residual_rms` (float)
+- Persistence:
+  - `last_save_unix_ns` (int)
+  - `save_period_sec` (float)
+  - `save_fail_count` (count)
+
+### 4.4 Calibration lifecycle
+
+The node **starts calibrating immediately** on startup and **continuously refines** the mount estimate online.
+
+#### 4.4.1 Startup behavior (assume flat + stationary)
+
+Constraint: at process start, `base_link` is **flat and stationary**.
+
+On startup, the node:
+
+- Begins stationary segmentation immediately.
+- Enters an initial **bootstrap** phase for `bootstrap_sec` to characterize noise and lock in priors:
+  - latch the **first valid** `imu_calibration` as the one-shot prior (per §2.3)
+  - estimate gyro stationary statistics (mean + covariance / PSD) from `ω_corr`
+  - estimate accel stationary statistics from `a_corr` (for gating and weights)
+- Automatically captures the **reference pose** at the end of bootstrap (equivalent to §6.4 anchor):
+  - set `R_WB,ref := I`
+  - record reference gravity direction (from bootstrap stationary mean)
+  - record reference magnetic direction if mag is valid (else mark `mag_reference_invalid = true`)
+
+Defaults:
+
+- `bootstrap_sec = 5.0`
+
+Log when bootstrap is complete.
+
+#### 4.4.2 Continuous calibration + periodic persist
+
+The node runs the optimizer continuously as new stationary segments arrive and updates `T_BI`, `T_BM` whenever the solution changes.
+
+Persistence policy:
+
+- Write the current calibration to disk **every `save_period_sec`**, regardless of delta.
+- Default: `save_period_sec = 2.0`
+
+Notes:
+
+- High write counts are acceptable.
+- If reference capture occurred without valid mag, calibration is still saved but marked as gravity-only / `mag_reference_invalid = true` in metadata.
+
+### 4.5 Parameters
+
+This node is configured entirely via parameters using constants near the top of the file, with a one-line comment of descriptive documentation for each.
+
+Numeric values shown as `TBD` are intended to be tuned later; the parameter names and semantics are the stable contract. `TBD` parameters may come from ROS, for example.
+
+#### 4.5.1 Topics and frames
+
+- `topics.imu_raw` (string): IMU raw topic name
+  - default: `imu_raw`
+- `topics.imu_calibration` (string): IMU calibration prior topic name
+  - default: `imu_calibration`
+- `topics.magnetic_field` (string): magnetometer topic name
+  - default: `magnetic_field`
+
+- `frames.base_frame` (string): body/base frame
+  - default: `base_link`
+- `frames.world_frame` (string): internal world/anchor frame name (internal use)
+  - default: `world`
+
+#### 4.5.2 Bootstrap and anchoring
+
+- `bootstrap.bootstrap_sec` (double): duration of startup bootstrap window (flat + stationary assumption)
+  - default: `5.0`
+- `bootstrap.require_flat_stationary` (bool): enforce “flat + stationary at boot” assumption (else only best-effort)
+  - default: `true`
+- `bootstrap.mag_reference_required` (bool): if true, refuse to declare “fully anchored” without valid mag reference
+  - default: `false`
+
+#### 4.5.3 Steady detection (windowed gating)
+
+- `steady.steady_sec` (double): minimum continuous steady duration before emitting a steady segment
+  - default: `2.0`
+- `steady.window_type` (string): windowing policy (e.g., `sliding`, `tumbling`)
+  - default: `sliding`
+
+Thresholds (tuned later; used in §5.1):
+
+- `steady.omega_mean_thresh` (double): threshold on `||mean(ω_corr)||`
+  - default: `TBD`
+- `steady.omega_cov_thresh` (double): threshold on `trace(cov(ω_corr))`
+  - default: `TBD` (often derived from bootstrap stats via `steady.k_omega`)
+- `steady.a_cov_thresh` (double): threshold on `trace(cov(a_corr))`
+  - default: `TBD`
+- `steady.a_norm_min` (double): minimum plausible `||mean(a_corr)||` (m/s²)
+  - default: `TBD`
+- `steady.a_norm_max` (double): maximum plausible `||mean(a_corr)||` (m/s²)
+  - default: `TBD`
+
+Derived-threshold helpers:
+
+- `steady.k_omega` (double): scale factor applied to bootstrap gyro covariance statistic to form `omega_cov_thresh`
+  - default: `TBD`
+
+#### 4.5.4 Keyframing / clustering
+
+- `cluster.cluster_g_deg` (double): gravity-direction angular threshold for keyframe assignment (deg)
+  - default: `7.5`
+- `cluster.cluster_h_deg` (double): mag-direction angular threshold for keyframe assignment when mag is valid (deg)
+  - default: `12.5`
+- `cluster.K_max` (int): maximum number of active keyframes (0 = unlimited)
+  - default: `0`
+- `cluster.drop_policy` (string): policy when `K_max` exceeded (`redundant`, `oldest`, `lowest_information`)
+  - default: `lowest_information`
+
+#### 4.5.5 Motion diversity requirements
+
+- `diversity.N_min` (int): minimum number of steady segments (or keyframes) before reporting “sufficient data”
+  - default: `TBD`
+- `diversity.tilt_min_deg` (double): minimum gravity-direction spread to be considered diverse enough (deg)
+  - default: `TBD`
+- `diversity.yaw_min_deg` (double): minimum mag-projection spread to be considered diverse enough (deg)
+  - default: `TBD`
+- `diversity.use_mag_for_yaw` (bool): if false, do not require yaw diversity even when mag is present
+  - default: `true`
+
+#### 4.5.6 Magnetometer direction-noise model (direction residual)
+
+Conversion / gating for driver covariance (`Σ_m_raw`, tesla² → direction covariance, unitless²):
+
+- `mag.s_min_T` (double): minimum `||m_raw||` allowed for covariance conversion (T)
+  - default: `1e-6`
+- `mag.use_driver_cov_as_prior` (bool): if true, attempt to initialize direction covariance from `Σ_m_raw` via Jacobian normalization; otherwise ignore `Σ_m_raw` entirely
+  - default: `true`
+
+Adaptive direction-noise model `R_m(t)` (unitless² ≈ rad²):
+
+- `mag.Rm_init_diag` (double[3]): fallback diagonal initialization for `R_m0` when `Σ_dir` is unavailable
+  - default: `[TBD, TBD, TBD]`
+- `mag.Rm_min_diag` (double[3]): lower bound on `R_m(t)` (SPD clamp)
+  - default: `[TBD, TBD, TBD]`
+- `mag.Rm_max_diag` (double[3]): upper bound on `R_m(t)` (SPD clamp)
+  - default: `[TBD, TBD, TBD]`
+- `mag.Rm_alpha` (double): covariance-matching update rate
+  - default: `TBD`
+- `mag.disturbance_gate_enabled` (bool): enable mag disturbance detection / factor dropping
+  - default: `true`
+- `mag.disturbance_gate_sigma` (double): gating threshold for declaring mag disturbance (e.g., NIS or robust score)
+  - default: `TBD`
+
+#### 4.5.7 TF publishing and stability
+
+- `tf.publish_dynamic` (bool): publish changing estimates to `/tf`
+  - default: `true`
+- `tf.publish_static_when_stable` (bool): publish to `/tf_static` once stable
+  - default: `true`
+- `tf.republish_static_on_save` (bool): republish `/tf_static` whenever the calibration file is updated
+  - default: `true`
+
+Stability detection (used by §4.3.1 “stable enough”):
+
+- `stability.stable_window_sec` (double): window over which stability is evaluated
+  - default: `TBD`
+- `stability.stable_rot_thresh_rad` (double): max allowed rotation change magnitude `||Δθ||` over the stable window
+  - default: `TBD`
+- `stability.require_need_more_tilt_false` (bool): require `need_more_tilt == false` before declaring stable
+  - default: `true`
+- `stability.require_need_more_yaw_false` (bool): require `need_more_yaw == false` (when mag is used) before declaring stable
+  - default: `true`
+
+#### 4.5.8 Persistence / output file
+
+- `save.save_period_sec` (double): period for writing the calibration snapshot to disk
+  - default: `2.0`
+- `save.output_path` (string): output YAML/JSON file path
+  - default: `TBD` (e.g., a package/config path or runtime-writable directory)
+- `save.format` (string): file format (`yaml` or `json`)
+  - default: `yaml`
+- `save.atomic_write` (bool): write via temp file + atomic rename
+  - default: `true`
+
+#### 4.5.9 Optimizer settings (online SO(3) solve)
+
+- `solver.backend` (string): solver backend identifier (`gn`, `lm`, etc.)
+  - default: `TBD`
+- `solver.max_iters` (int): max iterations per update
+  - default: `TBD`
+- `solver.update_rate_hz` (double): maximum optimizer update rate
+  - default: `TBD`
+- `solver.robust_loss` (string): robust loss type (`huber`, `cauchy`, etc.)
+  - default: `TBD`
+- `solver.robust_scale_a` (double): robust scale for accel direction residuals
+  - default: `TBD`
+- `solver.robust_scale_m` (double): robust scale for mag direction residuals
+  - default: `TBD`
+
+Regularization (prevents “mount absorbs bias”):
+
+- `solver.reg_mount_vs_bias` (double): strength of regularization discouraging mount rotation from compensating nuisance biases
+  - default: `TBD`
+- `solver.reg_translation` (double): strength of translation regularization toward priors (if translation variables exist)
+  - default: `TBD`
+
+#### 4.5.10 Translation priors (if translation is not estimated)
+
+- `mount.p_BI_prior_m` (double[3]): IMU translation prior in body frame
+  - default: `[0.0, 0.0, 0.0]`
+- `mount.p_BM_prior_m` (double[3]): mag translation prior in body frame
+  - default: `[0.0, 0.0, 0.0]`
+
+#### 4.5.11 Diagnostics
+
+- `diag.publish_rate_hz` (double): diagnostics publish rate
+  - default: `TBD`
+- `diag.track_time_sync_slop` (bool): track and report time-sync slop metrics
+  - default: `true`
+
+#### 4.5.12 IMU–mag baseline constraint
+
+- `mount.baseline_im_to_mag_m` (double): measured distance between IMU and magnetometer origins (meters)
+  - default: `TBD`
+- `mount.baseline_hard_enabled` (bool): enable hard constraint \|\|p_BM - p_BI\|\| = baseline
+  - default: `false`
+
+Behavior:
+
+- When `mount.baseline_hard_enabled == true`, the solver MUST enforce the hard constraint at all times.
+- When disabled, translation follows the translation policy in §3.2 (priors / regularization only).
+
+---
+
+## 5. Motion calibration procedure
+
+The node estimates mount rotations by collecting **multiple stationary segments** spanning different attitudes (tilts and yaw changes). Full inversion is not required.
+
+### 5.1 Quasi-stationary (“steady”) detection
+
+We want to accept “held mostly steady” poses (small hand motion) and only create a new sample point when the device has been steady for long enough.
+
+Define a sliding window of length `steady_sec` (default 2.0 s). Let gyro be `ω_corr(t)` and accel be `a_corr(t)`.
+
+A window is **STEADY** if all hold:
+
+- Mean gyro magnitude is small:
+  - `||mean(ω_corr)|| < ω_mean_thresh`
+- Gyro variation is small:
+  - `trace(cov(ω_corr)) < ω_cov_thresh`
+- Accel variation is small:
+  - `trace(cov(a_corr)) < a_cov_thresh`
+- Accel magnitude is plausible (reject gross motion):
+  - `a_norm_min < ||mean(a_corr)|| < a_norm_max`
+
+When the stream transitions from NOT_STEADY → STEADY and remains STEADY continuously for `steady_sec`,
+emit one **steady segment** `S_k` with:
+
+- mean accel `\bar a_I,k`, covariance `Σ_a,k`
+- mean mag `\bar m_M,k`, covariance `Σ_m,k` (if mag available; else mark missing)
+- duration and timestamps
+
+Notes:
+
+- This is intentionally looser than strict “stationary.” It tolerates small hand jitter as long as the statistics stay tight.
+- Use bootstrap-estimated gyro stats to initialize thresholds:
+  - `ω_cov_thresh` derived from stationary `cov(ω_corr)` during bootstrap (scaled by factor `k_ω`, default 3–5×).
+
+### 5.2 Motion diversity requirement
+
+To solve rotations robustly:
+
+- require at least `N_min` stationary segments (e.g., 10)
+- require tilt diversity (e.g., max angle between gravity directions across segments > 30°)
+- require yaw diversity (mag projection diversity) if possible
+
+If diversity is insufficient, keep collecting and publish a diagnostic like:
+
+- `need_more_tilt = true`
+- `need_more_yaw = true`
+
+### 5.3 Segment clustering + keyframes (pose diversity)
+
+Held poses can repeat (or be too similar). We cluster steady segments into **keyframes** so the optimizer
+gets diverse constraints and we avoid overweighting one attitude.
+
+Define per-segment unit directions:
+
+- `g_k := normalize(-\bar a_I,k)` (gravity “up” direction in `{I}`)
+- `h_k := normalize( \bar m_M,k )` (mag direction in `{M}`), if available
+
+Maintain a set of keyframes `K_j`. Each keyframe stores running means/covariances for `(g, h)` and counts.
+
+Assignment rule (online):
+
+- For a new segment `S_k`, compute similarity to each keyframe:
+  - `Δg = angle(g_k, g_j)`
+  - if mag valid: `Δh = angle(h_k, h_j)` else ignore mag
+- Assign to the closest keyframe if:
+  - `Δg < cluster_g_deg` AND (if mag valid) `Δh < cluster_h_deg`
+- Otherwise create a new keyframe.
+
+Defaults:
+
+- `cluster_g_deg = 7.5`
+- `cluster_h_deg = 12.5`
+
+Optimization dataset policy:
+
+- The optimizer runs on the current set of keyframes (one “representative” constraint per cluster),
+  using the keyframe’s aggregated mean/covariance as the measurement.
+- Optionally cap keyframes at `K_max` by dropping the lowest-information ones (e.g., most redundant gravity directions).
+
+This provides pose diversity automatically while allowing the user to “hold kinda steady” for ~2 s per pose.
+
+---
+
+## 6. Mathematical model
+
+This section defines the estimation problem for continuous mounting calibration. Measurements are accumulated into **steady segments** and then **clustered into keyframes** (§5.3). The optimizer runs over keyframes.
+
+### 6.1 Unknowns to estimate (outputs + nuisance)
+
+Primary outputs:
+
+- `R_BI` : rotation IMU→body
+- `R_BM` : rotation mag→body
+
+Nuisance (internal, continuously refined):
+
+- IMU systematic parameters (live in state):
+  - accel: `a_corr = A_a (a_raw − b_a)` where `b_a, A_a` are estimated
+  - gyro: `ω_corr = ω_raw − b_g` where `b_g` is estimated
+- Magnetometer offset: `m_corr = m_raw − b_m`
+- World directions (unit vectors):
+  - `g_W` gravity direction in `{W}`
+  - `m_W` magnetic field direction in `{W}`
+- Per-keyframe body attitude:
+  - `R_WB,j` for each keyframe `j`
+- Measurement noise models (refined online):
+  - IMU steady-window statistics (used for weighting / gating)
+  - `R_m(t)` magnetometer noise covariance (adaptive, bounded SPD, §2.4)
+
+**Prior semantics:**
+
+- `imu_calibration` and any mag-cal inputs are **priors only**; they initialize the nuisance parameters and their covariances.
+- During operation, nuisance parameters are refined using accumulated steady/keyframe data (robust, continuous estimation), not “locked”.
+
+### 6.1.1 Baseline hard constraint (translation coupling)
+
+When enabled (`mount.baseline_hard_enabled`), the problem includes translation variables `p_BI` and `p_BM` and enforces:
+
+\[
+c(p_{BI}, p_{BM}) := \|p_{BM} - p_{BI}\| - d_{IM} = 0
+\]
+
+This constraint is treated as a **hard equality constraint** in the optimizer (e.g., via constrained GN/LM, variable elimination / reparameterization, or exact projection after each update). It MUST NOT be implemented as a soft penalty term.
+
+---
+
+### 6.2 Keyframe measurement factors (direction constraints)
+
+For keyframe `j`, we form direction observations from aggregated steady data:
+
+- IMU “up” direction in `{I}`:
+  - `â_I,j = normalize( -\bar a_I,j )`
+- Magnetometer direction in `{M}` (if valid):
+  - `m̂_M,j = normalize( \bar m_M,j )`
+
+Predicted directions (same frame as measurement):
+
+Rotation chains:
+
+- `R_WI,j = R_BIᵀ * R_WB,j`
+- `R_WM,j = R_BMᵀ * R_WB,j`
+
+So:
+
+- `R_IW,j = R_WB,jᵀ * R_BI`
+- `R_MW,j = R_WB,jᵀ * R_BM`
+
+Predictions:
+
+- `â̂_I,j = (R_WB,jᵀ * R_BI) * g_W`
+- `m̂̂_M,j = (R_WB,jᵀ * R_BM) * m_W`
+
+Residuals (direction-only, robust to magnitude):
+
+- accel: `r_a,j = â_I,j × â̂_I,j`
+- mag: `r_m,j = m̂_M,j × m̂̂_M,j`
+
+Weighting:
+
+- `w_a,j` from the steady-window / keyframe aggregated accel covariance (and duration / sample count)
+- `w_m,j` from adaptive `R_m(t)` and keyframe aggregated mag covariance
+- If mag is flagged disturbed for the keyframe, drop the mag factor for that keyframe (gravity-only constraint).
+
+---
+
+### 6.3 Joint optimization structure (online)
+
+Solve for:
+
+- global: `R_BI`, `R_BM`, `g_W`, `m_W` (and nuisance IMU/mag params)
+- per-keyframe: `R_WB,j`
+
+Objective:
+\[
+\min \sum_j \rho_a(\|r_{a,j}\|^2, w_{a,j}) + \rho_m(\|r_{m,j}\|^2, w_{m,j})
++ \text{priors}
+\]
+
+Priors:
+
+- Unit constraints: `||g_W|| = 1`, `||m_W|| = 1`
+- Rotations live on SO(3): `R_BI, R_BM, R_WB,j ∈ SO(3)`
+- Systematic priors:
+  - initialize `(b_a, A_a, b_g)` from the first valid `imu_calibration`
+  - initialize R_m0 from Σ_dir (computed from Σ_m_raw via normalization Jacobian, §2.4); else use defaults
+  - initialize `b_m` from a provided mag offset prior, if available
+- Weak regularization on nuisance parameters to prevent “mount absorbs bias”.
+
+Robustness:
+
+- Use robust loss (`ρ`) on both accel and mag residuals.
+- Downweight or drop mag factors for keyframes where mag innovation is inconsistent (disturbance).
+
+---
+
+### 6.4 Reference anchoring (ties result to `base_link`)
+
+There is a global rotational gauge freedom unless anchored.
+
+In this system, anchoring is automatic (per §4.4):
+
+- At end of bootstrap, assume `base_link` is flat + stationary and set:
+  - `R_WB,ref := I`
+- The world frame `{W}` is defined as “body at the reference pose”.
+- All `R_WB,j` are solved relative to this anchor.
+
+This makes `R_BI` and `R_BM` directly interpretable as IMU→body and mag→body.
+
+---
+
+### 6.5 Initialization (deterministic)
+
+1. Bootstrap (`bootstrap_sec`): collect steady data, estimate gyro/accel stationary statistics, latch priors.
+2. Set `R_WB,ref = I` and initialize:
+   - `g_W := [0, 0, -1]` (or derived from reference accel)
+   - `m_W := normalize(reference mag)` if mag valid
+3. Initialize `R_BI, R_BM := I` (or from URDF if available).
+4. For each new keyframe `j`, seed `R_WB,j` using TRIAD-like construction (gravity + mag when available).
+5. Run iterative optimization on SO(3) (GN/LM) continuously as keyframes update.
+
+### 6.6 Calibration algorithm (summary)
+
+Pipeline:
+
+1. Bootstrap (startup, flat + stationary): latch `imu_calibration` as priors, estimate steady/noise stats, set `R_WB,ref := I`, initialize `g_W` and `m_W`.
+2. Continuous STEADY detection (`steady_sec`): emit steady segments `S_k` from windowed statistics on `ω_corr, a_corr`.
+3. Cluster segments into keyframes `K_j` using angular thresholds on gravity (and mag if valid).
+4. Optimize online over `{R_BI, R_BM, g_W, m_W, R_WB,j}` using direction residuals (`×`) with robust loss; update adaptive mag noise `R_m(t)`.
+5. Publish TF and persist snapshot every `save_period_sec`.
+
+---
+
+## 7. Outputs and persistence format
+
+### 7.1 What gets saved
+
+Save a single self-contained calibration snapshot including **mount TF** and **nuisance parameters** used by the estimator.
+
+**Mount transforms (primary outputs)**
+
+- `T_BI` and `T_BM`:
+  - rotation quaternion (explicit convention, e.g. `quaternion_wxyz`)
+  - translation vector (`p_BI`, `p_BM`, typically priors)
+  - rotation covariance 3×3 in tangent space (full matrix; do not diagonalize)
+
+**IMU systematic parameters (nuisance, refined online)**
+
+- Accel correction parameters:
+  - `b_a` (m/s²), 3×1
+  - `A_a` (3×3, row-major)
+  - `cov(b_a, A_a)` (12×12, row-major) if maintained
+- Gyro bias:
+  - `b_g` (rad/s), 3×1
+  - `cov(b_g)` (3×3, row-major)
+
+**Magnetometer nuisance (refined online)**
+
+- Optional mag offset:
+  - `b_m` (tesla), 3×1
+  - `cov(b_m)` (3×3) if maintained
+- Adaptive mag measurement noise model:
+  - `R_m` (3×3, unitless² ≈ rad²), current bounded SPD value for the direction residual `r_m`
+
+**Estimator bookkeeping / quality metadata**
+
+- Data volume:
+  - counts: raw samples ingested, steady segments accepted, keyframes active
+  - total duration used
+- Conditioning / diversity:
+  - gravity max-angle (deg)
+  - mag projection max-angle (deg), if mag valid
+- Fit quality:
+  - accel residual RMS (direction residual)
+  - mag residual RMS (direction residual), if mag valid
+  - robust inlier ratio (optional)
+- Flags:
+  - `anchored: true|false`
+  - `mag_reference_invalid: true|false`
+  - `mag_disturbance_detected: true|false` (if any keyframes dropped mag)
+
+### 7.2 File format (YAML)
+
+`ahrs_mount.yaml`:
+
+```yaml
+format_version: 1
+
+frames:
+  base_frame: base_link
+  imu_frame: imu_link
+  mag_frame: mag_link
+
+flags:
+  anchored: true
+  mag_reference_invalid: false
+  mag_disturbance_detected: false
+  mag_dir_prior_from_driver_cov: false
+
+mounts:
+  T_BI:
+    translation_m: [0.0, 0.0, 0.0]
+    quaternion_wxyz: [1.0, 0.0, 0.0, 0.0]
+    rot_cov_rad2: [[...], [...], [...]]
+  T_BM:
+    translation_m: [0.0, 0.0, 0.0]
+    quaternion_wxyz: [1.0, 0.0, 0.0, 0.0]
+    rot_cov_rad2: [[...], [...], [...]]
+
+nuisance:
+  imu:
+    accel_bias_mps2: [0.0, 0.0, 0.0] # b_a
+    accel_A_row_major: [... 9 ...] # A_a
+    accel_param_cov_row_major_12x12: [... 144 ...]
+    gyro_bias_rads: [0.0, 0.0, 0.0] # b_g
+    gyro_bias_cov_row_major_3x3: [... 9 ...]
+  mag:
+    offset_t: [0.0, 0.0, 0.0] # b_m
+    offset_cov_row_major_3x3: [... 9 ...]
+    R_m_unitless2_row_major_3x3: [... 9 ...] # adaptive noise for direction residual r_m
+    R_m0_unitless2_row_major_3x3: [... 9 ...]
+
+quality:
+  raw_samples: 0
+  steady_segments: 0
+  keyframes: 0
+  total_duration_sec: 0.0
+  accel_residual_rms: 0.0
+  mag_residual_rms: 0.0
+  diversity:
+    gravity_max_angle_deg: 0.0
+    mag_proj_max_angle_deg: 0.0
+```

--- a/oasis_control/oasis_control/cli/ahrs_mounting_cli.py
+++ b/oasis_control/oasis_control/cli/ahrs_mounting_cli.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/oasis_control/localization/mounting/config/mounting_config.py
+++ b/oasis_control/oasis_control/localization/mounting/config/mounting_config.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/oasis_control/localization/mounting/config/mounting_params.py
+++ b/oasis_control/oasis_control/localization/mounting/config/mounting_params.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/oasis_control/localization/mounting/config/mounting_params.py
+++ b/oasis_control/oasis_control/localization/mounting/config/mounting_params.py
@@ -7,3 +7,595 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+"""Structured configuration schema for AHRS mounting calibration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field
+from dataclasses import fields
+from dataclasses import replace
+from typing import Any
+
+import numpy as np
+
+
+# IMU raw topic name
+TOPIC_IMU_RAW: str = "imu_raw"
+# IMU calibration topic name
+TOPIC_IMU_CALIBRATION: str = "imu_calibration"
+# Magnetometer topic name
+TOPIC_MAGNETIC_FIELD: str = "magnetic_field"
+
+# Base frame name
+FRAME_BASE: str = "base_link"
+# World frame name
+FRAME_WORLD: str = "world"
+
+# Bootstrap duration in seconds
+BOOTSTRAP_SEC: float = 5.0
+# Enforce flat and stationary assumption at boot
+BOOTSTRAP_REQUIRE_FLAT_STATIONARY: bool = True
+# Require a valid mag reference before anchoring
+BOOTSTRAP_MAG_REFERENCE_REQUIRED: bool = False
+
+# Steady detection window duration in seconds
+STEADY_SEC: float = 2.0
+# Windowing policy for steady detection
+STEADY_WINDOW_TYPE: str = "sliding"
+
+# Threshold on mean gyro magnitude in rad/s
+STEADY_OMEGA_MEAN_THRESH: float | None = None
+# Threshold on gyro covariance trace in (rad/s)^2
+STEADY_OMEGA_COV_THRESH: float | None = None
+# Threshold on accel covariance trace in (m/s^2)^2
+STEADY_A_COV_THRESH: float | None = None
+# Minimum mean accel magnitude in m/s^2
+STEADY_A_NORM_MIN: float | None = None
+# Maximum mean accel magnitude in m/s^2
+STEADY_A_NORM_MAX: float | None = None
+# Scale factor applied to bootstrap gyro covariance
+STEADY_K_OMEGA: float | None = None
+
+# Gravity direction cluster threshold in degrees
+CLUSTER_G_DEG: float = 7.5
+# Mag direction cluster threshold in degrees
+CLUSTER_H_DEG: float = 12.5
+# Maximum number of keyframes (0 means unlimited)
+CLUSTER_K_MAX: int = 0
+# Policy for dropping keyframes when exceeding K_max
+CLUSTER_DROP_POLICY: str = "lowest_information"
+
+# Minimum number of steady segments required
+DIVERSITY_N_MIN: int | None = None
+# Minimum tilt diversity in degrees
+DIVERSITY_TILT_MIN_DEG: float | None = None
+# Minimum yaw diversity in degrees
+DIVERSITY_YAW_MIN_DEG: float | None = None
+# Require mag-based yaw diversity when mag is available
+DIVERSITY_USE_MAG_FOR_YAW: bool = True
+
+# Minimum mag magnitude for covariance conversion in tesla
+MAG_S_MIN_T: float = 1e-6
+# Use driver covariance as prior for mag direction noise
+MAG_USE_DRIVER_COV_AS_PRIOR: bool = True
+
+# Initial mag direction noise diagonal in unitless^2
+MAG_RM_INIT_DIAG: np.ndarray = np.array([1e-3, 1e-3, 1e-3], dtype=np.float64)
+# Minimum mag direction noise diagonal in unitless^2
+MAG_RM_MIN_DIAG: np.ndarray = np.array([1e-5, 1e-5, 1e-5], dtype=np.float64)
+# Maximum mag direction noise diagonal in unitless^2
+MAG_RM_MAX_DIAG: np.ndarray = np.array([1e-1, 1e-1, 1e-1], dtype=np.float64)
+# Mag covariance matching update rate
+MAG_RM_ALPHA: float = 0.01
+# Enable mag disturbance gating
+MAG_DISTURBANCE_GATE_ENABLED: bool = True
+# Mag disturbance gating threshold
+MAG_DISTURBANCE_GATE_SIGMA: float | None = None
+
+# Publish dynamic TF while estimate changes
+TF_PUBLISH_DYNAMIC: bool = True
+# Publish static TF when stable
+TF_PUBLISH_STATIC_WHEN_STABLE: bool = True
+# Republish static TF when saving calibration
+TF_REPUBLISH_STATIC_ON_SAVE: bool = True
+
+# Stability window duration in seconds
+STABILITY_STABLE_WINDOW_SEC: float | None = None
+# Stability rotation change threshold in radians
+STABILITY_STABLE_ROT_THRESH_RAD: float | None = None
+# Require need_more_tilt to be false for stability
+STABILITY_REQUIRE_NEED_MORE_TILT_FALSE: bool = True
+# Require need_more_yaw to be false for stability
+STABILITY_REQUIRE_NEED_MORE_YAW_FALSE: bool = True
+
+# Save period in seconds
+SAVE_PERIOD_SEC: float = 2.0
+# Output path for saved calibration
+SAVE_OUTPUT_PATH: str | None = None
+# Output format for saved calibration
+SAVE_FORMAT: str = "yaml"
+# Use atomic write for persistence
+SAVE_ATOMIC_WRITE: bool = True
+
+# Solver backend identifier
+SOLVER_BACKEND: str | None = None
+# Maximum solver iterations per update
+SOLVER_MAX_ITERS: int | None = None
+# Maximum update rate in Hz
+SOLVER_UPDATE_RATE_HZ: float | None = None
+# Robust loss identifier
+SOLVER_ROBUST_LOSS: str | None = None
+# Robust scale for accel residuals
+SOLVER_ROBUST_SCALE_A: float | None = None
+# Robust scale for mag residuals
+SOLVER_ROBUST_SCALE_M: float | None = None
+# Regularization against mount absorbing bias
+SOLVER_REG_MOUNT_VS_BIAS: float | None = None
+# Regularization strength toward translation priors
+SOLVER_REG_TRANSLATION: float | None = None
+
+# IMU translation prior in body frame in meters
+MOUNT_P_BI_PRIOR_M: np.ndarray = np.array([0.0, 0.0, 0.0], dtype=np.float64)
+# Mag translation prior in body frame in meters
+MOUNT_P_BM_PRIOR_M: np.ndarray = np.array([0.0, 0.0, 0.0], dtype=np.float64)
+# Baseline between IMU and mag origins in meters
+MOUNT_BASELINE_IM_TO_MAG_M: float | None = None
+# Enable hard baseline constraint
+MOUNT_BASELINE_HARD_ENABLED: bool = False
+
+# Diagnostics publish rate in Hz
+DIAG_PUBLISH_RATE_HZ: float | None = None
+# Track and report time sync slop
+DIAG_TRACK_TIME_SYNC_SLOP: bool = True
+
+
+class MountingParamsError(Exception):
+    """Raised when mounting parameter validation fails."""
+
+
+def _as_float_array(value: Any, name: str) -> np.ndarray:
+    """Coerce a value to a float64 numpy array with shape (3,)."""
+    array: np.ndarray = np.asarray(value, dtype=np.float64)
+    if array.shape != (3,):
+        raise MountingParamsError(f"{name} must have shape (3,)")
+    if not np.all(np.isfinite(array)):
+        raise MountingParamsError(f"{name} must contain finite values")
+    return array
+
+
+def _require_positive(value: float, name: str) -> None:
+    """Require a positive value."""
+    if value <= 0.0:
+        raise MountingParamsError(f"{name} must be positive")
+
+
+def _require_non_negative(value: float, name: str) -> None:
+    """Require a non-negative value."""
+    if value < 0.0:
+        raise MountingParamsError(f"{name} must be non-negative")
+
+
+def _validate_optional_positive(value: float | None, name: str) -> None:
+    """Validate an optional positive parameter."""
+    if value is None:
+        return
+    _require_positive(value, name)
+
+
+def _validate_optional_non_negative(value: float | None, name: str) -> None:
+    """Validate an optional non-negative parameter."""
+    if value is None:
+        return
+    _require_non_negative(value, name)
+
+
+def _validate_optional_int(value: int | None, name: str) -> None:
+    """Validate an optional integer value."""
+    if value is None:
+        return
+    if not isinstance(value, int):
+        raise MountingParamsError(f"{name} must be an int")
+
+
+def _validate_optional_positive_int(value: int | None, name: str) -> None:
+    """Validate an optional positive integer value."""
+    if value is None:
+        return
+    if not isinstance(value, int):
+        raise MountingParamsError(f"{name} must be an int")
+    if value <= 0:
+        raise MountingParamsError(f"{name} must be positive")
+
+
+def _validate_optional_non_negative_int(value: int | None, name: str) -> None:
+    """Validate an optional non-negative integer value."""
+    if value is None:
+        return
+    if not isinstance(value, int):
+        raise MountingParamsError(f"{name} must be an int")
+    if value < 0:
+        raise MountingParamsError(f"{name} must be non-negative")
+
+
+def _validate_positive_array(values: np.ndarray, name: str) -> None:
+    """Validate that an array contains strictly positive values."""
+    if np.any(values <= 0.0):
+        raise MountingParamsError(f"{name} must be positive")
+
+
+@dataclass(frozen=True)
+class TopicsParams:
+    """Topic names used by mounting calibration."""
+
+    # IMU raw topic name
+    imu_raw: str = TOPIC_IMU_RAW
+    # IMU calibration topic name
+    imu_calibration: str = TOPIC_IMU_CALIBRATION
+    # Magnetometer topic name
+    magnetic_field: str = TOPIC_MAGNETIC_FIELD
+
+
+@dataclass(frozen=True)
+class FramesParams:
+    """Frame identifiers for mounting calibration."""
+
+    # Base frame name
+    base_frame: str = FRAME_BASE
+    # World frame name
+    world_frame: str = FRAME_WORLD
+
+
+@dataclass(frozen=True)
+class BootstrapParams:
+    """Bootstrap configuration for startup anchoring."""
+
+    # Bootstrap duration in seconds
+    bootstrap_sec: float = BOOTSTRAP_SEC
+    # Enforce flat and stationary boot assumption
+    require_flat_stationary: bool = BOOTSTRAP_REQUIRE_FLAT_STATIONARY
+    # Require mag reference for anchoring
+    mag_reference_required: bool = BOOTSTRAP_MAG_REFERENCE_REQUIRED
+
+
+@dataclass(frozen=True)
+class SteadyParams:
+    """Steady detection parameters for gating steady segments."""
+
+    # Steady window duration in seconds
+    steady_sec: float = STEADY_SEC
+    # Windowing policy identifier
+    window_type: str = STEADY_WINDOW_TYPE
+
+    # Threshold on mean gyro magnitude in rad/s
+    omega_mean_thresh: float | None = STEADY_OMEGA_MEAN_THRESH
+    # Threshold on gyro covariance trace in (rad/s)^2
+    omega_cov_thresh: float | None = STEADY_OMEGA_COV_THRESH
+    # Threshold on accel covariance trace in (m/s^2)^2
+    a_cov_thresh: float | None = STEADY_A_COV_THRESH
+    # Minimum mean accel magnitude in m/s^2
+    a_norm_min: float | None = STEADY_A_NORM_MIN
+    # Maximum mean accel magnitude in m/s^2
+    a_norm_max: float | None = STEADY_A_NORM_MAX
+    # Scale factor applied to bootstrap gyro covariance
+    k_omega: float | None = STEADY_K_OMEGA
+
+
+@dataclass(frozen=True)
+class ClusterParams:
+    """Keyframe clustering thresholds and policies."""
+
+    # Gravity direction clustering threshold in degrees
+    cluster_g_deg: float = CLUSTER_G_DEG
+    # Magnetometer direction clustering threshold in degrees
+    cluster_h_deg: float = CLUSTER_H_DEG
+    # Maximum number of keyframes (0 means unlimited)
+    K_max: int = CLUSTER_K_MAX
+    # Policy for dropping keyframes when full
+    drop_policy: str = CLUSTER_DROP_POLICY
+
+
+@dataclass(frozen=True)
+class DiversityParams:
+    """Motion diversity requirements."""
+
+    # Minimum number of steady segments required
+    N_min: int | None = DIVERSITY_N_MIN
+    # Minimum tilt diversity in degrees
+    tilt_min_deg: float | None = DIVERSITY_TILT_MIN_DEG
+    # Minimum yaw diversity in degrees
+    yaw_min_deg: float | None = DIVERSITY_YAW_MIN_DEG
+    # Require mag-based yaw diversity when mag is available
+    use_mag_for_yaw: bool = DIVERSITY_USE_MAG_FOR_YAW
+
+
+@dataclass(frozen=True)
+class MagParams:
+    """Magnetometer direction-noise parameters."""
+
+    # Minimum mag magnitude for covariance conversion in tesla
+    s_min_T: float = MAG_S_MIN_T
+    # Use driver covariance as prior for mag direction noise
+    use_driver_cov_as_prior: bool = MAG_USE_DRIVER_COV_AS_PRIOR
+
+    # Initial mag direction noise diagonal in unitless^2
+    Rm_init_diag: np.ndarray = field(default_factory=lambda: MAG_RM_INIT_DIAG.copy())
+    # Minimum mag direction noise diagonal in unitless^2
+    Rm_min_diag: np.ndarray = field(default_factory=lambda: MAG_RM_MIN_DIAG.copy())
+    # Maximum mag direction noise diagonal in unitless^2
+    Rm_max_diag: np.ndarray = field(default_factory=lambda: MAG_RM_MAX_DIAG.copy())
+    # Mag covariance matching update rate
+    Rm_alpha: float = MAG_RM_ALPHA
+    # Enable mag disturbance gating
+    disturbance_gate_enabled: bool = MAG_DISTURBANCE_GATE_ENABLED
+    # Mag disturbance gating threshold
+    disturbance_gate_sigma: float | None = MAG_DISTURBANCE_GATE_SIGMA
+
+    def __post_init__(self) -> None:
+        """Coerce diagonal arrays into float64 numpy arrays."""
+        object.__setattr__(
+            self,
+            "Rm_init_diag",
+            _as_float_array(self.Rm_init_diag, "mag.Rm_init_diag"),
+        )
+        object.__setattr__(
+            self,
+            "Rm_min_diag",
+            _as_float_array(self.Rm_min_diag, "mag.Rm_min_diag"),
+        )
+        object.__setattr__(
+            self,
+            "Rm_max_diag",
+            _as_float_array(self.Rm_max_diag, "mag.Rm_max_diag"),
+        )
+
+
+@dataclass(frozen=True)
+class TfParams:
+    """TF publishing policy parameters."""
+
+    # Publish dynamic TF while estimates change
+    publish_dynamic: bool = TF_PUBLISH_DYNAMIC
+    # Publish static TF once stable
+    publish_static_when_stable: bool = TF_PUBLISH_STATIC_WHEN_STABLE
+    # Republish static TF when saving
+    republish_static_on_save: bool = TF_REPUBLISH_STATIC_ON_SAVE
+
+
+@dataclass(frozen=True)
+class StabilityParams:
+    """Stability detection parameters for TF publication."""
+
+    # Stability window duration in seconds
+    stable_window_sec: float | None = STABILITY_STABLE_WINDOW_SEC
+    # Max allowed rotation change in radians
+    stable_rot_thresh_rad: float | None = STABILITY_STABLE_ROT_THRESH_RAD
+    # Require need_more_tilt to be false for stability
+    require_need_more_tilt_false: bool = STABILITY_REQUIRE_NEED_MORE_TILT_FALSE
+    # Require need_more_yaw to be false for stability
+    require_need_more_yaw_false: bool = STABILITY_REQUIRE_NEED_MORE_YAW_FALSE
+
+
+@dataclass(frozen=True)
+class SaveParams:
+    """Persistence and output file parameters."""
+
+    # Save period in seconds
+    save_period_sec: float = SAVE_PERIOD_SEC
+    # Output path for saved calibration
+    output_path: str | None = SAVE_OUTPUT_PATH
+    # Output format name
+    format: str = SAVE_FORMAT
+    # Use atomic write for persistence
+    atomic_write: bool = SAVE_ATOMIC_WRITE
+
+
+@dataclass(frozen=True)
+class SolverParams:
+    """Optimizer configuration parameters."""
+
+    # Solver backend identifier
+    backend: str | None = SOLVER_BACKEND
+    # Maximum solver iterations per update
+    max_iters: int | None = SOLVER_MAX_ITERS
+    # Maximum update rate in Hz
+    update_rate_hz: float | None = SOLVER_UPDATE_RATE_HZ
+    # Robust loss identifier
+    robust_loss: str | None = SOLVER_ROBUST_LOSS
+    # Robust scale for accel residuals
+    robust_scale_a: float | None = SOLVER_ROBUST_SCALE_A
+    # Robust scale for mag residuals
+    robust_scale_m: float | None = SOLVER_ROBUST_SCALE_M
+    # Regularization against mount absorbing bias
+    reg_mount_vs_bias: float | None = SOLVER_REG_MOUNT_VS_BIAS
+    # Regularization strength toward translation priors
+    reg_translation: float | None = SOLVER_REG_TRANSLATION
+
+
+@dataclass(frozen=True)
+class MountParams:
+    """Translation priors and baseline constraints."""
+
+    # IMU translation prior in body frame in meters
+    p_BI_prior_m: np.ndarray = field(default_factory=lambda: MOUNT_P_BI_PRIOR_M.copy())
+    # Mag translation prior in body frame in meters
+    p_BM_prior_m: np.ndarray = field(default_factory=lambda: MOUNT_P_BM_PRIOR_M.copy())
+    # Baseline distance between IMU and mag in meters
+    baseline_im_to_mag_m: float | None = MOUNT_BASELINE_IM_TO_MAG_M
+    # Enable hard baseline constraint
+    baseline_hard_enabled: bool = MOUNT_BASELINE_HARD_ENABLED
+
+    def __post_init__(self) -> None:
+        """Coerce translation priors into float64 numpy arrays."""
+        object.__setattr__(
+            self,
+            "p_BI_prior_m",
+            _as_float_array(self.p_BI_prior_m, "mount.p_BI_prior_m"),
+        )
+        object.__setattr__(
+            self,
+            "p_BM_prior_m",
+            _as_float_array(self.p_BM_prior_m, "mount.p_BM_prior_m"),
+        )
+
+
+@dataclass(frozen=True)
+class DiagParams:
+    """Diagnostics publishing parameters."""
+
+    # Diagnostics publish rate in Hz
+    publish_rate_hz: float | None = DIAG_PUBLISH_RATE_HZ
+    # Track and report time-sync slop
+    track_time_sync_slop: bool = DIAG_TRACK_TIME_SYNC_SLOP
+
+
+@dataclass(frozen=True)
+class MountingParams:
+    """Complete configuration tree for mounting calibration."""
+
+    topics: TopicsParams
+    frames: FramesParams
+    bootstrap: BootstrapParams
+    steady: SteadyParams
+    cluster: ClusterParams
+    diversity: DiversityParams
+    mag: MagParams
+    tf: TfParams
+    stability: StabilityParams
+    save: SaveParams
+    solver: SolverParams
+    mount: MountParams
+    diag: DiagParams
+
+    @classmethod
+    def defaults(cls) -> MountingParams:
+        """Return the default mounting parameter tree."""
+        return cls(
+            topics=TopicsParams(),
+            frames=FramesParams(),
+            bootstrap=BootstrapParams(),
+            steady=SteadyParams(),
+            cluster=ClusterParams(),
+            diversity=DiversityParams(),
+            mag=MagParams(),
+            tf=TfParams(),
+            stability=StabilityParams(),
+            save=SaveParams(),
+            solver=SolverParams(),
+            mount=MountParams(),
+            diag=DiagParams(),
+        )
+
+    def validate(self) -> None:
+        """Validate parameter invariants and constraints."""
+        if not self.topics.imu_raw:
+            raise MountingParamsError("topics.imu_raw must be set")
+        if not self.topics.imu_calibration:
+            raise MountingParamsError("topics.imu_calibration must be set")
+        if not self.topics.magnetic_field:
+            raise MountingParamsError("topics.magnetic_field must be set")
+        if not self.frames.base_frame:
+            raise MountingParamsError("frames.base_frame must be set")
+        if not self.frames.world_frame:
+            raise MountingParamsError("frames.world_frame must be set")
+
+        _require_positive(self.bootstrap.bootstrap_sec, "bootstrap.bootstrap_sec")
+        _require_positive(self.steady.steady_sec, "steady.steady_sec")
+        _validate_optional_positive(
+            self.steady.omega_mean_thresh, "steady.omega_mean_thresh"
+        )
+        _validate_optional_positive(
+            self.steady.omega_cov_thresh, "steady.omega_cov_thresh"
+        )
+        _validate_optional_positive(self.steady.a_cov_thresh, "steady.a_cov_thresh")
+        _validate_optional_positive(self.steady.a_norm_min, "steady.a_norm_min")
+        _validate_optional_positive(self.steady.a_norm_max, "steady.a_norm_max")
+        _validate_optional_positive(self.steady.k_omega, "steady.k_omega")
+
+        _validate_optional_non_negative(
+            self.cluster.cluster_g_deg, "cluster.cluster_g_deg"
+        )
+        _validate_optional_non_negative(
+            self.cluster.cluster_h_deg, "cluster.cluster_h_deg"
+        )
+        _validate_optional_non_negative_int(self.cluster.K_max, "cluster.K_max")
+
+        _validate_optional_non_negative_int(self.diversity.N_min, "diversity.N_min")
+        _validate_optional_positive(
+            self.diversity.tilt_min_deg, "diversity.tilt_min_deg"
+        )
+        _validate_optional_positive(self.diversity.yaw_min_deg, "diversity.yaw_min_deg")
+
+        _require_positive(self.mag.s_min_T, "mag.s_min_T")
+        _validate_optional_positive(self.mag.Rm_alpha, "mag.Rm_alpha")
+        _validate_optional_positive(
+            self.mag.disturbance_gate_sigma, "mag.disturbance_gate_sigma"
+        )
+        _validate_positive_array(self.mag.Rm_init_diag, "mag.Rm_init_diag")
+        _validate_positive_array(self.mag.Rm_min_diag, "mag.Rm_min_diag")
+        _validate_positive_array(self.mag.Rm_max_diag, "mag.Rm_max_diag")
+        if np.any(self.mag.Rm_min_diag > self.mag.Rm_max_diag):
+            raise MountingParamsError("mag.Rm_min_diag must not exceed mag.Rm_max_diag")
+
+        _validate_optional_positive(
+            self.stability.stable_window_sec, "stability.stable_window_sec"
+        )
+        _validate_optional_positive(
+            self.stability.stable_rot_thresh_rad,
+            "stability.stable_rot_thresh_rad",
+        )
+
+        _require_positive(self.save.save_period_sec, "save.save_period_sec")
+
+        _validate_optional_int(self.solver.max_iters, "solver.max_iters")
+        _validate_optional_positive(self.solver.update_rate_hz, "solver.update_rate_hz")
+        _validate_optional_positive(self.solver.robust_scale_a, "solver.robust_scale_a")
+        _validate_optional_positive(self.solver.robust_scale_m, "solver.robust_scale_m")
+        _validate_optional_non_negative(
+            self.solver.reg_mount_vs_bias, "solver.reg_mount_vs_bias"
+        )
+        _validate_optional_non_negative(
+            self.solver.reg_translation, "solver.reg_translation"
+        )
+
+        _as_float_array(self.mount.p_BI_prior_m, "mount.p_BI_prior_m")
+        _as_float_array(self.mount.p_BM_prior_m, "mount.p_BM_prior_m")
+        if self.mount.baseline_hard_enabled:
+            if self.mount.baseline_im_to_mag_m is None:
+                raise MountingParamsError(
+                    "mount.baseline_im_to_mag_m must be set when "
+                    "mount.baseline_hard_enabled is true"
+                )
+            _require_positive(
+                self.mount.baseline_im_to_mag_m,
+                "mount.baseline_im_to_mag_m",
+            )
+        else:
+            if self.mount.baseline_im_to_mag_m is not None:
+                _require_positive(
+                    self.mount.baseline_im_to_mag_m,
+                    "mount.baseline_im_to_mag_m",
+                )
+
+        _validate_optional_positive(self.diag.publish_rate_hz, "diag.publish_rate_hz")
+
+    def replace(self, **namespace_overrides: Any) -> MountingParams:
+        """Return a modified copy of the parameters."""
+        return replace(self, **namespace_overrides)
+
+    def as_nested_dict(self) -> dict[str, Any]:
+        """Return a nested dict representation for debugging."""
+        return _dataclass_to_dict(self)
+
+
+def _dataclass_to_dict(value: Any) -> Any:
+    """Convert dataclasses and numpy arrays into plain Python values."""
+    if hasattr(value, "__dataclass_fields__"):
+        return {
+            field.name: _dataclass_to_dict(getattr(value, field.name))
+            for field in fields(value)
+        }
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    return value

--- a/oasis_control/oasis_control/localization/mounting/math_utils/linalg.py
+++ b/oasis_control/oasis_control/localization/mounting/math_utils/linalg.py
@@ -7,3 +7,135 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+"""Linear algebra utilities for rotations and matrices."""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .units import PhysicalConstants
+from .units import assert_finite
+
+
+class SO3:
+    """SO(3) rotation utilities."""
+
+    @staticmethod
+    def hat(w: NDArray[np.float64]) -> NDArray[np.float64]:
+        """Return the skew-symmetric matrix for a rotation vector."""
+        vec: NDArray[np.float64] = np.asarray(w, dtype=float)
+        Linalg.ensure_shape(vec, (3,), "w")
+        assert_finite(vec, "w")
+        wx: float = float(vec[0])
+        wy: float = float(vec[1])
+        wz: float = float(vec[2])
+        return np.array(
+            [
+                [0.0, -wz, wy],
+                [wz, 0.0, -wx],
+                [-wy, wx, 0.0],
+            ],
+            dtype=float,
+        )
+
+    @staticmethod
+    def vee(W: NDArray[np.float64]) -> NDArray[np.float64]:
+        """Return the rotation vector from a skew-symmetric matrix."""
+        mat: NDArray[np.float64] = np.asarray(W, dtype=float)
+        Linalg.ensure_shape(mat, (3, 3), "W")
+        assert_finite(mat, "W")
+        return np.array([mat[2, 1], mat[0, 2], mat[1, 0]], dtype=float)
+
+    @staticmethod
+    def exp(w: NDArray[np.float64]) -> NDArray[np.float64]:
+        """Exponentiate a rotation vector to a rotation matrix."""
+        vec: NDArray[np.float64] = np.asarray(w, dtype=float)
+        Linalg.ensure_shape(vec, (3,), "w")
+        assert_finite(vec, "w")
+        theta: float = float(np.linalg.norm(vec))
+        W: NDArray[np.float64] = SO3.hat(vec)
+        eye: NDArray[np.float64] = np.eye(3, dtype=float)
+        if theta < 1e-8:
+            return eye + W + 0.5 * (W @ W)
+        sin_theta: float = float(np.sin(theta))
+        cos_theta: float = float(np.cos(theta))
+        A: float = sin_theta / theta
+        B: float = (1.0 - cos_theta) / (theta * theta)
+        return eye + A * W + B * (W @ W)
+
+    @staticmethod
+    def log(R: NDArray[np.float64]) -> NDArray[np.float64]:
+        """Compute the rotation vector from a rotation matrix."""
+        mat: NDArray[np.float64] = np.asarray(R, dtype=float)
+        Linalg.ensure_shape(mat, (3, 3), "R")
+        assert_finite(mat, "R")
+        cos_theta: float = float((np.trace(mat) - 1.0) * 0.5)
+        cos_theta = float(np.clip(cos_theta, -1.0, 1.0))
+        theta: float = float(np.arccos(cos_theta))
+        if theta < 1e-8:
+            return 0.5 * SO3.vee(mat - mat.T)
+        sin_theta: float = float(np.sin(theta))
+        if abs(sin_theta) < PhysicalConstants.EPS:
+            return 0.5 * SO3.vee(mat - mat.T)
+        scale: float = theta / (2.0 * sin_theta)
+        return scale * SO3.vee(mat - mat.T)
+
+    @staticmethod
+    def project_to_so3(R: NDArray[np.float64]) -> NDArray[np.float64]:
+        """Project a matrix to the nearest SO(3) rotation matrix."""
+        mat: NDArray[np.float64] = np.asarray(R, dtype=float)
+        Linalg.ensure_shape(mat, (3, 3), "R")
+        assert_finite(mat, "R")
+        U: NDArray[np.float64]
+        S: NDArray[np.float64]
+        Vt: NDArray[np.float64]
+        U, S, Vt = np.linalg.svd(mat)
+        R_proj: NDArray[np.float64] = U @ Vt
+        if np.linalg.det(R_proj) < 0.0:
+            U[:, -1] *= -1.0
+            R_proj = U @ Vt
+        return R_proj
+
+    @staticmethod
+    def angle(R: NDArray[np.float64]) -> float:
+        """Return the rotation angle of a rotation matrix."""
+        mat: NDArray[np.float64] = np.asarray(R, dtype=float)
+        Linalg.ensure_shape(mat, (3, 3), "R")
+        assert_finite(mat, "R")
+        cos_theta: float = float((np.trace(mat) - 1.0) * 0.5)
+        cos_theta = float(np.clip(cos_theta, -1.0, 1.0))
+        return float(np.arccos(cos_theta))
+
+
+class Linalg:
+    """General linear algebra helpers."""
+
+    @staticmethod
+    def block_diag(*blocks: NDArray[np.float64]) -> NDArray[np.float64]:
+        """Create a block diagonal matrix from the given blocks."""
+        if not blocks:
+            return np.zeros((0, 0), dtype=float)
+        shapes: list[tuple[int, int]] = []
+        for block in blocks:
+            mat: NDArray[np.float64] = np.asarray(block, dtype=float)
+            if mat.ndim != 2:
+                raise ValueError("blocks must be 2D arrays")
+            shapes.append((mat.shape[0], mat.shape[1]))
+        total_rows: int = sum(shape[0] for shape in shapes)
+        total_cols: int = sum(shape[1] for shape in shapes)
+        result: NDArray[np.float64] = np.zeros((total_rows, total_cols), dtype=float)
+        row: int = 0
+        col: int = 0
+        for block, (rows, cols) in zip(blocks, shapes):
+            mat_block: NDArray[np.float64] = np.asarray(block, dtype=float)
+            result[row : row + rows, col : col + cols] = mat_block
+            row += rows
+            col += cols
+        return result
+
+    @staticmethod
+    def ensure_shape(x: NDArray[np.float64], shape: tuple[int, ...], name: str) -> None:
+        """Ensure an array has the expected shape."""
+        if x.shape != shape:
+            raise ValueError(f"{name} must have shape {shape}")

--- a/oasis_control/oasis_control/localization/mounting/math_utils/linalg.py
+++ b/oasis_control/oasis_control/localization/mounting/math_utils/linalg.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/oasis_control/localization/mounting/math_utils/quat.py
+++ b/oasis_control/oasis_control/localization/mounting/math_utils/quat.py
@@ -7,3 +7,163 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+"""Quaternion utilities using the wxyz convention."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .linalg import SO3
+from .units import PhysicalConstants
+from .units import assert_finite
+
+
+@dataclass(frozen=True)
+class Quaternion:
+    """Quaternion stored in wxyz order."""
+
+    wxyz: NDArray[np.float64]
+
+    def __post_init__(self) -> None:
+        """Validate quaternion inputs and normalize storage."""
+        wxyz: NDArray[np.float64] = np.asarray(self.wxyz, dtype=float)
+        if wxyz.shape != (4,):
+            raise ValueError("wxyz must be shape (4,)")
+        assert_finite(wxyz, "wxyz")
+        object.__setattr__(self, "wxyz", wxyz)
+
+    @staticmethod
+    def identity() -> "Quaternion":
+        """Return the identity quaternion."""
+        return Quaternion.from_wxyz(1.0, 0.0, 0.0, 0.0)
+
+    @staticmethod
+    def from_wxyz(w: float, x: float, y: float, z: float) -> "Quaternion":
+        """Create a quaternion from components."""
+        return Quaternion(np.array([w, x, y, z], dtype=float))
+
+    @staticmethod
+    def from_rotvec(w: NDArray[np.float64]) -> "Quaternion":
+        """Create a quaternion from a rotation vector."""
+        R: NDArray[np.float64] = SO3.exp(w)
+        return Quaternion.from_matrix(R)
+
+    @staticmethod
+    def from_matrix(R: NDArray[np.float64]) -> "Quaternion":
+        """Create a quaternion from a rotation matrix."""
+        mat: NDArray[np.float64] = np.asarray(R, dtype=float)
+        if mat.shape != (3, 3):
+            raise ValueError("R must be shape (3, 3)")
+        assert_finite(mat, "R")
+        trace: float = float(np.trace(mat))
+        if trace > 0.0:
+            s: float = float(np.sqrt(trace + 1.0) * 2.0)
+            w: float = 0.25 * s
+            x: float = float((mat[2, 1] - mat[1, 2]) / s)
+            y: float = float((mat[0, 2] - mat[2, 0]) / s)
+            z: float = float((mat[1, 0] - mat[0, 1]) / s)
+        else:
+            diag: NDArray[np.float64] = np.diag(mat)
+            idx: int = int(np.argmax(diag))
+            if idx == 0:
+                s = float(np.sqrt(1.0 + mat[0, 0] - mat[1, 1] - mat[2, 2]) * 2.0)
+                w = float((mat[2, 1] - mat[1, 2]) / s)
+                x = 0.25 * s
+                y = float((mat[0, 1] + mat[1, 0]) / s)
+                z = float((mat[0, 2] + mat[2, 0]) / s)
+            elif idx == 1:
+                s = float(np.sqrt(1.0 + mat[1, 1] - mat[0, 0] - mat[2, 2]) * 2.0)
+                w = float((mat[0, 2] - mat[2, 0]) / s)
+                x = float((mat[0, 1] + mat[1, 0]) / s)
+                y = 0.25 * s
+                z = float((mat[1, 2] + mat[2, 1]) / s)
+            else:
+                s = float(np.sqrt(1.0 + mat[2, 2] - mat[0, 0] - mat[1, 1]) * 2.0)
+                w = float((mat[1, 0] - mat[0, 1]) / s)
+                x = float((mat[0, 2] + mat[2, 0]) / s)
+                y = float((mat[1, 2] + mat[2, 1]) / s)
+                z = 0.25 * s
+        return Quaternion.from_wxyz(w, x, y, z).normalized()
+
+    def as_matrix(self) -> NDArray[np.float64]:
+        """Return the rotation matrix representation."""
+        q: NDArray[np.float64] = self.normalized().wxyz
+        w: float = float(q[0])
+        x: float = float(q[1])
+        y: float = float(q[2])
+        z: float = float(q[3])
+        return np.array(
+            [
+                [
+                    1.0 - 2.0 * (y * y + z * z),
+                    2.0 * (x * y - z * w),
+                    2.0 * (x * z + y * w),
+                ],
+                [
+                    2.0 * (x * y + z * w),
+                    1.0 - 2.0 * (x * x + z * z),
+                    2.0 * (y * z - x * w),
+                ],
+                [
+                    2.0 * (x * z - y * w),
+                    2.0 * (y * z + x * w),
+                    1.0 - 2.0 * (x * x + y * y),
+                ],
+            ],
+            dtype=float,
+        )
+
+    def normalized(self) -> "Quaternion":
+        """Return a normalized quaternion."""
+        norm: float = float(np.linalg.norm(self.wxyz))
+        if norm < PhysicalConstants.EPS:
+            raise ValueError("Quaternion norm is too small")
+        return Quaternion(self.wxyz / norm)
+
+    def inverse(self) -> "Quaternion":
+        """Return the inverse quaternion."""
+        q: NDArray[np.float64] = self.normalized().wxyz
+        return Quaternion.from_wxyz(
+            float(q[0]), float(-q[1]), float(-q[2]), float(-q[3])
+        )
+
+    def __mul__(self, other: "Quaternion") -> "Quaternion":
+        """Multiply two quaternions using the Hamilton product."""
+        q1: NDArray[np.float64] = self.wxyz
+        q2: NDArray[np.float64] = other.wxyz
+        w1: float = float(q1[0])
+        x1: float = float(q1[1])
+        y1: float = float(q1[2])
+        z1: float = float(q1[3])
+        w2: float = float(q2[0])
+        x2: float = float(q2[1])
+        y2: float = float(q2[2])
+        z2: float = float(q2[3])
+        w: float = w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2
+        x: float = w1 * x2 + x1 * w2 + y1 * z2 - z1 * y2
+        y: float = w1 * y2 - x1 * z2 + y1 * w2 + z1 * x2
+        z: float = w1 * z2 + x1 * y2 - y1 * x2 + z1 * w2
+        return Quaternion.from_wxyz(w, x, y, z)
+
+    def rotate(self, v: NDArray[np.float64]) -> NDArray[np.float64]:
+        """Rotate a 3-vector by this quaternion."""
+        vec: NDArray[np.float64] = np.asarray(v, dtype=float)
+        if vec.shape != (3,):
+            raise ValueError("v must be shape (3,)")
+        assert_finite(vec, "v")
+        return self.as_matrix() @ vec
+
+    def to_wxyz(self) -> NDArray[np.float64]:
+        """Return a copy of the quaternion components."""
+        return np.array(self.wxyz, dtype=float)
+
+    def almost_equal(self, other: "Quaternion", atol: float = 1e-9) -> bool:
+        """Check approximate equality, accounting for sign ambiguity."""
+        q1: NDArray[np.float64] = self.wxyz
+        q2: NDArray[np.float64] = other.wxyz
+        if np.allclose(q1, q2, atol=atol):
+            return True
+        return bool(np.allclose(q1, -q2, atol=atol))

--- a/oasis_control/oasis_control/localization/mounting/math_utils/quat.py
+++ b/oasis_control/oasis_control/localization/mounting/math_utils/quat.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/oasis_control/localization/mounting/math_utils/se3.py
+++ b/oasis_control/oasis_control/localization/mounting/math_utils/se3.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/oasis_control/localization/mounting/math_utils/se3.py
+++ b/oasis_control/oasis_control/localization/mounting/math_utils/se3.py
@@ -7,3 +7,85 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+"""SE(3) rigid-body transforms."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .linalg import SO3
+from .linalg import Linalg
+from .quat import Quaternion
+from .units import assert_finite
+
+
+@dataclass(frozen=True)
+class SE3:
+    """Rigid-body transform with rotation and translation."""
+
+    R: NDArray[np.float64]
+    p: NDArray[np.float64]
+
+    def __post_init__(self) -> None:
+        """Validate and project rotation and translation inputs."""
+        R_mat: NDArray[np.float64] = np.asarray(self.R, dtype=float)
+        p_vec: NDArray[np.float64] = np.asarray(self.p, dtype=float)
+        Linalg.ensure_shape(R_mat, (3, 3), "R")
+        Linalg.ensure_shape(p_vec, (3,), "p")
+        assert_finite(R_mat, "R")
+        assert_finite(p_vec, "p")
+        R_proj: NDArray[np.float64] = SO3.project_to_so3(R_mat)
+        object.__setattr__(self, "R", R_proj)
+        object.__setattr__(self, "p", p_vec)
+
+    @staticmethod
+    def identity() -> "SE3":
+        """Return the identity transform."""
+        return SE3(np.eye(3, dtype=float), np.zeros(3, dtype=float))
+
+    @staticmethod
+    def from_quat_translation(q: Quaternion, p: NDArray[np.float64]) -> "SE3":
+        """Create a transform from a quaternion and translation."""
+        vec: NDArray[np.float64] = np.asarray(p, dtype=float)
+        if vec.shape != (3,):
+            raise ValueError("p must be shape (3,)")
+        assert_finite(vec, "p")
+        return SE3(q.as_matrix(), vec)
+
+    def as_matrix4(self) -> NDArray[np.float64]:
+        """Return the homogeneous 4x4 transform matrix."""
+        mat: NDArray[np.float64] = np.eye(4, dtype=float)
+        mat[:3, :3] = self.R
+        mat[:3, 3] = self.p
+        return mat
+
+    def inverse(self) -> "SE3":
+        """Return the inverse transform."""
+        R_inv: NDArray[np.float64] = self.R.T
+        p_inv: NDArray[np.float64] = -(R_inv @ self.p)
+        return SE3(R_inv, p_inv)
+
+    def __mul__(self, other: "SE3") -> "SE3":
+        """Compose two transforms."""
+        R_new: NDArray[np.float64] = self.R @ other.R
+        p_new: NDArray[np.float64] = self.R @ other.p + self.p
+        return SE3(R_new, p_new)
+
+    def transform_point(self, x: NDArray[np.float64]) -> NDArray[np.float64]:
+        """Transform a point by rotation and translation."""
+        vec: NDArray[np.float64] = np.asarray(x, dtype=float)
+        if vec.shape != (3,):
+            raise ValueError("x must be shape (3,)")
+        assert_finite(vec, "x")
+        return self.R @ vec + self.p
+
+    def transform_vector(self, v: NDArray[np.float64]) -> NDArray[np.float64]:
+        """Transform a vector by rotation only."""
+        vec: NDArray[np.float64] = np.asarray(v, dtype=float)
+        if vec.shape != (3,):
+            raise ValueError("v must be shape (3,)")
+        assert_finite(vec, "v")
+        return self.R @ vec

--- a/oasis_control/oasis_control/localization/mounting/math_utils/small_linalg3.py
+++ b/oasis_control/oasis_control/localization/mounting/math_utils/small_linalg3.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/oasis_control/localization/mounting/math_utils/small_linalg3.py
+++ b/oasis_control/oasis_control/localization/mounting/math_utils/small_linalg3.py
@@ -7,3 +7,98 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+"""Small 3D linear algebra helpers."""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .units import PhysicalConstants
+from .units import assert_finite
+
+
+class Vec3:
+    """Vector utilities for 3D vectors."""
+
+    @staticmethod
+    def normalize(
+        v: NDArray[np.float64],
+        eps: float = PhysicalConstants.EPS,
+    ) -> NDArray[np.float64]:
+        """Normalize a 3-vector."""
+        vec: NDArray[np.float64] = np.asarray(v, dtype=float)
+        if vec.shape != (3,):
+            raise ValueError("v must be shape (3,)")
+        assert_finite(vec, "v")
+        norm: float = float(np.linalg.norm(vec))
+        if norm < eps:
+            raise ValueError("v has near-zero norm")
+        return vec / norm
+
+    @staticmethod
+    def angle_between(
+        u: NDArray[np.float64],
+        v: NDArray[np.float64],
+        eps: float = PhysicalConstants.EPS,
+    ) -> float:
+        """Return the angle between two 3-vectors in radians."""
+        u_vec: NDArray[np.float64] = np.asarray(u, dtype=float)
+        v_vec: NDArray[np.float64] = np.asarray(v, dtype=float)
+        if u_vec.shape != (3,) or v_vec.shape != (3,):
+            raise ValueError("u and v must be shape (3,)")
+        assert_finite(u_vec, "u")
+        assert_finite(v_vec, "v")
+        u_norm: float = float(np.linalg.norm(u_vec))
+        v_norm: float = float(np.linalg.norm(v_vec))
+        if u_norm < eps or v_norm < eps:
+            raise ValueError("u and v must be non-zero")
+        cos_angle: float = float(np.dot(u_vec, v_vec) / (u_norm * v_norm))
+        cos_angle = float(np.clip(cos_angle, -1.0, 1.0))
+        return float(np.arccos(cos_angle))
+
+
+class Mat3:
+    """Matrix utilities for 3x3 matrices."""
+
+    @staticmethod
+    def is_spd(A: NDArray[np.float64], tol: float = 1e-12) -> bool:
+        """Check whether a matrix is symmetric positive definite."""
+        mat: NDArray[np.float64] = np.asarray(A, dtype=float)
+        if mat.shape != (3, 3):
+            return False
+        if not np.allclose(mat, mat.T, atol=tol):
+            return False
+        eigvals: NDArray[np.float64] = np.asarray(np.linalg.eigvalsh(mat), dtype=float)
+        return bool(np.all(eigvals > tol))
+
+    @staticmethod
+    def sym(A: NDArray[np.float64]) -> NDArray[np.float64]:
+        """Return the symmetric part of a 3x3 matrix."""
+        mat: NDArray[np.float64] = np.asarray(A, dtype=float)
+        if mat.shape != (3, 3):
+            raise ValueError("A must be shape (3, 3)")
+        return 0.5 * (mat + mat.T)
+
+    @staticmethod
+    def clamp_spd(
+        A: NDArray[np.float64],
+        eig_min: float,
+        eig_max: float,
+    ) -> NDArray[np.float64]:
+        """Clamp eigenvalues of a symmetric matrix and return SPD matrix."""
+        mat: NDArray[np.float64] = np.asarray(A, dtype=float)
+        if mat.shape != (3, 3):
+            raise ValueError("A must be shape (3, 3)")
+        assert_finite(mat, "A")
+        if eig_min > eig_max:
+            raise ValueError("eig_min must be <= eig_max")
+
+        sym_mat: NDArray[np.float64] = Mat3.sym(mat)
+        eigvals: NDArray[np.float64]
+        eigvecs: NDArray[np.float64]
+        eigvals, eigvecs = np.linalg.eigh(sym_mat)
+        clamped: NDArray[np.float64] = np.clip(eigvals, eig_min, eig_max)
+        diag: NDArray[np.float64] = np.diag(clamped)
+        result: NDArray[np.float64] = eigvecs @ diag @ eigvecs.T
+        return Mat3.sym(result)

--- a/oasis_control/oasis_control/localization/mounting/math_utils/stats.py
+++ b/oasis_control/oasis_control/localization/mounting/math_utils/stats.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/oasis_control/localization/mounting/math_utils/stats.py
+++ b/oasis_control/oasis_control/localization/mounting/math_utils/stats.py
@@ -7,3 +7,112 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+"""Running statistics for 3D vectors."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from dataclasses import field
+from typing import Deque
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .units import assert_finite
+
+
+@dataclass
+class RunningMoments3:
+    """Online mean and covariance for 3D vectors."""
+
+    _count: int = 0
+    _mean: NDArray[np.float64] = field(default_factory=lambda: np.zeros(3, dtype=float))
+    _m2: NDArray[np.float64] = field(
+        default_factory=lambda: np.zeros((3, 3), dtype=float)
+    )
+
+    def update(self, x: NDArray[np.float64]) -> None:
+        """Update moments with a new sample."""
+        vec: NDArray[np.float64] = np.asarray(x, dtype=float)
+        if vec.shape != (3,):
+            raise ValueError("x must be shape (3,)")
+        assert_finite(vec, "x")
+        self._count += 1
+        delta: NDArray[np.float64] = vec - self._mean
+        self._mean = self._mean + delta / float(self._count)
+        delta2: NDArray[np.float64] = vec - self._mean
+        self._m2 = self._m2 + np.outer(delta, delta2)
+
+    def count(self) -> int:
+        """Return the number of samples processed."""
+        return self._count
+
+    def mean(self) -> NDArray[np.float64]:
+        """Return the current mean."""
+        if self._count == 0:
+            raise ValueError("No samples available")
+        return np.array(self._mean, dtype=float)
+
+    def covariance(self, ddof: int = 0) -> NDArray[np.float64]:
+        """Return the covariance matrix."""
+        if ddof < 0:
+            raise ValueError("ddof must be non-negative")
+        if self._count == 0:
+            raise ValueError("No samples available")
+        if self._count <= ddof:
+            raise ValueError("ddof is too large for the sample count")
+        scale: float = 1.0 / float(self._count - ddof)
+        return self._m2 * scale
+
+    def reset(self) -> None:
+        """Reset the running statistics."""
+        self._count = 0
+        self._mean = np.zeros(3, dtype=float)
+        self._m2 = np.zeros((3, 3), dtype=float)
+
+
+class SlidingWindowMoments3:
+    """Sliding-window mean and covariance for 3D vectors."""
+
+    def __init__(self, window_size: int) -> None:
+        """Create a sliding window estimator."""
+        if window_size <= 0:
+            raise ValueError("window_size must be positive")
+        self._window_size: int = window_size
+        self._window: Deque[NDArray[np.float64]] = deque(maxlen=window_size)
+
+    def push(self, x: NDArray[np.float64]) -> None:
+        """Add a new sample to the window."""
+        vec: NDArray[np.float64] = np.asarray(x, dtype=float)
+        if vec.shape != (3,):
+            raise ValueError("x must be shape (3,)")
+        assert_finite(vec, "x")
+        self._window.append(vec)
+
+    def full(self) -> bool:
+        """Return True when the window is full."""
+        return len(self._window) == self._window_size
+
+    def mean(self) -> NDArray[np.float64]:
+        """Return the window mean."""
+        if not self._window:
+            raise ValueError("No samples available")
+        data: NDArray[np.float64] = np.stack(list(self._window), axis=0)
+        return np.mean(data, axis=0)
+
+    def covariance(self, ddof: int = 0) -> NDArray[np.float64]:
+        """Return the window covariance matrix."""
+        if ddof < 0:
+            raise ValueError("ddof must be non-negative")
+        if not self._window:
+            raise ValueError("No samples available")
+        data: NDArray[np.float64] = np.stack(list(self._window), axis=0)
+        count: int = data.shape[0]
+        if count <= ddof:
+            raise ValueError("ddof is too large for the sample count")
+        mean: NDArray[np.float64] = np.mean(data, axis=0)
+        centered: NDArray[np.float64] = data - mean
+        scale: float = 1.0 / float(count - ddof)
+        cov: NDArray[np.float64] = (centered.T @ centered) * scale
+        return 0.5 * (cov + cov.T)

--- a/oasis_control/oasis_control/localization/mounting/math_utils/units.py
+++ b/oasis_control/oasis_control/localization/mounting/math_utils/units.py
@@ -7,3 +7,44 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+"""Unit conversion helpers and physical constants."""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+class Angle:
+    """Angular unit conversions."""
+
+    @staticmethod
+    def deg2rad(x: float | NDArray[np.float64]) -> float | NDArray[np.float64]:
+        """Convert degrees to radians."""
+        arr: NDArray[np.float64] = np.asarray(x, dtype=float)
+        result: NDArray[np.float64] = np.deg2rad(arr)
+        if np.ndim(result) == 0:
+            return float(result)
+        return result
+
+    @staticmethod
+    def rad2deg(x: float | NDArray[np.float64]) -> float | NDArray[np.float64]:
+        """Convert radians to degrees."""
+        arr: NDArray[np.float64] = np.asarray(x, dtype=float)
+        result: NDArray[np.float64] = np.rad2deg(arr)
+        if np.ndim(result) == 0:
+            return float(result)
+        return result
+
+
+class PhysicalConstants:
+    """Physical constants used by math utilities."""
+
+    GRAVITY_MPS2: float = 9.80665
+    EPS: float = 1e-12
+
+
+def assert_finite(x: NDArray[np.float64], name: str) -> None:
+    """Raise ValueError when the array contains non-finite values."""
+    if not np.all(np.isfinite(x)):
+        raise ValueError(f"{name} must be finite")

--- a/oasis_control/oasis_control/localization/mounting/math_utils/units.py
+++ b/oasis_control/oasis_control/localization/mounting/math_utils/units.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/oasis_control/localization/mounting/models/anchor_model.py
+++ b/oasis_control/oasis_control/localization/mounting/models/anchor_model.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/oasis_control/localization/mounting/models/anchor_model.py
+++ b/oasis_control/oasis_control/localization/mounting/models/anchor_model.py
@@ -7,3 +7,79 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+"""Reference anchoring model for mounting calibration."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+class AnchorModelError(Exception):
+    """Raised when anchor model usage is invalid."""
+
+
+def _unit_vector(vector: np.ndarray, name: str) -> np.ndarray:
+    """Return a unit vector after validation."""
+    vec: np.ndarray = np.asarray(vector, dtype=np.float64)
+    if vec.shape != (3,):
+        raise AnchorModelError(f"{name} must have shape (3,)")
+    if not np.all(np.isfinite(vec)):
+        raise AnchorModelError(f"{name} must be finite")
+    norm: float = float(np.linalg.norm(vec))
+    if not np.isfinite(norm) or norm <= 0.0:
+        raise AnchorModelError(f"{name} must be non-zero to normalize")
+    return vec / norm
+
+
+class AnchorModel:
+    """Capture and access reference gravity/mag directions."""
+
+    def __init__(self) -> None:
+        """Initialize the anchor model with no captured reference."""
+        self.captured: bool = False
+        self.g_ref_W: np.ndarray | None = None
+        self.m_ref_W: np.ndarray | None = None
+        self.mag_reference_invalid: bool = False
+
+    def reset(self) -> None:
+        """Reset the anchor model state."""
+        self.captured = False
+        self.g_ref_W = None
+        self.m_ref_W = None
+        self.mag_reference_invalid = False
+
+    def capture(self, *, g_ref_W: np.ndarray, m_ref_W: np.ndarray | None) -> None:
+        """Capture reference gravity and magnetometer directions."""
+        if self.captured:
+            raise AnchorModelError("anchor already captured; reset required")
+        self.g_ref_W = _unit_vector(g_ref_W, "g_ref_W")
+        if m_ref_W is None:
+            self.m_ref_W = None
+            self.mag_reference_invalid = True
+        else:
+            self.m_ref_W = _unit_vector(m_ref_W, "m_ref_W")
+            self.mag_reference_invalid = False
+        self.captured = True
+
+    def has_mag_reference(self) -> bool:
+        """Return True when a valid magnetometer reference exists."""
+        return (
+            self.captured
+            and self.m_ref_W is not None
+            and not self.mag_reference_invalid
+        )
+
+    def gravity_ref_W(self) -> np.ndarray:
+        """Return the captured gravity reference direction."""
+        if not self.captured or self.g_ref_W is None:
+            raise AnchorModelError("gravity reference not captured")
+        return np.array(self.g_ref_W, dtype=np.float64)
+
+    def mag_ref_W(self) -> np.ndarray:
+        """Return the captured magnetometer reference direction."""
+        if not self.captured:
+            raise AnchorModelError("mag reference not captured")
+        if self.m_ref_W is None or self.mag_reference_invalid:
+            raise AnchorModelError("mag reference is not available")
+        return np.array(self.m_ref_W, dtype=np.float64)

--- a/oasis_control/oasis_control/localization/mounting/models/diversity_metrics.py
+++ b/oasis_control/oasis_control/localization/mounting/models/diversity_metrics.py
@@ -7,3 +7,66 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+"""Diversity metrics for mounting calibration keyframes."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from oasis_control.localization.mounting.mounting_types import Keyframe
+
+
+class DiversityMetricsError(Exception):
+    """Raised when diversity metric inputs are invalid."""
+
+
+def _angle_deg(u: np.ndarray, v: np.ndarray) -> float:
+    """Return the angle between two unit vectors in degrees."""
+    u_vec: np.ndarray = np.asarray(u, dtype=np.float64)
+    v_vec: np.ndarray = np.asarray(v, dtype=np.float64)
+    if u_vec.shape != (3,) or v_vec.shape != (3,):
+        raise DiversityMetricsError("vectors must have shape (3,)")
+    if not np.all(np.isfinite(u_vec)) or not np.all(np.isfinite(v_vec)):
+        raise DiversityMetricsError("vectors must be finite")
+    dot: float = float(np.dot(u_vec, v_vec))
+    dot = float(np.clip(dot, -1.0, 1.0))
+    return float(np.degrees(np.arccos(dot)))
+
+
+def _max_pairwise_angle(vectors: list[np.ndarray]) -> float:
+    """Return the maximum pairwise angle between vectors."""
+    max_angle: float = 0.0
+    for i, vec_i in enumerate(vectors):
+        for vec_j in vectors[i + 1 :]:
+            angle: float = _angle_deg(vec_i, vec_j)
+            max_angle = max(max_angle, angle)
+    return max_angle
+
+
+def gravity_max_angle_deg(
+    keyframes: list[Keyframe] | tuple[Keyframe, ...],
+) -> float | None:
+    """Return the max gravity-direction separation in degrees."""
+    gravity_dirs: list[np.ndarray] = [
+        keyframe.gravity_unit_mean_dir_I()
+        for keyframe in keyframes
+        if keyframe.gravity_weight > 0
+    ]
+    if len(gravity_dirs) < 2:
+        return None
+    return _max_pairwise_angle(gravity_dirs)
+
+
+def mag_proj_max_angle_deg(
+    keyframes: list[Keyframe] | tuple[Keyframe, ...],
+) -> float | None:
+    """Return the max mag-direction separation in degrees."""
+    mag_dirs: list[np.ndarray] = [
+        keyframe.mag_unit_mean_dir_M()
+        for keyframe in keyframes
+        if keyframe.mag_weight > 0
+    ]
+    if len(mag_dirs) < 2:
+        return None
+    return _max_pairwise_angle(mag_dirs)

--- a/oasis_control/oasis_control/localization/mounting/models/diversity_metrics.py
+++ b/oasis_control/oasis_control/localization/mounting/models/diversity_metrics.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/oasis_control/localization/mounting/models/imu_calibration_model.py
+++ b/oasis_control/oasis_control/localization/mounting/models/imu_calibration_model.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/oasis_control/localization/mounting/models/imu_calibration_model.py
+++ b/oasis_control/oasis_control/localization/mounting/models/imu_calibration_model.py
@@ -7,3 +7,87 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+"""IMU calibration model helpers for mounting calibration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from oasis_control.localization.mounting.mounting_types import ImuCalibrationPrior
+
+
+class ImuCalibrationModelError(Exception):
+    """Raised when IMU calibration model validation fails."""
+
+
+def _as_float_array(value: Any, name: str, shape: tuple[int, ...]) -> np.ndarray:
+    """Return a float64 numpy array with a required shape."""
+    array: np.ndarray = np.asarray(value, dtype=np.float64)
+    if array.shape != shape:
+        raise ImuCalibrationModelError(f"{name} must have shape {shape}")
+    if not np.all(np.isfinite(array)):
+        raise ImuCalibrationModelError(f"{name} must contain finite values")
+    return array
+
+
+@dataclass(frozen=True)
+class ImuNuisanceState:
+    """Nuisance calibration state for IMU measurements.
+
+    Attributes:
+        b_a_mps2: Accelerometer bias in m/s^2
+        A_a: Accelerometer scale/misalignment matrix
+        b_g_rads: Gyroscope bias in rad/s
+    """
+
+    b_a_mps2: np.ndarray
+    A_a: np.ndarray
+    b_g_rads: np.ndarray
+
+    def __post_init__(self) -> None:
+        """Validate nuisance state fields."""
+        b_a_mps2: np.ndarray = _as_float_array(self.b_a_mps2, "b_a_mps2", (3,))
+        A_a: np.ndarray = _as_float_array(self.A_a, "A_a", (3, 3))
+        b_g_rads: np.ndarray = _as_float_array(self.b_g_rads, "b_g_rads", (3,))
+
+        object.__setattr__(self, "b_a_mps2", b_a_mps2)
+        object.__setattr__(self, "A_a", A_a)
+        object.__setattr__(self, "b_g_rads", b_g_rads)
+
+    def correct_accel(self, a_raw_mps2: np.ndarray) -> np.ndarray:
+        """Return calibrated accelerometer data using the nuisance state."""
+        a_raw: np.ndarray = _as_float_array(a_raw_mps2, "a_raw_mps2", (3,))
+        return self.A_a @ (a_raw - self.b_a_mps2)
+
+    def correct_gyro(self, omega_raw_rads: np.ndarray) -> np.ndarray:
+        """Return calibrated gyro data using the nuisance state."""
+        omega_raw: np.ndarray = _as_float_array(omega_raw_rads, "omega_raw_rads", (3,))
+        return omega_raw - self.b_g_rads
+
+
+class ImuCalibrationModel:
+    """Factory helpers for IMU nuisance state initialization."""
+
+    @staticmethod
+    def default_state() -> ImuNuisanceState:
+        """Return the default nuisance state with zero biases."""
+        return ImuNuisanceState(
+            b_a_mps2=np.zeros(3, dtype=np.float64),
+            A_a=np.eye(3, dtype=np.float64),
+            b_g_rads=np.zeros(3, dtype=np.float64),
+        )
+
+    @staticmethod
+    def state_from_prior(prior: ImuCalibrationPrior) -> ImuNuisanceState:
+        """Create a nuisance state from a one-shot calibration prior."""
+        if not prior.valid:
+            return ImuCalibrationModel.default_state()
+        return ImuNuisanceState(
+            b_a_mps2=prior.b_a_mps2,
+            A_a=prior.A_a,
+            b_g_rads=prior.b_g_rads,
+        )

--- a/oasis_control/oasis_control/localization/mounting/models/keyframe_clustering.py
+++ b/oasis_control/oasis_control/localization/mounting/models/keyframe_clustering.py
@@ -7,3 +7,197 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+"""Keyframe clustering for mounting calibration."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from oasis_control.localization.mounting.config.mounting_params import MountingParams
+from oasis_control.localization.mounting.mounting_types import Keyframe
+from oasis_control.localization.mounting.mounting_types import SteadySegment
+
+
+class KeyframeClusteringError(Exception):
+    """Raised when keyframe clustering encounters invalid data."""
+
+
+def _as_float_array(value: np.ndarray, name: str, shape: tuple[int, ...]) -> np.ndarray:
+    """Coerce an array to float64 with a required shape."""
+    array: np.ndarray = np.asarray(value, dtype=np.float64)
+    if array.shape != shape:
+        raise KeyframeClusteringError(f"{name} must have shape {shape}")
+    if not np.all(np.isfinite(array)):
+        raise KeyframeClusteringError(f"{name} must contain finite values")
+    return array
+
+
+def _unit_vector(vector: np.ndarray, name: str) -> np.ndarray:
+    """Return a unit vector after validating the input."""
+    vec: np.ndarray = _as_float_array(vector, name, (3,))
+    norm: float = float(np.linalg.norm(vec))
+    if not np.isfinite(norm) or norm <= 0.0:
+        raise KeyframeClusteringError(f"{name} must be non-zero to normalize")
+    return vec / norm
+
+
+def _angle_deg(u: np.ndarray, v: np.ndarray) -> float:
+    """Return the angle between two vectors in degrees."""
+    u_unit: np.ndarray = _unit_vector(u, "u")
+    v_unit: np.ndarray = _unit_vector(v, "v")
+    dot: float = float(np.dot(u_unit, v_unit))
+    dot = float(np.clip(dot, -1.0, 1.0))
+    return float(np.degrees(np.arccos(dot)))
+
+
+def _trace(matrix: np.ndarray) -> float:
+    """Return the trace of a matrix after validation."""
+    mat: np.ndarray = _as_float_array(matrix, "matrix", (3, 3))
+    return float(np.trace(mat))
+
+
+class KeyframeClustering:
+    """Online clustering of steady segments into keyframes."""
+
+    def __init__(self, params: MountingParams) -> None:
+        """Create a keyframe clustering helper from parameters."""
+        self._params: MountingParams = params
+        self._keyframes: dict[int, Keyframe] = {}
+        self._next_id: int = 0
+
+    def reset(self) -> None:
+        """Reset keyframe state."""
+        self._keyframes = {}
+        self._next_id = 0
+
+    def keyframes(self) -> tuple[Keyframe, ...]:
+        """Return a deterministic snapshot of keyframes."""
+        return tuple(self._keyframes[key] for key in sorted(self._keyframes))
+
+    def add_segment(self, segment: SteadySegment) -> tuple[int, Keyframe]:
+        """Assign a steady segment to a keyframe and return the assignment."""
+        if not isinstance(segment, SteadySegment):
+            raise KeyframeClusteringError("segment must be a SteadySegment")
+        gravity_dir_I: np.ndarray = segment.gravity_up_dir_I()
+        mag_dir_M: np.ndarray | None
+        if segment.m_mean_T is None:
+            mag_dir_M = None
+        else:
+            mag_dir_M = _unit_vector(segment.m_mean_T, "segment.m_mean_T")
+
+        assigned_id: int | None = None
+        best_angle: float = float("inf")
+        for keyframe_id, keyframe in self._keyframes.items():
+            gravity_angle: float = _angle_deg(
+                gravity_dir_I,
+                keyframe.gravity_unit_mean_dir_I(),
+            )
+            if gravity_angle >= float(self._params.cluster.cluster_g_deg):
+                continue
+            if mag_dir_M is not None and keyframe.mag_weight > 0:
+                mag_angle: float = _angle_deg(
+                    mag_dir_M,
+                    keyframe.mag_unit_mean_dir_M(),
+                )
+                if mag_angle >= float(self._params.cluster.cluster_h_deg):
+                    continue
+            if assigned_id is None or gravity_angle < best_angle:
+                best_angle = gravity_angle
+                assigned_id = keyframe_id
+                continue
+            if gravity_angle == best_angle and keyframe_id < assigned_id:
+                best_angle = gravity_angle
+                assigned_id = keyframe_id
+
+        if assigned_id is not None:
+            candidate: Keyframe = self._keyframes[assigned_id]
+            updated: Keyframe = candidate.update_with_segment(segment)
+            self._keyframes[assigned_id] = updated
+            return assigned_id, updated
+
+        new_keyframe: Keyframe = Keyframe(
+            keyframe_id=self._next_id,
+            gravity_mean_dir_I=gravity_dir_I,
+            gravity_cov_dir_I=np.zeros((3, 3), dtype=np.float64),
+            gravity_weight=1,
+            mag_mean_dir_M=mag_dir_M,
+            mag_cov_dir_M=(
+                np.zeros((3, 3), dtype=np.float64) if mag_dir_M is not None else None
+            ),
+            mag_weight=1 if mag_dir_M is not None else 0,
+            segment_count=1,
+        )
+        self._keyframes[self._next_id] = new_keyframe
+        assigned_id = self._next_id
+        self._next_id += 1
+
+        self._enforce_kmax()
+        return assigned_id, self._keyframes[assigned_id]
+
+    def _enforce_kmax(self) -> None:
+        """Apply keyframe budget policies when exceeding K_max."""
+        k_max: int = int(self._params.cluster.K_max)
+        if k_max == 0:
+            return
+        while len(self._keyframes) > k_max:
+            drop_id: int = self._choose_drop_id()
+            self._keyframes.pop(drop_id, None)
+
+    def _choose_drop_id(self) -> int:
+        """Select a keyframe to drop based on policy."""
+        drop_policy: str = self._params.cluster.drop_policy
+        if drop_policy == "oldest":
+            return min(self._keyframes)
+        if drop_policy == "lowest_information":
+            return self._drop_lowest_information()
+        if drop_policy == "redundant":
+            return self._drop_redundant()
+        raise KeyframeClusteringError(f"Unknown drop_policy: {drop_policy}")
+
+    def _drop_lowest_information(self) -> int:
+        """Return the keyframe id with the lowest information content."""
+        candidates: list[tuple[int, int, float]] = []
+        for keyframe_id, keyframe in self._keyframes.items():
+            candidates.append(
+                (
+                    keyframe_id,
+                    keyframe.segment_count,
+                    _trace(keyframe.gravity_cov_dir_I),
+                )
+            )
+        candidates_sorted: list[tuple[int, int, float]] = sorted(
+            candidates,
+            key=lambda item: (item[1], -item[2], item[0]),
+        )
+        return candidates_sorted[0][0]
+
+    def _drop_redundant(self) -> int:
+        """Return the keyframe id that is most redundant in gravity space."""
+        keyframes: list[Keyframe] = list(self._keyframes.values())
+        if len(keyframes) < 2:
+            raise KeyframeClusteringError(
+                "redundant policy requires at least 2 keyframes"
+            )
+        min_angles: dict[int, float] = {}
+        for keyframe in keyframes:
+            min_angles[keyframe.keyframe_id] = float("inf")
+        for i, keyframe_i in enumerate(keyframes):
+            for keyframe_j in keyframes[i + 1 :]:
+                angle: float = _angle_deg(
+                    keyframe_i.gravity_unit_mean_dir_I(),
+                    keyframe_j.gravity_unit_mean_dir_I(),
+                )
+                min_angles[keyframe_i.keyframe_id] = min(
+                    min_angles[keyframe_i.keyframe_id],
+                    angle,
+                )
+                min_angles[keyframe_j.keyframe_id] = min(
+                    min_angles[keyframe_j.keyframe_id],
+                    angle,
+                )
+        min_items: list[tuple[int, float]] = sorted(
+            min_angles.items(),
+            key=lambda item: (item[1], item[0]),
+        )
+        return min_items[0][0]

--- a/oasis_control/oasis_control/localization/mounting/models/keyframe_clustering.py
+++ b/oasis_control/oasis_control/localization/mounting/models/keyframe_clustering.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/oasis_control/localization/mounting/models/mag_direction_model.py
+++ b/oasis_control/oasis_control/localization/mounting/models/mag_direction_model.py
@@ -7,3 +7,67 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+"""Direction-only magnetometer modeling utilities."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+class MagDirectionModelError(Exception):
+    """Raised when magnetometer direction modeling fails."""
+
+
+def normalize(m_raw_T: np.ndarray) -> np.ndarray:
+    """Return a unit magnetic-field direction vector."""
+    m_vec: np.ndarray = np.asarray(m_raw_T, dtype=np.float64)
+    if m_vec.shape != (3,):
+        raise MagDirectionModelError("m_raw_T must have shape (3,)")
+    if not np.all(np.isfinite(m_vec)):
+        raise MagDirectionModelError("m_raw_T must be finite")
+    magnitude: float = float(np.linalg.norm(m_vec))
+    if not np.isfinite(magnitude) or magnitude <= 0.0:
+        raise MagDirectionModelError("m_raw_T must be non-zero to normalize")
+    return m_vec / magnitude
+
+
+def direction_covariance_from_raw(
+    *,
+    m_raw_T: np.ndarray,
+    cov_m_raw_T2: np.ndarray,
+    s_min_T: float,
+) -> np.ndarray:
+    """Convert raw mag covariance to direction covariance."""
+    m_vec: np.ndarray = np.asarray(m_raw_T, dtype=np.float64)
+    cov_raw: np.ndarray = np.asarray(cov_m_raw_T2, dtype=np.float64)
+    if m_vec.shape != (3,):
+        raise MagDirectionModelError("m_raw_T must have shape (3,)")
+    if cov_raw.shape != (3, 3):
+        raise MagDirectionModelError("cov_m_raw_T2 must have shape (3, 3)")
+    if not np.all(np.isfinite(m_vec)):
+        raise MagDirectionModelError("m_raw_T must be finite")
+    if not np.all(np.isfinite(cov_raw)):
+        raise MagDirectionModelError("cov_m_raw_T2 must be finite")
+    if not np.isfinite(s_min_T) or s_min_T <= 0.0:
+        raise MagDirectionModelError("s_min_T must be positive")
+
+    u: np.ndarray = normalize(m_vec)
+    s: float = float(np.linalg.norm(m_vec))
+    if s <= s_min_T:
+        raise MagDirectionModelError("m_raw_T magnitude is below s_min_T")
+    eye: np.ndarray = np.eye(3, dtype=np.float64)
+    J: np.ndarray = (eye - np.outer(u, u)) / s
+    Sigma_dir: np.ndarray = J @ cov_raw @ J.T
+    return 0.5 * (Sigma_dir + Sigma_dir.T)
+
+
+def direction_residual_cross(u_meas: np.ndarray, u_pred: np.ndarray) -> np.ndarray:
+    """Return the direction residual defined by a cross product."""
+    u_meas_vec: np.ndarray = np.asarray(u_meas, dtype=np.float64)
+    u_pred_vec: np.ndarray = np.asarray(u_pred, dtype=np.float64)
+    if u_meas_vec.shape != (3,) or u_pred_vec.shape != (3,):
+        raise MagDirectionModelError("u_meas and u_pred must have shape (3,)")
+    if not np.all(np.isfinite(u_meas_vec)) or not np.all(np.isfinite(u_pred_vec)):
+        raise MagDirectionModelError("u_meas and u_pred must be finite")
+    return np.cross(u_meas_vec, u_pred_vec)

--- a/oasis_control/oasis_control/localization/mounting/models/mag_direction_model.py
+++ b/oasis_control/oasis_control/localization/mounting/models/mag_direction_model.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/oasis_control/localization/mounting/models/noise_adaptation.py
+++ b/oasis_control/oasis_control/localization/mounting/models/noise_adaptation.py
@@ -7,3 +7,78 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+"""Adaptive noise modeling for magnetometer direction residuals."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+class NoiseAdaptationError(Exception):
+    """Raised when noise adaptation inputs are invalid."""
+
+
+def _as_float_array(value: np.ndarray, name: str, shape: tuple[int, ...]) -> np.ndarray:
+    """Return a float64 numpy array with a required shape."""
+    array: np.ndarray = np.asarray(value, dtype=np.float64)
+    if array.shape != shape:
+        raise NoiseAdaptationError(f"{name} must have shape {shape}")
+    if not np.all(np.isfinite(array)):
+        raise NoiseAdaptationError(f"{name} must contain finite values")
+    return array
+
+
+def _sorted_diagonal_bounds(matrix: np.ndarray) -> np.ndarray:
+    """Return sorted diagonal bounds from a matrix."""
+    diag: np.ndarray = np.diag(matrix).astype(np.float64)
+    if diag.shape != (3,):
+        raise NoiseAdaptationError("matrix diagonal must be length 3")
+    if not np.all(np.isfinite(diag)):
+        raise NoiseAdaptationError("matrix diagonal must be finite")
+    return np.sort(diag)
+
+
+class DirectionNoiseAdapter:
+    """Adaptive covariance-matching update for direction residual noise."""
+
+    def __init__(
+        self,
+        *,
+        R_init: np.ndarray,
+        R_min: np.ndarray,
+        R_max: np.ndarray,
+        alpha: float,
+    ) -> None:
+        """Initialize the direction-noise adapter."""
+        self._R: np.ndarray = _as_float_array(R_init, "R_init", (3, 3))
+        self._R_min: np.ndarray = _as_float_array(R_min, "R_min", (3, 3))
+        self._R_max: np.ndarray = _as_float_array(R_max, "R_max", (3, 3))
+        if not np.isfinite(alpha) or alpha <= 0.0 or alpha > 1.0:
+            raise NoiseAdaptationError("alpha must be in (0, 1]")
+        self._alpha: float = float(alpha)
+        self._lam_min: np.ndarray = _sorted_diagonal_bounds(self._R_min)
+        self._lam_max: np.ndarray = _sorted_diagonal_bounds(self._R_max)
+
+    def R(self) -> np.ndarray:
+        """Return the current noise covariance."""
+        return np.array(self._R, dtype=np.float64)
+
+    def update(self, *, r: np.ndarray, S_hat: np.ndarray) -> np.ndarray:
+        """Update the noise covariance using covariance matching."""
+        residual: np.ndarray = _as_float_array(r, "r", (3,))
+        S_hat_mat: np.ndarray = _as_float_array(S_hat, "S_hat", (3, 3))
+
+        outer: np.ndarray = np.outer(residual, residual)
+        R_new: np.ndarray = (1.0 - self._alpha) * self._R + self._alpha * (
+            outer - S_hat_mat
+        )
+        R_new = 0.5 * (R_new + R_new.T)
+
+        eigvals: np.ndarray
+        eigvecs: np.ndarray
+        eigvals, eigvecs = np.linalg.eigh(R_new)
+        clamped: np.ndarray = np.clip(eigvals, self._lam_min, self._lam_max)
+        R_clamped: np.ndarray = eigvecs @ np.diag(clamped) @ eigvecs.T
+        self._R = 0.5 * (R_clamped + R_clamped.T)
+        return np.array(self._R, dtype=np.float64)

--- a/oasis_control/oasis_control/localization/mounting/models/noise_adaptation.py
+++ b/oasis_control/oasis_control/localization/mounting/models/noise_adaptation.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/oasis_control/localization/mounting/models/steady_detector.py
+++ b/oasis_control/oasis_control/localization/mounting/models/steady_detector.py
@@ -7,3 +7,259 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+"""Windowed steady-state detector for mounting calibration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+import numpy as np
+
+from oasis_control.localization.mounting.config.mounting_params import MountingParams
+from oasis_control.localization.mounting.mounting_types import MagPacket
+from oasis_control.localization.mounting.mounting_types import SteadySegment
+
+
+class SteadyDetectorError(Exception):
+    """Raised when the steady detector encounters invalid data."""
+
+
+def _as_float_array(value: np.ndarray, name: str, shape: tuple[int, ...]) -> np.ndarray:
+    """Coerce an array to float64 with a required shape."""
+    array: np.ndarray = np.asarray(value, dtype=np.float64)
+    if array.shape != shape:
+        raise SteadyDetectorError(f"{name} must have shape {shape}")
+    if not np.all(np.isfinite(array)):
+        raise SteadyDetectorError(f"{name} must contain finite values")
+    return array
+
+
+def _covariance(samples: Iterable[np.ndarray]) -> np.ndarray:
+    """Return the covariance of a sequence of 3D samples."""
+    data_list: list[np.ndarray] = [
+        np.asarray(sample, dtype=np.float64) for sample in samples
+    ]
+    if not data_list:
+        raise SteadyDetectorError("covariance requires at least one sample")
+    data: np.ndarray = np.stack(data_list, axis=0)
+    mean: np.ndarray = np.mean(data, axis=0)
+    centered: np.ndarray = data - mean
+    cov: np.ndarray = (centered.T @ centered) / float(data.shape[0])
+    return 0.5 * (cov + cov.T)
+
+
+@dataclass(frozen=True)
+class _ImuSample:
+    """Internal representation of an IMU sample."""
+
+    t_ns: int
+    omega_corr_rads: np.ndarray
+    a_corr_mps2: np.ndarray
+
+
+@dataclass(frozen=True)
+class _MagSample:
+    """Internal representation of a mag sample."""
+
+    t_ns: int
+    frame_id: str
+    m_T: np.ndarray
+
+
+class SteadyDetector:
+    """Detect steady intervals using a time-based window."""
+
+    def __init__(self, params: MountingParams) -> None:
+        """Create a steady detector from mounting parameters."""
+        self._params: MountingParams = params
+        self._steady_ns: int = int(round(params.steady.steady_sec * 1e9))
+        if self._steady_ns <= 0:
+            raise SteadyDetectorError("steady_sec must be positive")
+        if params.steady.window_type != "sliding":
+            raise SteadyDetectorError("Only sliding window_type is supported")
+        self._imu_samples: list[_ImuSample] = []
+        self._mag_samples: list[_MagSample] = []
+        self._last_t_ns: int | None = None
+        self._last_mag_t_ns: int | None = None
+        self._was_steady: bool = False
+        self._steady_enter_ns: int | None = None
+        self._has_emitted: bool = False
+
+    def reset(self) -> None:
+        """Reset internal buffers and emission state."""
+        self._imu_samples = []
+        self._mag_samples = []
+        self._last_t_ns = None
+        self._last_mag_t_ns = None
+        self._was_steady = False
+        self._steady_enter_ns = None
+        self._has_emitted = False
+
+    def push(
+        self,
+        *,
+        t_ns: int,
+        omega_corr_rads: np.ndarray,
+        a_corr_mps2: np.ndarray,
+        imu_frame_id: str,
+        mag: MagPacket | None = None,
+    ) -> SteadySegment | None:
+        """Push a corrected IMU sample and return a steady segment if emitted."""
+        if not isinstance(t_ns, int) or isinstance(t_ns, bool):
+            raise SteadyDetectorError("t_ns must be an int")
+        if self._last_t_ns is not None and t_ns <= self._last_t_ns:
+            raise SteadyDetectorError("t_ns must be strictly increasing")
+        if not isinstance(imu_frame_id, str):
+            raise SteadyDetectorError("imu_frame_id must be a str")
+
+        omega_corr: np.ndarray = _as_float_array(
+            omega_corr_rads, "omega_corr_rads", (3,)
+        )
+        a_corr: np.ndarray = _as_float_array(a_corr_mps2, "a_corr_mps2", (3,))
+
+        self._last_t_ns = t_ns
+        self._imu_samples.append(
+            _ImuSample(t_ns=t_ns, omega_corr_rads=omega_corr, a_corr_mps2=a_corr)
+        )
+
+        if mag is not None:
+            if self._last_mag_t_ns is not None and mag.t_meas_ns <= self._last_mag_t_ns:
+                raise SteadyDetectorError("mag.t_meas_ns must be strictly increasing")
+            if not isinstance(mag.frame_id, str):
+                raise SteadyDetectorError("mag.frame_id must be a str")
+            m_T: np.ndarray = _as_float_array(mag.m_raw_T, "mag.m_raw_T", (3,))
+            self._mag_samples.append(
+                _MagSample(t_ns=mag.t_meas_ns, frame_id=mag.frame_id, m_T=m_T)
+            )
+            self._last_mag_t_ns = mag.t_meas_ns
+
+        self._trim_buffers(t_ns)
+
+        is_steady: bool = self._window_is_steady()
+        if not is_steady:
+            self._was_steady = False
+            self._steady_enter_ns = None
+            self._has_emitted = False
+            return None
+
+        if not self._was_steady:
+            self._was_steady = True
+            self._steady_enter_ns = t_ns
+            self._has_emitted = False
+        elif self._steady_enter_ns is None:
+            self._steady_enter_ns = t_ns
+
+        if self._has_emitted:
+            return None
+
+        if t_ns - self._steady_enter_ns < self._steady_ns:
+            return None
+
+        segment: SteadySegment = self._build_segment(imu_frame_id)
+        self._has_emitted = True
+        return segment
+
+    def _trim_buffers(self, t_ns: int) -> None:
+        """Trim samples outside the current steady window."""
+        window_start: int = t_ns - self._steady_ns
+        self._imu_samples = [
+            sample for sample in self._imu_samples if sample.t_ns >= window_start
+        ]
+        self._mag_samples = [
+            sample for sample in self._mag_samples if sample.t_ns >= window_start
+        ]
+
+    def _window_is_steady(self) -> bool:
+        """Return True when the current window satisfies steady criteria."""
+        if not self._imu_samples:
+            return False
+        window_span_ns: int = self._imu_samples[-1].t_ns - self._imu_samples[0].t_ns
+        if window_span_ns < self._steady_ns:
+            return False
+        omega_samples: list[np.ndarray] = [
+            sample.omega_corr_rads for sample in self._imu_samples
+        ]
+        a_samples: list[np.ndarray] = [
+            sample.a_corr_mps2 for sample in self._imu_samples
+        ]
+
+        omega_mean: np.ndarray = np.mean(np.stack(omega_samples, axis=0), axis=0)
+        a_mean: np.ndarray = np.mean(np.stack(a_samples, axis=0), axis=0)
+        omega_cov: np.ndarray = _covariance(omega_samples)
+        a_cov: np.ndarray = _covariance(a_samples)
+
+        omega_mean_norm: float = float(np.linalg.norm(omega_mean))
+        a_mean_norm: float = float(np.linalg.norm(a_mean))
+
+        omega_mean_thresh: float | None = self._params.steady.omega_mean_thresh
+        if omega_mean_thresh is not None and omega_mean_norm >= omega_mean_thresh:
+            return False
+
+        omega_cov_thresh: float | None = self._params.steady.omega_cov_thresh
+        if (
+            omega_cov_thresh is not None
+            and float(np.trace(omega_cov)) >= omega_cov_thresh
+        ):
+            return False
+
+        a_cov_thresh: float | None = self._params.steady.a_cov_thresh
+        if a_cov_thresh is not None and float(np.trace(a_cov)) >= a_cov_thresh:
+            return False
+
+        a_norm_min: float | None = self._params.steady.a_norm_min
+        if a_norm_min is not None and a_mean_norm <= a_norm_min:
+            return False
+
+        a_norm_max: float | None = self._params.steady.a_norm_max
+        if a_norm_max is not None and a_mean_norm >= a_norm_max:
+            return False
+
+        return True
+
+    def _build_segment(self, imu_frame_id: str) -> SteadySegment:
+        """Build a SteadySegment from the current window."""
+        samples: list[_ImuSample] = list(self._imu_samples)
+        if not samples:
+            raise SteadyDetectorError("no samples available for segment")
+        t_start_ns: int = samples[0].t_ns
+        t_end_ns: int = samples[-1].t_ns
+        t_meas_ns: int = (t_start_ns + t_end_ns) // 2
+        a_samples: list[np.ndarray] = [sample.a_corr_mps2 for sample in samples]
+        a_mean: np.ndarray = np.mean(np.stack(a_samples, axis=0), axis=0)
+        cov_a: np.ndarray = _covariance(a_samples)
+
+        mag_samples: list[_MagSample] = [
+            sample
+            for sample in self._mag_samples
+            if t_start_ns <= sample.t_ns <= t_end_ns
+        ]
+        mag_frame_id: str | None
+        m_mean: np.ndarray | None
+        cov_m: np.ndarray | None
+        if mag_samples:
+            mag_frame_id = mag_samples[0].frame_id
+            if any(sample.frame_id != mag_frame_id for sample in mag_samples):
+                raise SteadyDetectorError("mag_frame_id must be consistent")
+            m_samples: list[np.ndarray] = [sample.m_T for sample in mag_samples]
+            m_mean = np.mean(np.stack(m_samples, axis=0), axis=0)
+            cov_m = _covariance(m_samples)
+        else:
+            mag_frame_id = None
+            m_mean = None
+            cov_m = None
+
+        return SteadySegment(
+            t_start_ns=t_start_ns,
+            t_end_ns=t_end_ns,
+            t_meas_ns=t_meas_ns,
+            imu_frame_id=imu_frame_id,
+            mag_frame_id=mag_frame_id,
+            a_mean_mps2=a_mean,
+            cov_a=cov_a,
+            m_mean_T=m_mean,
+            cov_m=cov_m,
+            sample_count=len(samples),
+            duration_ns=t_end_ns - t_start_ns,
+        )

--- a/oasis_control/oasis_control/localization/mounting/models/steady_detector.py
+++ b/oasis_control/oasis_control/localization/mounting/models/steady_detector.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/oasis_control/localization/mounting/mounting_types/__init__.py
+++ b/oasis_control/oasis_control/localization/mounting/mounting_types/__init__.py
@@ -1,0 +1,44 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""Type definitions for AHRS mounting calibration."""
+
+from __future__ import annotations
+
+from oasis_control.localization.mounting.math_utils.se3 import SE3
+from oasis_control.localization.mounting.mounting_types.diagnostics import Diagnostics
+from oasis_control.localization.mounting.mounting_types.imu_packet import (
+    ImuCalibrationPrior,
+)
+from oasis_control.localization.mounting.mounting_types.imu_packet import ImuPacket
+from oasis_control.localization.mounting.mounting_types.keyframe import Keyframe
+from oasis_control.localization.mounting.mounting_types.mag_packet import MagPacket
+from oasis_control.localization.mounting.mounting_types.result_snapshot import (
+    ResultSnapshot,
+)
+from oasis_control.localization.mounting.mounting_types.steady_segment import (
+    SteadySegment,
+)
+from oasis_control.localization.mounting.mounting_types.update_report import (
+    UpdateReport,
+)
+
+
+__all__ = [
+    "Diagnostics",
+    "ImuCalibrationPrior",
+    "ImuPacket",
+    "Keyframe",
+    "MagPacket",
+    "ResultSnapshot",
+    "SE3",
+    "SteadySegment",
+    "UpdateReport",
+]

--- a/oasis_control/oasis_control/localization/mounting/mounting_types/diagnostics.py
+++ b/oasis_control/oasis_control/localization/mounting/mounting_types/diagnostics.py
@@ -7,3 +7,121 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+"""Diagnostics types for mounting calibration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from oasis_control.localization.mounting.mounting_types.update_report import (
+    UpdateReport,
+)
+
+
+@dataclass(frozen=True)
+class Diagnostics:
+    """Structured diagnostics bundle for mounting calibration.
+
+    Attributes:
+        t_meas_ns: Timestamp associated with the diagnostics in nanoseconds
+        pipeline_state: Human-readable pipeline state
+        update_report: Optional update report details
+        segment_count: Number of segments processed
+        keyframe_count: Number of keyframes tracked
+        diversity_tilt_deg: Tilt diversity in degrees when available
+        diversity_yaw_deg: Yaw diversity in degrees when available
+        warnings: Warning messages
+        errors: Error messages
+        info: Informational messages
+        dropped_packets: Count of dropped input packets
+    """
+
+    t_meas_ns: int
+    pipeline_state: str
+    update_report: UpdateReport | None
+    segment_count: int
+    keyframe_count: int
+    diversity_tilt_deg: float | None
+    diversity_yaw_deg: float | None
+    warnings: tuple[str, ...] = ()
+    errors: tuple[str, ...] = ()
+    info: tuple[str, ...] = ()
+    dropped_packets: int = 0
+
+    def __post_init__(self) -> None:
+        """Validate diagnostic fields."""
+        if not isinstance(self.t_meas_ns, int) or isinstance(self.t_meas_ns, bool):
+            raise ValueError("t_meas_ns must be an int")
+        if not isinstance(self.pipeline_state, str):
+            raise ValueError("pipeline_state must be a str")
+        if not isinstance(self.segment_count, int) or isinstance(
+            self.segment_count, bool
+        ):
+            raise ValueError("segment_count must be an int")
+        if self.segment_count < 0:
+            raise ValueError("segment_count must be non-negative")
+        if not isinstance(self.keyframe_count, int) or isinstance(
+            self.keyframe_count, bool
+        ):
+            raise ValueError("keyframe_count must be an int")
+        if self.keyframe_count < 0:
+            raise ValueError("keyframe_count must be non-negative")
+        if not isinstance(self.dropped_packets, int) or isinstance(
+            self.dropped_packets, bool
+        ):
+            raise ValueError("dropped_packets must be an int")
+        if self.dropped_packets < 0:
+            raise ValueError("dropped_packets must be non-negative")
+
+        if self.diversity_tilt_deg is not None:
+            _require_finite(self.diversity_tilt_deg, "diversity_tilt_deg")
+        if self.diversity_yaw_deg is not None:
+            _require_finite(self.diversity_yaw_deg, "diversity_yaw_deg")
+
+        warnings: tuple[str, ...] = _as_str_tuple(self.warnings, "warnings")
+        errors: tuple[str, ...] = _as_str_tuple(self.errors, "errors")
+        info: tuple[str, ...] = _as_str_tuple(self.info, "info")
+
+        object.__setattr__(self, "warnings", warnings)
+        object.__setattr__(self, "errors", errors)
+        object.__setattr__(self, "info", info)
+
+    def has_errors(self) -> bool:
+        """Return True when any error messages are present."""
+        return len(self.errors) > 0
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a dictionary representation of the diagnostics."""
+        data: dict[str, object] = {
+            "t_meas_ns": self.t_meas_ns,
+            "pipeline_state": self.pipeline_state,
+            "segment_count": self.segment_count,
+            "keyframe_count": self.keyframe_count,
+            "diversity_tilt_deg": self.diversity_tilt_deg,
+            "diversity_yaw_deg": self.diversity_yaw_deg,
+            "warnings": self.warnings,
+            "errors": self.errors,
+            "info": self.info,
+            "dropped_packets": self.dropped_packets,
+        }
+        if self.update_report is not None:
+            data["update_report"] = self.update_report.to_dict()
+        return data
+
+
+def _require_finite(value: float, name: str) -> None:
+    """Ensure a scalar value is finite."""
+    if not np.isfinite(value):
+        raise ValueError(f"{name} must be finite")
+
+
+def _as_str_tuple(values: tuple[str, ...] | list[str], name: str) -> tuple[str, ...]:
+    """Normalize a sequence of strings into an immutable tuple."""
+    items: tuple[str, ...] = tuple(values)
+    for item in items:
+        if not isinstance(item, str):
+            raise ValueError(f"{name} entries must be strings")
+    return items

--- a/oasis_control/oasis_control/localization/mounting/mounting_types/diagnostics.py
+++ b/oasis_control/oasis_control/localization/mounting/mounting_types/diagnostics.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/oasis_control/localization/mounting/mounting_types/imu_packet.py
+++ b/oasis_control/oasis_control/localization/mounting/mounting_types/imu_packet.py
@@ -7,3 +7,124 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+"""IMU packet types for mounting calibration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class ImuCalibrationPrior:
+    """One-shot calibration prior for IMU nuisance parameters.
+
+    Attributes:
+        valid: Indicates whether the prior should be used
+        frame_id: Frame name associated with the prior
+        b_a_mps2: Accelerometer bias prior in m/s^2
+        A_a: Accelerometer scale/misalignment matrix
+        b_g_rads: Gyroscope bias prior in rad/s
+        cov_a_params: Covariance of [b_a, vec(A_a)] in (m/s^2)^2
+        cov_b_g: Covariance of gyroscope bias in (rad/s)^2
+    """
+
+    valid: bool
+    frame_id: str
+    b_a_mps2: np.ndarray
+    A_a: np.ndarray
+    b_g_rads: np.ndarray
+    cov_a_params: np.ndarray | None
+    cov_b_g: np.ndarray | None
+
+    def __post_init__(self) -> None:
+        """Validate calibration prior fields."""
+        if not isinstance(self.valid, bool):
+            raise ValueError("valid must be a bool")
+        if not isinstance(self.frame_id, str):
+            raise ValueError("frame_id must be a str")
+
+        b_a_mps2: np.ndarray = _as_float_array(self.b_a_mps2, "b_a_mps2", (3,))
+        A_a: np.ndarray = _as_float_array(self.A_a, "A_a", (3, 3))
+        b_g_rads: np.ndarray = _as_float_array(self.b_g_rads, "b_g_rads", (3,))
+
+        object.__setattr__(self, "b_a_mps2", b_a_mps2)
+        object.__setattr__(self, "A_a", A_a)
+        object.__setattr__(self, "b_g_rads", b_g_rads)
+
+        if self.cov_a_params is None:
+            cov_a_params: np.ndarray | None = None
+        else:
+            cov_a_params = _as_float_array(
+                self.cov_a_params,
+                "cov_a_params",
+                (12, 12),
+            )
+        if self.cov_b_g is None:
+            cov_b_g: np.ndarray | None = None
+        else:
+            cov_b_g = _as_float_array(self.cov_b_g, "cov_b_g", (3, 3))
+
+        object.__setattr__(self, "cov_a_params", cov_a_params)
+        object.__setattr__(self, "cov_b_g", cov_b_g)
+
+
+@dataclass(frozen=True)
+class ImuPacket:
+    """Raw IMU packet with optional calibration prior."""
+
+    t_meas_ns: int
+    frame_id: str
+    omega_raw_rads: np.ndarray
+    cov_omega_raw: np.ndarray
+    a_raw_mps2: np.ndarray
+    cov_a_raw: np.ndarray
+    calibration: ImuCalibrationPrior | None = None
+
+    def __post_init__(self) -> None:
+        """Validate packet fields and coerce arrays."""
+        if not isinstance(self.t_meas_ns, int) or isinstance(self.t_meas_ns, bool):
+            raise ValueError("t_meas_ns must be an int")
+        if not isinstance(self.frame_id, str):
+            raise ValueError("frame_id must be a str")
+        if self.calibration is not None and self.calibration.frame_id != self.frame_id:
+            raise ValueError("calibration frame_id must match frame_id")
+
+        omega_raw_rads: np.ndarray = _as_float_array(
+            self.omega_raw_rads,
+            "omega_raw_rads",
+            (3,),
+        )
+        cov_omega_raw: np.ndarray = _as_float_array(
+            self.cov_omega_raw,
+            "cov_omega_raw",
+            (3, 3),
+        )
+        a_raw_mps2: np.ndarray = _as_float_array(self.a_raw_mps2, "a_raw_mps2", (3,))
+        cov_a_raw: np.ndarray = _as_float_array(
+            self.cov_a_raw,
+            "cov_a_raw",
+            (3, 3),
+        )
+
+        object.__setattr__(self, "omega_raw_rads", omega_raw_rads)
+        object.__setattr__(self, "cov_omega_raw", cov_omega_raw)
+        object.__setattr__(self, "a_raw_mps2", a_raw_mps2)
+        object.__setattr__(self, "cov_a_raw", cov_a_raw)
+
+    def has_calibration(self) -> bool:
+        """Return True when a calibration prior is available."""
+        return self.calibration is not None
+
+
+def _as_float_array(value: Any, name: str, shape: tuple[int, ...]) -> np.ndarray:
+    """Coerce a value to a float64 numpy array with a specific shape."""
+    array: np.ndarray = np.asarray(value, dtype=np.float64)
+    if array.shape != shape:
+        raise ValueError(f"{name} must have shape {shape}")
+    if not np.all(np.isfinite(array)):
+        raise ValueError(f"{name} must contain finite values")
+    return array

--- a/oasis_control/oasis_control/localization/mounting/mounting_types/imu_packet.py
+++ b/oasis_control/oasis_control/localization/mounting/mounting_types/imu_packet.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/oasis_control/localization/mounting/mounting_types/keyframe.py
+++ b/oasis_control/oasis_control/localization/mounting/mounting_types/keyframe.py
@@ -7,3 +7,217 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+"""Keyframe aggregation types for mounting calibration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import replace
+from typing import Any
+
+import numpy as np
+
+from oasis_control.localization.mounting.mounting_types.steady_segment import (
+    SteadySegment,
+)
+
+
+@dataclass(frozen=True)
+class Keyframe:
+    """Running aggregate of steady segments.
+
+    Attributes:
+        keyframe_id: Unique keyframe identifier
+        gravity_mean_dir_I: Mean of unit gravity directions in the IMU frame
+        gravity_cov_dir_I: Covariance of gravity directions in the IMU frame
+        gravity_weight: Number of segments contributing to gravity statistics
+        mag_mean_dir_M: Mean of unit magnetic directions in the mag frame
+        mag_cov_dir_M: Covariance of magnetic directions in the mag frame
+        mag_weight: Number of segments contributing to mag statistics
+        segment_count: Total number of segments assigned to the keyframe
+    """
+
+    keyframe_id: int
+    gravity_mean_dir_I: np.ndarray
+    gravity_cov_dir_I: np.ndarray
+    gravity_weight: int
+    mag_mean_dir_M: np.ndarray | None
+    mag_cov_dir_M: np.ndarray | None
+    mag_weight: int
+    segment_count: int
+
+    def __post_init__(self) -> None:
+        """Validate keyframe fields and coerce arrays."""
+        if not isinstance(self.keyframe_id, int) or isinstance(self.keyframe_id, bool):
+            raise ValueError("keyframe_id must be an int")
+        if not isinstance(self.gravity_weight, int) or isinstance(
+            self.gravity_weight, bool
+        ):
+            raise ValueError("gravity_weight must be an int")
+        if self.gravity_weight < 0:
+            raise ValueError("gravity_weight must be non-negative")
+        if not isinstance(self.mag_weight, int) or isinstance(self.mag_weight, bool):
+            raise ValueError("mag_weight must be an int")
+        if self.mag_weight < 0:
+            raise ValueError("mag_weight must be non-negative")
+        if not isinstance(self.segment_count, int) or isinstance(
+            self.segment_count, bool
+        ):
+            raise ValueError("segment_count must be an int")
+        if self.segment_count < 0:
+            raise ValueError("segment_count must be non-negative")
+
+        gravity_mean_dir_I: np.ndarray = _as_float_array(
+            self.gravity_mean_dir_I,
+            "gravity_mean_dir_I",
+            (3,),
+        )
+        gravity_cov_dir_I: np.ndarray = _as_float_array(
+            self.gravity_cov_dir_I,
+            "gravity_cov_dir_I",
+            (3, 3),
+        )
+        if self.gravity_weight > 0:
+            _require_non_zero(gravity_mean_dir_I, "gravity_mean_dir_I")
+
+        object.__setattr__(self, "gravity_mean_dir_I", gravity_mean_dir_I)
+        object.__setattr__(self, "gravity_cov_dir_I", gravity_cov_dir_I)
+
+        if self.mag_mean_dir_M is None:
+            if self.mag_cov_dir_M is not None or self.mag_weight != 0:
+                raise ValueError("mag stats must be empty when mag_mean_dir_M is None")
+            object.__setattr__(self, "mag_cov_dir_M", None)
+        else:
+            mag_mean_dir_M: np.ndarray = _as_float_array(
+                self.mag_mean_dir_M,
+                "mag_mean_dir_M",
+                (3,),
+            )
+            mag_cov_dir_M: np.ndarray = _as_float_array(
+                self.mag_cov_dir_M,
+                "mag_cov_dir_M",
+                (3, 3),
+            )
+            if self.mag_weight > 0:
+                _require_non_zero(mag_mean_dir_M, "mag_mean_dir_M")
+            object.__setattr__(self, "mag_mean_dir_M", mag_mean_dir_M)
+            object.__setattr__(self, "mag_cov_dir_M", mag_cov_dir_M)
+
+    def update_with_segment(self, segment: SteadySegment) -> Keyframe:
+        """Return a new keyframe updated with a steady segment."""
+        gravity_dir_I: np.ndarray = segment.gravity_up_dir_I()
+        mag_dir_M: np.ndarray | None
+        if segment.m_mean_T is None:
+            mag_dir_M = None
+        else:
+            mag_dir_M = _unit_vector(segment.m_mean_T, "m_mean_T")
+        return self.update_with_directions(gravity_dir_I, mag_dir_M)
+
+    def update_with_directions(
+        self,
+        gravity_dir_I: np.ndarray,
+        mag_dir_M: np.ndarray | None = None,
+    ) -> Keyframe:
+        """Return a new keyframe updated with direction observations.
+
+        The input directions are normalized before they are aggregated.
+        """
+        gravity_dir_I_unit: np.ndarray = _unit_vector(gravity_dir_I, "gravity_dir_I")
+        gravity_mean_dir_I: np.ndarray
+        gravity_cov_dir_I: np.ndarray
+        gravity_weight: int
+        (
+            gravity_mean_dir_I,
+            gravity_cov_dir_I,
+            gravity_weight,
+        ) = _update_dir_stats(
+            self.gravity_mean_dir_I,
+            self.gravity_cov_dir_I,
+            self.gravity_weight,
+            gravity_dir_I_unit,
+        )
+
+        mag_mean_dir_M: np.ndarray | None = self.mag_mean_dir_M
+        mag_cov_dir_M: np.ndarray | None = self.mag_cov_dir_M
+        mag_weight: int = self.mag_weight
+        if mag_dir_M is not None:
+            mag_dir_M_unit: np.ndarray = _unit_vector(mag_dir_M, "mag_dir_M")
+            if mag_mean_dir_M is None or mag_cov_dir_M is None or mag_weight == 0:
+                mag_mean_dir_M = mag_dir_M_unit
+                mag_cov_dir_M = np.zeros((3, 3), dtype=np.float64)
+                mag_weight = 1
+            else:
+                mag_mean_dir_M, mag_cov_dir_M, mag_weight = _update_dir_stats(
+                    mag_mean_dir_M,
+                    mag_cov_dir_M,
+                    mag_weight,
+                    mag_dir_M_unit,
+                )
+
+        return replace(
+            self,
+            gravity_mean_dir_I=gravity_mean_dir_I,
+            gravity_cov_dir_I=gravity_cov_dir_I,
+            gravity_weight=gravity_weight,
+            mag_mean_dir_M=mag_mean_dir_M,
+            mag_cov_dir_M=mag_cov_dir_M,
+            mag_weight=mag_weight,
+            segment_count=self.segment_count + 1,
+        )
+
+    def gravity_unit_mean_dir_I(self) -> np.ndarray:
+        """Return the unit-length mean gravity direction."""
+        return _unit_vector(self.gravity_mean_dir_I, "gravity_mean_dir_I")
+
+    def mag_unit_mean_dir_M(self) -> np.ndarray:
+        """Return the unit-length mean magnetic direction."""
+        if self.mag_mean_dir_M is None:
+            raise ValueError("mag_mean_dir_M is not available")
+        return _unit_vector(self.mag_mean_dir_M, "mag_mean_dir_M")
+
+
+def _update_dir_stats(
+    mean_dir: np.ndarray,
+    cov_dir: np.ndarray,
+    weight: int,
+    direction: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, int]:
+    """Update mean and covariance for direction statistics."""
+    if weight == 0:
+        return direction, np.zeros((3, 3), dtype=np.float64), 1
+
+    new_weight: int = weight + 1
+    delta: np.ndarray = direction - mean_dir
+    mean_new: np.ndarray = mean_dir + delta / float(new_weight)
+    delta2: np.ndarray = direction - mean_new
+    m2_old: np.ndarray = cov_dir * float(weight)
+    m2_new: np.ndarray = m2_old + np.outer(delta, delta2)
+    cov_new: np.ndarray = m2_new / float(new_weight)
+
+    return mean_new, cov_new, new_weight
+
+
+def _as_float_array(value: Any, name: str, shape: tuple[int, ...]) -> np.ndarray:
+    """Coerce a value to a float64 numpy array with a specific shape."""
+    array: np.ndarray = np.asarray(value, dtype=np.float64)
+    if array.shape != shape:
+        raise ValueError(f"{name} must have shape {shape}")
+    if not np.all(np.isfinite(array)):
+        raise ValueError(f"{name} must contain finite values")
+    return array
+
+
+def _require_non_zero(vector: np.ndarray, name: str) -> None:
+    """Require a non-zero vector when weight is positive."""
+    norm: float = float(np.linalg.norm(vector))
+    if not np.isfinite(norm) or norm <= 0.0:
+        raise ValueError(f"{name} must be non-zero when weight is positive")
+
+
+def _unit_vector(vector: np.ndarray, name: str) -> np.ndarray:
+    """Return a unit vector derived from the input."""
+    norm: float = float(np.linalg.norm(vector))
+    if not np.isfinite(norm) or norm <= 0.0:
+        raise ValueError(f"{name} must be non-zero to normalize")
+    return vector / norm

--- a/oasis_control/oasis_control/localization/mounting/mounting_types/keyframe.py
+++ b/oasis_control/oasis_control/localization/mounting/mounting_types/keyframe.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/oasis_control/localization/mounting/mounting_types/mag_packet.py
+++ b/oasis_control/oasis_control/localization/mounting/mounting_types/mag_packet.py
@@ -7,3 +7,66 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+"""Magnetometer packet types for mounting calibration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class MagPacket:
+    """Magnetometer sample with covariance."""
+
+    t_meas_ns: int
+    frame_id: str
+    m_raw_T: np.ndarray
+    cov_m_raw_T2: np.ndarray
+
+    def __post_init__(self) -> None:
+        """Validate packet fields and coerce arrays."""
+        if not isinstance(self.t_meas_ns, int) or isinstance(self.t_meas_ns, bool):
+            raise ValueError("t_meas_ns must be an int")
+        if not isinstance(self.frame_id, str):
+            raise ValueError("frame_id must be a str")
+
+        m_raw_T: np.ndarray = _as_float_array(self.m_raw_T, "m_raw_T", (3,))
+        cov_m_raw_T2: np.ndarray = _as_float_array(
+            self.cov_m_raw_T2,
+            "cov_m_raw_T2",
+            (3, 3),
+        )
+
+        object.__setattr__(self, "m_raw_T", m_raw_T)
+        object.__setattr__(self, "cov_m_raw_T2", cov_m_raw_T2)
+
+    def magnitude_T(self) -> float:
+        """Return the magnitude of the raw magnetic field in tesla."""
+        magnitude: float = float(np.linalg.norm(self.m_raw_T))
+        return magnitude
+
+    def unit_direction(self) -> np.ndarray:
+        """Return the unit magnetic field direction without mutating state."""
+        return _unit_vector(self.m_raw_T, "m_raw_T")
+
+
+def _as_float_array(value: Any, name: str, shape: tuple[int, ...]) -> np.ndarray:
+    """Coerce a value to a float64 numpy array with a specific shape."""
+    array: np.ndarray = np.asarray(value, dtype=np.float64)
+    if array.shape != shape:
+        raise ValueError(f"{name} must have shape {shape}")
+    if not np.all(np.isfinite(array)):
+        raise ValueError(f"{name} must contain finite values")
+    return array
+
+
+def _unit_vector(vector: np.ndarray, name: str) -> np.ndarray:
+    """Return a unit vector derived from the input."""
+    norm: float = float(np.linalg.norm(vector))
+    if not np.isfinite(norm) or norm <= 0.0:
+        raise ValueError(f"{name} must be non-zero to normalize")
+    return vector / norm

--- a/oasis_control/oasis_control/localization/mounting/mounting_types/mag_packet.py
+++ b/oasis_control/oasis_control/localization/mounting/mounting_types/mag_packet.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/oasis_control/localization/mounting/mounting_types/result_snapshot.py
+++ b/oasis_control/oasis_control/localization/mounting/mounting_types/result_snapshot.py
@@ -7,3 +7,173 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+"""Snapshot of current mounting calibration estimates."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from oasis_control.localization.mounting.math_utils.se3 import SE3
+
+
+@dataclass(frozen=True)
+class ResultSnapshot:
+    """Immutable bundle of the current mounting calibration estimate.
+
+    Attributes:
+        t_meas_ns: Timestamp of the snapshot in nanoseconds
+        frame_base: Base frame name
+        frame_imu: IMU frame name
+        frame_mag: Magnetometer frame name when available
+        T_BI: Estimated base-to-IMU pose
+        T_BM: Estimated base-to-mag pose when available
+        cov_rot_BI: Rotation covariance for T_BI in tangent space
+        cov_trans_BI: Translation covariance for T_BI in meters^2
+        cov_rot_BM: Rotation covariance for T_BM in tangent space
+        cov_trans_BM: Translation covariance for T_BM in meters^2
+        b_a_mps2: Accelerometer bias estimate in m/s^2
+        A_a: Accelerometer scale/misalignment estimate
+        b_g_rads: Gyroscope bias estimate in rad/s
+        b_m_T: Magnetometer bias estimate in tesla when available
+        R_m: Adaptive magnetometer direction-residual noise covariance (unitless^2
+            ≈ rad^2) when available
+        segment_count: Number of steady segments processed
+        keyframe_count: Number of keyframes in the estimate
+        diversity_tilt_deg: Tilt diversity in degrees when available
+        diversity_yaw_deg: Yaw diversity in degrees when available
+        is_stable: Indicates whether the estimate is considered stable
+        quality_score: Aggregate quality score when available
+    """
+
+    t_meas_ns: int
+    frame_base: str
+    frame_imu: str
+    frame_mag: str | None
+    T_BI: SE3
+    T_BM: SE3 | None
+    cov_rot_BI: np.ndarray
+    cov_trans_BI: np.ndarray
+    cov_rot_BM: np.ndarray | None
+    cov_trans_BM: np.ndarray | None
+    b_a_mps2: np.ndarray
+    A_a: np.ndarray
+    b_g_rads: np.ndarray
+    b_m_T: np.ndarray | None
+    R_m: np.ndarray | None
+    segment_count: int
+    keyframe_count: int
+    diversity_tilt_deg: float | None
+    diversity_yaw_deg: float | None
+    is_stable: bool
+    quality_score: float | None
+
+    def __post_init__(self) -> None:
+        """Validate snapshot fields and coerce arrays."""
+        if not isinstance(self.t_meas_ns, int) or isinstance(self.t_meas_ns, bool):
+            raise ValueError("t_meas_ns must be an int")
+        if not isinstance(self.frame_base, str):
+            raise ValueError("frame_base must be a str")
+        if not isinstance(self.frame_imu, str):
+            raise ValueError("frame_imu must be a str")
+        if self.frame_mag is not None and not isinstance(self.frame_mag, str):
+            raise ValueError("frame_mag must be a str or None")
+        if not isinstance(self.segment_count, int) or isinstance(
+            self.segment_count, bool
+        ):
+            raise ValueError("segment_count must be an int")
+        if self.segment_count < 0:
+            raise ValueError("segment_count must be non-negative")
+        if not isinstance(self.keyframe_count, int) or isinstance(
+            self.keyframe_count, bool
+        ):
+            raise ValueError("keyframe_count must be an int")
+        if self.keyframe_count < 0:
+            raise ValueError("keyframe_count must be non-negative")
+        if not isinstance(self.is_stable, bool):
+            raise ValueError("is_stable must be a bool")
+
+        cov_rot_BI: np.ndarray = _as_float_array(
+            self.cov_rot_BI,
+            "cov_rot_BI",
+            (3, 3),
+        )
+        cov_trans_BI: np.ndarray = _as_float_array(
+            self.cov_trans_BI,
+            "cov_trans_BI",
+            (3, 3),
+        )
+        b_a_mps2: np.ndarray = _as_float_array(self.b_a_mps2, "b_a_mps2", (3,))
+        A_a: np.ndarray = _as_float_array(self.A_a, "A_a", (3, 3))
+        b_g_rads: np.ndarray = _as_float_array(self.b_g_rads, "b_g_rads", (3,))
+
+        object.__setattr__(self, "cov_rot_BI", cov_rot_BI)
+        object.__setattr__(self, "cov_trans_BI", cov_trans_BI)
+        object.__setattr__(self, "b_a_mps2", b_a_mps2)
+        object.__setattr__(self, "A_a", A_a)
+        object.__setattr__(self, "b_g_rads", b_g_rads)
+
+        if self.quality_score is not None:
+            _require_finite(self.quality_score, "quality_score")
+        if self.diversity_tilt_deg is not None:
+            _require_finite(self.diversity_tilt_deg, "diversity_tilt_deg")
+        if self.diversity_yaw_deg is not None:
+            _require_finite(self.diversity_yaw_deg, "diversity_yaw_deg")
+
+        if self.frame_mag is None:
+            if (
+                self.T_BM is not None
+                or self.cov_rot_BM is not None
+                or self.cov_trans_BM is not None
+                or self.b_m_T is not None
+                or self.R_m is not None
+            ):
+                raise ValueError("mag fields must be None when frame_mag is None")
+            object.__setattr__(self, "T_BM", None)
+            object.__setattr__(self, "cov_rot_BM", None)
+            object.__setattr__(self, "cov_trans_BM", None)
+            object.__setattr__(self, "b_m_T", None)
+            object.__setattr__(self, "R_m", None)
+        else:
+            if self.T_BM is None:
+                raise ValueError("T_BM is required when frame_mag is set")
+            if self.cov_rot_BM is None or self.cov_trans_BM is None:
+                raise ValueError("mag covariances are required when frame_mag is set")
+            cov_rot_BM: np.ndarray = _as_float_array(
+                self.cov_rot_BM,
+                "cov_rot_BM",
+                (3, 3),
+            )
+            cov_trans_BM: np.ndarray = _as_float_array(
+                self.cov_trans_BM,
+                "cov_trans_BM",
+                (3, 3),
+            )
+            object.__setattr__(self, "cov_rot_BM", cov_rot_BM)
+            object.__setattr__(self, "cov_trans_BM", cov_trans_BM)
+
+            if self.b_m_T is not None:
+                b_m_T: np.ndarray = _as_float_array(self.b_m_T, "b_m_T", (3,))
+                object.__setattr__(self, "b_m_T", b_m_T)
+            if self.R_m is not None:
+                R_m: np.ndarray = _as_float_array(self.R_m, "R_m", (3, 3))
+                object.__setattr__(self, "R_m", R_m)
+
+
+def _as_float_array(value: Any, name: str, shape: tuple[int, ...]) -> np.ndarray:
+    """Coerce a value to a float64 numpy array with a specific shape."""
+    array: np.ndarray = np.asarray(value, dtype=np.float64)
+    if array.shape != shape:
+        raise ValueError(f"{name} must have shape {shape}")
+    if not np.all(np.isfinite(array)):
+        raise ValueError(f"{name} must contain finite values")
+    return array
+
+
+def _require_finite(value: float, name: str) -> None:
+    """Ensure a scalar value is finite."""
+    if not np.isfinite(value):
+        raise ValueError(f"{name} must be finite")

--- a/oasis_control/oasis_control/localization/mounting/mounting_types/result_snapshot.py
+++ b/oasis_control/oasis_control/localization/mounting/mounting_types/result_snapshot.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/oasis_control/localization/mounting/mounting_types/steady_segment.py
+++ b/oasis_control/oasis_control/localization/mounting/mounting_types/steady_segment.py
@@ -7,3 +7,115 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+"""Steady-segment types for mounting calibration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class SteadySegment:
+    """Steady segment summary emitted by the detector.
+
+    Attributes:
+        t_start_ns: Segment start time in nanoseconds
+        t_end_ns: Segment end time in nanoseconds
+        t_meas_ns: Representative timestamp for the segment
+        imu_frame_id: IMU frame associated with the segment
+        mag_frame_id: Magnetometer frame, if magnetometer data was present
+        a_mean_mps2: Mean accelerometer sample in m/s^2
+        cov_a: Accelerometer covariance in (m/s^2)^2
+        m_mean_T: Mean magnetometer sample in tesla when available
+        cov_m: Magnetometer covariance in tesla^2 when available
+        sample_count: Number of samples included in the segment
+        duration_ns: Segment duration in nanoseconds
+    """
+
+    t_start_ns: int
+    t_end_ns: int
+    t_meas_ns: int
+    imu_frame_id: str
+    mag_frame_id: str | None
+    a_mean_mps2: np.ndarray
+    cov_a: np.ndarray
+    m_mean_T: np.ndarray | None
+    cov_m: np.ndarray | None
+    sample_count: int
+    duration_ns: int
+
+    def __post_init__(self) -> None:
+        """Validate segment fields and coerce arrays."""
+        if not isinstance(self.t_start_ns, int) or isinstance(self.t_start_ns, bool):
+            raise ValueError("t_start_ns must be an int")
+        if not isinstance(self.t_end_ns, int) or isinstance(self.t_end_ns, bool):
+            raise ValueError("t_end_ns must be an int")
+        if not isinstance(self.t_meas_ns, int) or isinstance(self.t_meas_ns, bool):
+            raise ValueError("t_meas_ns must be an int")
+        if self.t_end_ns < self.t_start_ns:
+            raise ValueError("t_end_ns must be >= t_start_ns")
+        if not (self.t_start_ns <= self.t_meas_ns <= self.t_end_ns):
+            raise ValueError("t_meas_ns must be within segment bounds")
+        if not isinstance(self.imu_frame_id, str):
+            raise ValueError("imu_frame_id must be a str")
+        if self.mag_frame_id is not None and not isinstance(self.mag_frame_id, str):
+            raise ValueError("mag_frame_id must be a str or None")
+        if not isinstance(self.sample_count, int) or isinstance(
+            self.sample_count, bool
+        ):
+            raise ValueError("sample_count must be an int")
+        if self.sample_count <= 0:
+            raise ValueError("sample_count must be positive")
+        if not isinstance(self.duration_ns, int) or isinstance(self.duration_ns, bool):
+            raise ValueError("duration_ns must be an int")
+        if self.duration_ns != self.t_end_ns - self.t_start_ns:
+            raise ValueError("duration_ns must match t_end_ns - t_start_ns")
+
+        a_mean_mps2: np.ndarray = _as_float_array(
+            self.a_mean_mps2,
+            "a_mean_mps2",
+            (3,),
+        )
+        cov_a: np.ndarray = _as_float_array(self.cov_a, "cov_a", (3, 3))
+
+        object.__setattr__(self, "a_mean_mps2", a_mean_mps2)
+        object.__setattr__(self, "cov_a", cov_a)
+
+        if self.mag_frame_id is None:
+            if self.m_mean_T is not None or self.cov_m is not None:
+                raise ValueError("m_mean_T and cov_m must be None without mag_frame_id")
+            object.__setattr__(self, "m_mean_T", None)
+            object.__setattr__(self, "cov_m", None)
+        else:
+            if self.m_mean_T is None or self.cov_m is None:
+                raise ValueError("m_mean_T and cov_m are required with mag_frame_id")
+            m_mean_T: np.ndarray = _as_float_array(self.m_mean_T, "m_mean_T", (3,))
+            cov_m: np.ndarray = _as_float_array(self.cov_m, "cov_m", (3, 3))
+            object.__setattr__(self, "m_mean_T", m_mean_T)
+            object.__setattr__(self, "cov_m", cov_m)
+
+    def gravity_up_dir_I(self) -> np.ndarray:
+        """Return the unit gravity-up direction in the IMU frame."""
+        return _unit_vector(-self.a_mean_mps2, "a_mean_mps2")
+
+
+def _as_float_array(value: Any, name: str, shape: tuple[int, ...]) -> np.ndarray:
+    """Coerce a value to a float64 numpy array with a specific shape."""
+    array: np.ndarray = np.asarray(value, dtype=np.float64)
+    if array.shape != shape:
+        raise ValueError(f"{name} must have shape {shape}")
+    if not np.all(np.isfinite(array)):
+        raise ValueError(f"{name} must contain finite values")
+    return array
+
+
+def _unit_vector(vector: np.ndarray, name: str) -> np.ndarray:
+    """Return a unit vector derived from the input."""
+    norm: float = float(np.linalg.norm(vector))
+    if not np.isfinite(norm) or norm <= 0.0:
+        raise ValueError(f"{name} must be non-zero to normalize")
+    return vector / norm

--- a/oasis_control/oasis_control/localization/mounting/mounting_types/steady_segment.py
+++ b/oasis_control/oasis_control/localization/mounting/mounting_types/steady_segment.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/oasis_control/localization/mounting/mounting_types/update_report.py
+++ b/oasis_control/oasis_control/localization/mounting/mounting_types/update_report.py
@@ -7,3 +7,91 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+"""Update report types for mounting calibration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class UpdateReport:
+    """Summary of one update step in the mounting calibration pipeline.
+
+    Attributes:
+        did_update: True when the solver performed an update
+        iterations: Number of solver iterations executed
+        step_norm: Step size norm from the solver when available
+        residual_rms: RMS of residuals when available
+        need_more_tilt: True when more tilt diversity is required
+        need_more_yaw: True when more yaw diversity is required
+        dropped_segments: Number of segments dropped in this update
+        dropped_mags: Number of mag samples dropped in this update
+        message: Optional status message
+    """
+
+    did_update: bool
+    iterations: int
+    step_norm: float | None
+    residual_rms: float | None
+    need_more_tilt: bool
+    need_more_yaw: bool
+    dropped_segments: int
+    dropped_mags: int
+    message: str | None = None
+
+    def __post_init__(self) -> None:
+        """Validate update report fields."""
+        if not isinstance(self.did_update, bool):
+            raise ValueError("did_update must be a bool")
+        if not isinstance(self.iterations, int) or isinstance(self.iterations, bool):
+            raise ValueError("iterations must be an int")
+        if self.iterations < 0:
+            raise ValueError("iterations must be non-negative")
+        if not isinstance(self.need_more_tilt, bool):
+            raise ValueError("need_more_tilt must be a bool")
+        if not isinstance(self.need_more_yaw, bool):
+            raise ValueError("need_more_yaw must be a bool")
+        if not isinstance(self.dropped_segments, int) or isinstance(
+            self.dropped_segments, bool
+        ):
+            raise ValueError("dropped_segments must be an int")
+        if self.dropped_segments < 0:
+            raise ValueError("dropped_segments must be non-negative")
+        if not isinstance(self.dropped_mags, int) or isinstance(
+            self.dropped_mags, bool
+        ):
+            raise ValueError("dropped_mags must be an int")
+        if self.dropped_mags < 0:
+            raise ValueError("dropped_mags must be non-negative")
+        if self.step_norm is not None:
+            _require_finite_non_negative(self.step_norm, "step_norm")
+        if self.residual_rms is not None:
+            _require_finite_non_negative(self.residual_rms, "residual_rms")
+        if self.message is not None and not isinstance(self.message, str):
+            raise ValueError("message must be a str or None")
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a dictionary representation of the update report."""
+        return {
+            "did_update": self.did_update,
+            "iterations": self.iterations,
+            "step_norm": self.step_norm,
+            "residual_rms": self.residual_rms,
+            "need_more_tilt": self.need_more_tilt,
+            "need_more_yaw": self.need_more_yaw,
+            "dropped_segments": self.dropped_segments,
+            "dropped_mags": self.dropped_mags,
+            "message": self.message,
+        }
+
+
+def _require_finite_non_negative(value: float, name: str) -> None:
+    """Require a finite, non-negative scalar value."""
+    if not np.isfinite(value):
+        raise ValueError(f"{name} must be finite")
+    if value < 0.0:
+        raise ValueError(f"{name} must be non-negative")

--- a/oasis_control/oasis_control/localization/mounting/mounting_types/update_report.py
+++ b/oasis_control/oasis_control/localization/mounting/mounting_types/update_report.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/oasis_control/localization/mounting/pipeline/mounting_pipeline.py
+++ b/oasis_control/oasis_control/localization/mounting/pipeline/mounting_pipeline.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/oasis_control/localization/mounting/solver/initialization.py
+++ b/oasis_control/oasis_control/localization/mounting/solver/initialization.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/oasis_control/localization/mounting/solver/initialization.py
+++ b/oasis_control/oasis_control/localization/mounting/solver/initialization.py
@@ -7,3 +7,65 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+"""Initialization helpers for mounting calibration solver."""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+from oasis_control.localization.mounting.math_utils.quat import Quaternion
+
+
+# Units: unitless. Meaning: threshold for near-parallel direction alignment
+_DIR_ALIGN_EPS: float = 1e-8
+
+# Units: unitless. Meaning: dot-product limit for reference axis selection
+_REF_DOT_LIMIT: float = 0.9
+
+
+def _unit(vec: NDArray[np.float64]) -> NDArray[np.float64]:
+    norm: float = float(np.linalg.norm(vec))
+    if norm <= 0.0 or not np.isfinite(norm):
+        raise ValueError("vector must be non-zero")
+    return vec / norm
+
+
+def seed_keyframe_attitude_from_measurements(
+    gravity_dir_I: NDArray[np.float64],
+    mag_dir_M: NDArray[np.float64] | None,
+    q_BI_wxyz: NDArray[np.float64],
+    q_BM_wxyz: NDArray[np.float64],
+) -> NDArray[np.float64]:
+    """Seed the world-to-body attitude from gravity and optional mag."""
+    g_I_unit: NDArray[np.float64] = _unit(np.asarray(gravity_dir_I, dtype=np.float64))
+    R_BI: NDArray[np.float64] = Quaternion(q_BI_wxyz).normalized().as_matrix()
+    g_B: NDArray[np.float64] = R_BI @ g_I_unit
+    z_B: NDArray[np.float64] = _unit(-g_B)
+
+    ref: NDArray[np.float64]
+    x_B: NDArray[np.float64]
+    if mag_dir_M is not None:
+        m_M_unit: NDArray[np.float64] = _unit(np.asarray(mag_dir_M, dtype=np.float64))
+        R_BM: NDArray[np.float64] = Quaternion(q_BM_wxyz).normalized().as_matrix()
+        m_B: NDArray[np.float64] = R_BM @ m_M_unit
+        x_B = m_B - float(m_B @ z_B) * z_B
+        x_norm: float = float(np.linalg.norm(x_B))
+        if x_norm <= _DIR_ALIGN_EPS:
+            ref = np.array([1.0, 0.0, 0.0], dtype=np.float64)
+            if abs(float(ref @ z_B)) > _REF_DOT_LIMIT:
+                ref = np.array([0.0, 1.0, 0.0], dtype=np.float64)
+            x_B = ref - float(ref @ z_B) * z_B
+        x_B = _unit(x_B)
+    else:
+        ref = np.array([1.0, 0.0, 0.0], dtype=np.float64)
+        if abs(float(ref @ z_B)) > _REF_DOT_LIMIT:
+            ref = np.array([0.0, 1.0, 0.0], dtype=np.float64)
+        x_B = _unit(ref - float(ref @ z_B) * z_B)
+
+    y_B: NDArray[np.float64] = _unit(np.cross(z_B, x_B))
+    x_B = _unit(np.cross(y_B, z_B))
+    R_BW: NDArray[np.float64] = np.column_stack((x_B, y_B, z_B))
+    R_WB: NDArray[np.float64] = R_BW.T
+    return Quaternion.from_matrix(R_WB).to_wxyz()

--- a/oasis_control/oasis_control/localization/mounting/solver/optimizer.py
+++ b/oasis_control/oasis_control/localization/mounting/solver/optimizer.py
@@ -7,3 +7,225 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+"""Gauss-Newton optimizer for mounting calibration."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+from oasis_control.localization.mounting.config.mounting_params import MountingParams
+from oasis_control.localization.mounting.math_utils.linalg import SO3
+from oasis_control.localization.mounting.math_utils.quat import Quaternion
+from oasis_control.localization.mounting.mounting_types.keyframe import Keyframe
+from oasis_control.localization.mounting.solver.problem import build_linearization
+from oasis_control.localization.mounting.state.mounting_state import ImuNuisance
+from oasis_control.localization.mounting.state.mounting_state import KeyframeAttitude
+from oasis_control.localization.mounting.state.mounting_state import MagNuisance
+from oasis_control.localization.mounting.state.mounting_state import MountEstimate
+from oasis_control.localization.mounting.state.mounting_state import MountingState
+from oasis_control.localization.mounting.state.state_mapping import BLOCK_NAME_A_A
+from oasis_control.localization.mounting.state.state_mapping import BLOCK_NAME_B_A
+from oasis_control.localization.mounting.state.state_mapping import BLOCK_NAME_B_G
+from oasis_control.localization.mounting.state.state_mapping import BLOCK_NAME_B_M
+from oasis_control.localization.mounting.state.state_mapping import BLOCK_NAME_G_W
+from oasis_control.localization.mounting.state.state_mapping import BLOCK_NAME_M_W
+from oasis_control.localization.mounting.state.state_mapping import BLOCK_NAME_P_BI
+from oasis_control.localization.mounting.state.state_mapping import BLOCK_NAME_P_BM
+from oasis_control.localization.mounting.state.state_mapping import BLOCK_NAME_R_BI
+from oasis_control.localization.mounting.state.state_mapping import BLOCK_NAME_R_BM
+from oasis_control.localization.mounting.state.state_mapping import StateBlock
+from oasis_control.localization.mounting.state.state_mapping import StateMapping
+
+
+# Units: unitless. Meaning: Levenberg-Marquardt diagonal damping
+_LM_DAMPING: float = 1e-6
+
+
+def _apply_rotation(
+    q_wxyz: NDArray[np.float64],
+    delta: NDArray[np.float64],
+) -> NDArray[np.float64]:
+    dq: Quaternion = Quaternion.from_rotvec(delta)
+    q: Quaternion = Quaternion(q_wxyz).normalized()
+    return (dq * q).normalized().to_wxyz()
+
+
+def _apply_direction(
+    direction: NDArray[np.float64],
+    delta: NDArray[np.float64],
+) -> NDArray[np.float64]:
+    updated: NDArray[np.float64] = SO3.exp(delta) @ direction
+    norm: float = float(np.linalg.norm(updated))
+    if norm <= 0.0:
+        return direction
+    return updated / norm
+
+
+def _solve(H: NDArray[np.float64], b: NDArray[np.float64]) -> NDArray[np.float64]:
+    rhs: NDArray[np.float64] = -b
+    try:
+        delta: NDArray[np.float64] = np.asarray(
+            np.linalg.solve(H, rhs),
+            dtype=np.float64,
+        )
+    except np.linalg.LinAlgError:
+        dim: int = int(H.shape[0])
+        H_damped: NDArray[np.float64] = H + np.eye(dim, dtype=np.float64) * _LM_DAMPING
+        try:
+            delta = np.asarray(
+                np.linalg.solve(H_damped, rhs),
+                dtype=np.float64,
+            )
+        except np.linalg.LinAlgError:
+            delta = np.asarray(
+                np.linalg.lstsq(H_damped, rhs, rcond=None)[0],
+                dtype=np.float64,
+            )
+    return delta
+
+
+def _apply_delta(
+    state: MountingState,
+    delta: NDArray[np.float64],
+    mapping: StateMapping,
+) -> MountingState:
+    q_BI_wxyz: NDArray[np.float64] = state.mount.q_BI_wxyz
+    if mapping.has(BLOCK_NAME_R_BI):
+        block_r_bi: StateBlock = mapping.block(BLOCK_NAME_R_BI)
+        q_BI_wxyz = _apply_rotation(q_BI_wxyz, delta[block_r_bi.sl()])
+
+    q_BM_wxyz: NDArray[np.float64] = state.mount.q_BM_wxyz
+    if mapping.has(BLOCK_NAME_R_BM):
+        block_r_bm: StateBlock = mapping.block(BLOCK_NAME_R_BM)
+        q_BM_wxyz = _apply_rotation(q_BM_wxyz, delta[block_r_bm.sl()])
+
+    g_W_unit: NDArray[np.float64] = state.g_W_unit
+    if mapping.has(BLOCK_NAME_G_W):
+        block_g_w: StateBlock = mapping.block(BLOCK_NAME_G_W)
+        g_W_unit = _apply_direction(g_W_unit, delta[block_g_w.sl()])
+
+    m_W_unit: NDArray[np.float64] | None = state.m_W_unit
+    if m_W_unit is not None and mapping.has(BLOCK_NAME_M_W):
+        block_m_w: StateBlock = mapping.block(BLOCK_NAME_M_W)
+        m_W_unit = _apply_direction(m_W_unit, delta[block_m_w.sl()])
+
+    b_a_mps2: NDArray[np.float64] = state.imu.b_a_mps2
+    if mapping.has(BLOCK_NAME_B_A):
+        block_b_a: StateBlock = mapping.block(BLOCK_NAME_B_A)
+        b_a_mps2 = b_a_mps2 + delta[block_b_a.sl()]
+
+    A_a: NDArray[np.float64] = state.imu.A_a
+    if mapping.has(BLOCK_NAME_A_A):
+        block_a_a: StateBlock = mapping.block(BLOCK_NAME_A_A)
+        delta_A: NDArray[np.float64] = delta[block_a_a.sl()].reshape(3, 3)
+        A_a = A_a + delta_A
+
+    b_g_rads: NDArray[np.float64] = state.imu.b_g_rads
+    if mapping.has(BLOCK_NAME_B_G):
+        block_b_g: StateBlock = mapping.block(BLOCK_NAME_B_G)
+        b_g_rads = b_g_rads + delta[block_b_g.sl()]
+
+    b_m_T: NDArray[np.float64] | None = state.mag.b_m_T
+    if b_m_T is not None and mapping.has(BLOCK_NAME_B_M):
+        block_b_m: StateBlock = mapping.block(BLOCK_NAME_B_M)
+        b_m_T = b_m_T + delta[block_b_m.sl()]
+
+    p_BI_m: NDArray[np.float64] = state.mount.p_BI_m
+    if mapping.has(BLOCK_NAME_P_BI):
+        block_p_bi: StateBlock = mapping.block(BLOCK_NAME_P_BI)
+        p_BI_m = p_BI_m + delta[block_p_bi.sl()]
+
+    p_BM_m: NDArray[np.float64] = state.mount.p_BM_m
+    if mapping.has(BLOCK_NAME_P_BM):
+        block_p_bm: StateBlock = mapping.block(BLOCK_NAME_P_BM)
+        p_BM_m = p_BM_m + delta[block_p_bm.sl()]
+
+    updated_keyframes: list[KeyframeAttitude] = []
+    for attitude in state.keyframes:
+        block_wb: StateBlock = mapping.keyframe_block(attitude.keyframe_id)
+        q_WB_updated: NDArray[np.float64] = _apply_rotation(
+            attitude.q_WB_wxyz,
+            delta[block_wb.sl()],
+        )
+        updated_keyframes.append(
+            KeyframeAttitude(
+                keyframe_id=attitude.keyframe_id,
+                q_WB_wxyz=q_WB_updated,
+            )
+        )
+
+    mount: MountEstimate = MountEstimate(
+        q_BI_wxyz=q_BI_wxyz,
+        q_BM_wxyz=q_BM_wxyz,
+        p_BI_m=p_BI_m,
+        p_BM_m=p_BM_m,
+    )
+    imu: ImuNuisance = ImuNuisance(
+        b_a_mps2=b_a_mps2,
+        A_a=A_a,
+        b_g_rads=b_g_rads,
+    )
+    mag: MagNuisance = MagNuisance(
+        b_m_T=b_m_T,
+        R_m_unitless2=state.mag.R_m_unitless2,
+    )
+    return replace(
+        state,
+        mount=mount,
+        g_W_unit=g_W_unit,
+        m_W_unit=m_W_unit,
+        imu=imu,
+        mag=mag,
+        keyframes=tuple(updated_keyframes),
+    )
+
+
+def optimize(
+    state: MountingState,
+    keyframes: tuple[Keyframe, ...],
+    params: MountingParams | None,
+    *,
+    include_translation_vars: bool,
+) -> tuple[MountingState, dict[str, Any]]:
+    """Run Gauss-Newton iterations and return the updated state."""
+    if params is not None and params.mount.baseline_hard_enabled:
+        raise NotImplementedError("TODO: hard baseline constraint is not implemented")
+    max_iters: int = 1
+    if params is not None and params.solver.max_iters is not None:
+        max_iters = int(params.solver.max_iters)
+    max_iters = max(max_iters, 1)
+
+    current: MountingState = state
+    initial_cost: float = 0.0
+    final_cost: float = 0.0
+    metrics: dict[str, Any] = {}
+
+    for iteration in range(max_iters):
+        mapping: StateMapping = StateMapping.from_state(
+            current,
+            include_translation_vars=include_translation_vars,
+        )
+        H, b, cost, metrics = build_linearization(
+            current,
+            keyframes,
+            params,
+            include_translation_vars=include_translation_vars,
+        )
+        if iteration == 0:
+            initial_cost = cost
+        delta: NDArray[np.float64] = _solve(H, b)
+        current = _apply_delta(current, delta, mapping)
+        final_cost = cost
+
+    report: dict[str, Any] = {
+        "initial_cost": initial_cost,
+        "final_cost": final_cost,
+        "iterations": max_iters,
+    }
+    report.update(metrics)
+    return current, report

--- a/oasis_control/oasis_control/localization/mounting/solver/optimizer.py
+++ b/oasis_control/oasis_control/localization/mounting/solver/optimizer.py
@@ -220,7 +220,13 @@ def optimize(
             initial_cost = cost
         delta: NDArray[np.float64] = _solve(H, b)
         current = _apply_delta(current, delta, mapping)
-        final_cost = cost
+
+    _, _, final_cost, metrics = build_linearization(
+        current,
+        keyframes,
+        params,
+        include_translation_vars=include_translation_vars,
+    )
 
     report: dict[str, Any] = {
         "initial_cost": initial_cost,

--- a/oasis_control/oasis_control/localization/mounting/solver/optimizer.py
+++ b/oasis_control/oasis_control/localization/mounting/solver/optimizer.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/oasis_control/localization/mounting/solver/problem.py
+++ b/oasis_control/oasis_control/localization/mounting/solver/problem.py
@@ -7,3 +7,202 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+"""Linearization builder for mounting calibration solver."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+from oasis_control.localization.mounting.config.mounting_params import MountingParams
+from oasis_control.localization.mounting.mounting_types.keyframe import Keyframe
+from oasis_control.localization.mounting.solver.residuals import (
+    accel_residual_with_jacobians,
+)
+from oasis_control.localization.mounting.solver.residuals import (
+    mag_residual_with_jacobians,
+)
+from oasis_control.localization.mounting.solver.robust_loss import robust_weight
+from oasis_control.localization.mounting.state.mounting_state import MountingState
+from oasis_control.localization.mounting.state.state_mapping import BLOCK_NAME_G_W
+from oasis_control.localization.mounting.state.state_mapping import BLOCK_NAME_M_W
+from oasis_control.localization.mounting.state.state_mapping import BLOCK_NAME_R_BI
+from oasis_control.localization.mounting.state.state_mapping import BLOCK_NAME_R_BM
+from oasis_control.localization.mounting.state.state_mapping import (
+    BLOCK_NAME_R_WB_PREFIX,
+)
+from oasis_control.localization.mounting.state.state_mapping import StateBlock
+from oasis_control.localization.mounting.state.state_mapping import StateMapping
+
+
+# Units: unitless. Meaning: diagonal jitter for covariance inversion
+_COV_EPS: float = 1e-9
+
+
+def _info_from_cov(cov: NDArray[np.float64]) -> NDArray[np.float64]:
+    cov_in: NDArray[np.float64] = np.asarray(cov, dtype=np.float64)
+    cov_sym: NDArray[np.float64] = np.asarray(
+        0.5 * (cov_in + cov_in.T),
+        dtype=np.float64,
+    )
+    cov_sym = np.asarray(
+        cov_sym + np.eye(3, dtype=np.float64) * _COV_EPS,
+        dtype=np.float64,
+    )
+    try:
+        info: NDArray[np.float64] = np.asarray(
+            np.linalg.inv(cov_sym),
+            dtype=np.float64,
+        )
+    except np.linalg.LinAlgError:
+        info = np.asarray(
+            np.linalg.pinv(cov_sym),
+            dtype=np.float64,
+        )
+    return info
+
+
+def _accumulate_factor(
+    H: NDArray[np.float64],
+    b: NDArray[np.float64],
+    residual: NDArray[np.float64],
+    jacobians: dict[str, NDArray[np.float64]],
+    info: NDArray[np.float64],
+    mapping: StateMapping,
+    weight: float,
+) -> tuple[float, float, int]:
+    r_w: NDArray[np.float64] = residual * weight
+    cost: float = float(0.5 * r_w.T @ info @ r_w)
+    res_sq: float = float(r_w @ r_w)
+    res_count: int = int(r_w.size)
+    for name_i, J_i in jacobians.items():
+        block_i: StateBlock = mapping.block(name_i)
+        sl_i: slice = block_i.sl()
+        b[sl_i] += J_i.T @ info @ r_w
+        for name_j, J_j in jacobians.items():
+            block_j: StateBlock = mapping.block(name_j)
+            sl_j: slice = block_j.sl()
+            H[sl_i, sl_j] += J_i.T @ info @ J_j
+    return cost, res_sq, res_count
+
+
+def build_linearization(
+    state: MountingState,
+    keyframes: tuple[Keyframe, ...],
+    params: MountingParams | None,
+    *,
+    include_translation_vars: bool,
+) -> tuple[NDArray[np.float64], NDArray[np.float64], float, dict[str, Any]]:
+    """Build the Gauss-Newton linearization for the current state."""
+    mapping: StateMapping = StateMapping.from_state(
+        state,
+        include_translation_vars=include_translation_vars,
+    )
+    dim: int = mapping.dim()
+    H: NDArray[np.float64] = np.zeros((dim, dim), dtype=np.float64)
+    b: NDArray[np.float64] = np.zeros(dim, dtype=np.float64)
+    cost: float = 0.0
+    res_sq_sum: float = 0.0
+    res_count: int = 0
+
+    robust_type: str | None = None
+    robust_scale_a: float = 1.0
+    robust_scale_m: float = 1.0
+    if params is not None:
+        robust_type = params.solver.robust_loss
+        if params.solver.robust_scale_a is not None:
+            robust_scale_a = float(params.solver.robust_scale_a)
+        if params.solver.robust_scale_m is not None:
+            robust_scale_m = float(params.solver.robust_scale_m)
+
+    keyframe_attitudes: dict[int, NDArray[np.float64]] = {
+        attitude.keyframe_id: attitude.q_WB_wxyz for attitude in state.keyframes
+    }
+
+    for keyframe in keyframes:
+        if keyframe.gravity_weight <= 0:
+            continue
+        a_meas: NDArray[np.float64] = keyframe.gravity_unit_mean_dir_I()
+        q_WB_wxyz: NDArray[np.float64] = keyframe_attitudes[keyframe.keyframe_id]
+        accel = accel_residual_with_jacobians(
+            a_meas,
+            q_WB_wxyz,
+            state.mount.q_BI_wxyz,
+            state.g_W_unit,
+        )
+        accel_cov: NDArray[np.float64] = keyframe.gravity_cov_dir_I
+        accel_info: NDArray[np.float64] = _info_from_cov(accel_cov)
+        accel_weight: float = robust_weight(
+            accel.residual,
+            robust_type,
+            robust_scale_a,
+        )
+        jacobians: dict[str, NDArray[np.float64]] = {
+            BLOCK_NAME_R_BI: accel.J_bi,
+            BLOCK_NAME_G_W: accel.J_gw,
+            f"{BLOCK_NAME_R_WB_PREFIX}_{keyframe.keyframe_id}": accel.J_wb,
+        }
+        factor_cost, factor_sq, factor_count = _accumulate_factor(
+            H,
+            b,
+            accel.residual,
+            jacobians,
+            accel_info,
+            mapping,
+            accel_weight,
+        )
+        cost += factor_cost
+        res_sq_sum += factor_sq
+        res_count += factor_count
+
+        if (
+            keyframe.mag_mean_dir_M is None
+            or keyframe.mag_cov_dir_M is None
+            or keyframe.mag_weight <= 0
+            or state.m_W_unit is None
+        ):
+            continue
+        mag = mag_residual_with_jacobians(
+            keyframe.mag_unit_mean_dir_M(),
+            q_WB_wxyz,
+            state.mount.q_BM_wxyz,
+            state.m_W_unit,
+        )
+        mag_cov: NDArray[np.float64] = keyframe.mag_cov_dir_M
+        mag_info: NDArray[np.float64] = _info_from_cov(mag_cov)
+        mag_weight: float = robust_weight(
+            mag.residual,
+            robust_type,
+            robust_scale_m,
+        )
+        mag_jacobians: dict[str, NDArray[np.float64]] = {
+            BLOCK_NAME_R_BM: mag.J_bm,
+            BLOCK_NAME_M_W: mag.J_mw,
+            f"{BLOCK_NAME_R_WB_PREFIX}_{keyframe.keyframe_id}": mag.J_wb,
+        }
+        factor_cost, factor_sq, factor_count = _accumulate_factor(
+            H,
+            b,
+            mag.residual,
+            mag_jacobians,
+            mag_info,
+            mapping,
+            mag_weight,
+        )
+        cost += factor_cost
+        res_sq_sum += factor_sq
+        res_count += factor_count
+
+    rms: float
+    if res_count <= 0:
+        rms = 0.0
+    else:
+        rms = float(np.sqrt(res_sq_sum / float(res_count)))
+    metrics: dict[str, Any] = {
+        "rms": rms,
+        "residual_count": res_count,
+    }
+    return H, b, cost, metrics

--- a/oasis_control/oasis_control/localization/mounting/solver/problem.py
+++ b/oasis_control/oasis_control/localization/mounting/solver/problem.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/oasis_control/localization/mounting/solver/residuals.py
+++ b/oasis_control/oasis_control/localization/mounting/solver/residuals.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/oasis_control/localization/mounting/solver/residuals.py
+++ b/oasis_control/oasis_control/localization/mounting/solver/residuals.py
@@ -7,3 +7,157 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+"""Residual and Jacobian helpers for mounting calibration solver.
+
+Jacobians use left perturbations with q' = exp(δ) ⊗ q
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import NDArray
+
+from oasis_control.localization.mounting.math_utils.linalg import SO3
+from oasis_control.localization.mounting.math_utils.quat import Quaternion
+
+
+def _unit(vec: NDArray[np.float64]) -> NDArray[np.float64]:
+    norm: float = float(np.linalg.norm(vec))
+    if norm <= 0.0 or not np.isfinite(norm):
+        raise ValueError("vector must be non-zero")
+    return vec / norm
+
+
+def _quat_to_matrix(q_wxyz: NDArray[np.float64]) -> NDArray[np.float64]:
+    return Quaternion(q_wxyz).normalized().as_matrix()
+
+
+@dataclass(frozen=True)
+class AccelResidual:
+    """Container for accel residual and Jacobians."""
+
+    residual: NDArray[np.float64]
+    prediction: NDArray[np.float64]
+    J_wb: NDArray[np.float64]
+    J_bi: NDArray[np.float64]
+    J_gw: NDArray[np.float64]
+
+
+@dataclass(frozen=True)
+class MagResidual:
+    """Container for mag residual and Jacobians."""
+
+    residual: NDArray[np.float64]
+    prediction: NDArray[np.float64]
+    J_wb: NDArray[np.float64]
+    J_bm: NDArray[np.float64]
+    J_mw: NDArray[np.float64]
+
+
+def accel_residual(
+    a_hat_I_meas: NDArray[np.float64],
+    q_WB_wxyz: NDArray[np.float64],
+    q_BI_wxyz: NDArray[np.float64],
+    g_W_unit: NDArray[np.float64],
+) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+    """Return accel residual and predicted direction in the IMU frame."""
+    a_meas: NDArray[np.float64] = _unit(np.asarray(a_hat_I_meas, dtype=np.float64))
+    g_unit: NDArray[np.float64] = _unit(np.asarray(g_W_unit, dtype=np.float64))
+    R_WB: NDArray[np.float64] = _quat_to_matrix(q_WB_wxyz)
+    R_BI: NDArray[np.float64] = _quat_to_matrix(q_BI_wxyz)
+    a_hat_pred_I: NDArray[np.float64] = (R_WB.T @ R_BI) @ g_unit
+    residual: NDArray[np.float64] = np.cross(a_meas, a_hat_pred_I)
+    return residual.astype(np.float64), a_hat_pred_I.astype(np.float64)
+
+
+def mag_residual(
+    m_hat_M_meas: NDArray[np.float64],
+    q_WB_wxyz: NDArray[np.float64],
+    q_BM_wxyz: NDArray[np.float64],
+    m_W_unit: NDArray[np.float64],
+) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+    """Return mag residual and predicted direction in the mag frame."""
+    m_meas: NDArray[np.float64] = _unit(np.asarray(m_hat_M_meas, dtype=np.float64))
+    m_unit: NDArray[np.float64] = _unit(np.asarray(m_W_unit, dtype=np.float64))
+    R_WB: NDArray[np.float64] = _quat_to_matrix(q_WB_wxyz)
+    R_BM: NDArray[np.float64] = _quat_to_matrix(q_BM_wxyz)
+    m_hat_pred_M: NDArray[np.float64] = (R_WB.T @ R_BM) @ m_unit
+    residual: NDArray[np.float64] = np.cross(m_meas, m_hat_pred_M)
+    return residual.astype(np.float64), m_hat_pred_M.astype(np.float64)
+
+
+def accel_residual_with_jacobians(
+    a_hat_I_meas: NDArray[np.float64],
+    q_WB_wxyz: NDArray[np.float64],
+    q_BI_wxyz: NDArray[np.float64],
+    g_W_unit: NDArray[np.float64],
+) -> AccelResidual:
+    """Return accel residual and Jacobians for left perturbations."""
+    residual, a_hat_pred_I = accel_residual(
+        a_hat_I_meas,
+        q_WB_wxyz,
+        q_BI_wxyz,
+        g_W_unit,
+    )
+    a_meas: NDArray[np.float64] = _unit(np.asarray(a_hat_I_meas, dtype=np.float64))
+    R_WB: NDArray[np.float64] = _quat_to_matrix(q_WB_wxyz)
+    R_BI: NDArray[np.float64] = _quat_to_matrix(q_BI_wxyz)
+    g_unit: NDArray[np.float64] = _unit(np.asarray(g_W_unit, dtype=np.float64))
+    pred_hat: NDArray[np.float64] = a_hat_pred_I
+    hat_meas: NDArray[np.float64] = a_meas
+
+    J_pred_wb: NDArray[np.float64] = SO3.hat(pred_hat) @ R_WB.T
+    J_pred_bi: NDArray[np.float64] = -SO3.hat(pred_hat) @ R_WB.T
+    J_pred_gw: NDArray[np.float64] = -R_WB.T @ R_BI @ SO3.hat(g_unit)
+
+    J_wb: NDArray[np.float64] = SO3.hat(hat_meas) @ J_pred_wb
+    J_bi: NDArray[np.float64] = SO3.hat(hat_meas) @ J_pred_bi
+    J_gw: NDArray[np.float64] = SO3.hat(hat_meas) @ J_pred_gw
+
+    return AccelResidual(
+        residual=residual,
+        prediction=pred_hat,
+        J_wb=J_wb.astype(np.float64),
+        J_bi=J_bi.astype(np.float64),
+        J_gw=J_gw.astype(np.float64),
+    )
+
+
+def mag_residual_with_jacobians(
+    m_hat_M_meas: NDArray[np.float64],
+    q_WB_wxyz: NDArray[np.float64],
+    q_BM_wxyz: NDArray[np.float64],
+    m_W_unit: NDArray[np.float64],
+) -> MagResidual:
+    """Return mag residual and Jacobians for left perturbations."""
+    residual, m_hat_pred_M = mag_residual(
+        m_hat_M_meas,
+        q_WB_wxyz,
+        q_BM_wxyz,
+        m_W_unit,
+    )
+    m_meas: NDArray[np.float64] = _unit(np.asarray(m_hat_M_meas, dtype=np.float64))
+    R_WB: NDArray[np.float64] = _quat_to_matrix(q_WB_wxyz)
+    R_BM: NDArray[np.float64] = _quat_to_matrix(q_BM_wxyz)
+    m_unit: NDArray[np.float64] = _unit(np.asarray(m_W_unit, dtype=np.float64))
+    pred_hat: NDArray[np.float64] = m_hat_pred_M
+    hat_meas: NDArray[np.float64] = m_meas
+
+    J_pred_wb: NDArray[np.float64] = SO3.hat(pred_hat) @ R_WB.T
+    J_pred_bm: NDArray[np.float64] = -SO3.hat(pred_hat) @ R_WB.T
+    J_pred_mw: NDArray[np.float64] = -R_WB.T @ R_BM @ SO3.hat(m_unit)
+
+    J_wb: NDArray[np.float64] = SO3.hat(hat_meas) @ J_pred_wb
+    J_bm: NDArray[np.float64] = SO3.hat(hat_meas) @ J_pred_bm
+    J_mw: NDArray[np.float64] = SO3.hat(hat_meas) @ J_pred_mw
+
+    return MagResidual(
+        residual=residual,
+        prediction=pred_hat,
+        J_wb=J_wb.astype(np.float64),
+        J_bm=J_bm.astype(np.float64),
+        J_mw=J_mw.astype(np.float64),
+    )

--- a/oasis_control/oasis_control/localization/mounting/solver/robust_loss.py
+++ b/oasis_control/oasis_control/localization/mounting/solver/robust_loss.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/oasis_control/localization/mounting/solver/robust_loss.py
+++ b/oasis_control/oasis_control/localization/mounting/solver/robust_loss.py
@@ -7,3 +7,47 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+"""Robust loss helpers for mounting calibration."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def huber_weight(sq_norm: float, scale: float) -> float:
+    """Return the Huber weight for a squared residual norm."""
+    if scale <= 0.0:
+        return 1.0
+    if sq_norm <= scale * scale:
+        return 1.0
+    denom: float = float(np.sqrt(sq_norm))
+    if denom <= 0.0:
+        return 1.0
+    return float(scale / denom)
+
+
+def cauchy_weight(sq_norm: float, scale: float) -> float:
+    """Return the Cauchy weight for a squared residual norm."""
+    if scale <= 0.0:
+        return 1.0
+    return float(1.0 / (1.0 + sq_norm / (scale * scale)))
+
+
+def robust_weight(
+    residual: np.ndarray,
+    robust_type: str | None,
+    scale: float,
+) -> float:
+    """Return the scalar robust weight for a residual vector."""
+    if robust_type is None:
+        return 1.0
+    robust_name: str = robust_type.lower()
+    if robust_name in ("none", "identity", "off"):
+        return 1.0
+    sq_norm: float = float(np.dot(residual, residual))
+    if robust_name == "huber":
+        return huber_weight(sq_norm, scale)
+    if robust_name == "cauchy":
+        return cauchy_weight(sq_norm, scale)
+    return 1.0

--- a/oasis_control/oasis_control/localization/mounting/state/covariance.py
+++ b/oasis_control/oasis_control/localization/mounting/state/covariance.py
@@ -7,3 +7,83 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+"""Covariance container utilities for mounting calibration state."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+# Symmetry tolerance for covariance validation
+SYM_TOL: float = 1e-9
+
+# Default PSD tolerance for eigenvalue checks
+PSD_TOL: float = 1e-12
+
+
+class CovarianceError(Exception):
+    """Raised when covariance matrices are invalid or unsupported."""
+
+
+@dataclass(frozen=True)
+class Covariance:
+    """Container for symmetric covariance matrices.
+
+    Attributes:
+        P: Symmetric covariance matrix with shape (N, N)
+    """
+
+    P: np.ndarray
+
+    def __post_init__(self) -> None:
+        """Validate covariance shape, dtype, and symmetry."""
+        P: np.ndarray = np.asarray(self.P, dtype=np.float64)
+        if P.ndim != 2 or P.shape[0] != P.shape[1]:
+            raise CovarianceError("Covariance must be a square matrix")
+        if not np.all(np.isfinite(P)):
+            raise CovarianceError("Covariance contains non-finite values")
+        if not np.allclose(P, P.T, rtol=0.0, atol=SYM_TOL):
+            raise CovarianceError("Covariance must be symmetric")
+        object.__setattr__(self, "P", P)
+
+    def dim(self) -> int:
+        """Return the dimension of the covariance matrix."""
+        return int(self.P.shape[0])
+
+    def as_array(self) -> np.ndarray:
+        """Return a defensive copy of the covariance matrix."""
+        return self.P.copy()
+
+    def symmetrized(self) -> Covariance:
+        """Return a symmetrized version of this covariance matrix."""
+        sym: np.ndarray = 0.5 * (self.P + self.P.T)
+        return Covariance(sym)
+
+    def is_psd(self, *, tol: float = PSD_TOL) -> bool:
+        """Return True when the covariance is positive semi-definite."""
+        eigvals: np.ndarray = np.linalg.eigvalsh(self.P)
+        return bool(np.min(eigvals) >= -tol)
+
+    def assert_psd(self, *, tol: float = PSD_TOL) -> None:
+        """Raise CovarianceError if the covariance is not PSD."""
+        if not self.is_psd(tol=tol):
+            raise CovarianceError("Covariance is not positive semi-definite")
+
+    @staticmethod
+    def zeros(dim: int) -> Covariance:
+        """Return a zero covariance matrix of the given dimension."""
+        if dim <= 0:
+            raise CovarianceError("dim must be positive")
+        mat: np.ndarray = np.zeros((dim, dim), dtype=np.float64)
+        return Covariance(mat)
+
+    @staticmethod
+    def eye(dim: int, *, scale: float = 1.0) -> Covariance:
+        """Return a scaled identity covariance matrix."""
+        if dim <= 0:
+            raise CovarianceError("dim must be positive")
+        mat: np.ndarray = np.eye(dim, dtype=np.float64) * float(scale)
+        return Covariance(mat)

--- a/oasis_control/oasis_control/localization/mounting/state/covariance.py
+++ b/oasis_control/oasis_control/localization/mounting/state/covariance.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/oasis_control/localization/mounting/state/mounting_state.py
+++ b/oasis_control/oasis_control/localization/mounting/state/mounting_state.py
@@ -7,3 +7,302 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+"""Semantic mounting calibration state containers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import replace
+from typing import Any
+
+import numpy as np
+
+
+# Quaternion normalization tolerance used for validation
+QUAT_NORM_TOL: float = 1e-8
+
+# Unit vector normalization tolerance used for validation
+UNIT_VEC_TOL: float = 1e-8
+
+# Default diagonal entries for R_m adaptive noise covariance
+DEFAULT_RM_DIAG: tuple[float, float, float] = (1e-3, 1e-3, 1e-3)
+
+
+class MountingStateError(Exception):
+    """Raised when mounting state data is invalid."""
+
+
+def _as_f64(name: str, arr: Any, shape: tuple[int, ...]) -> np.ndarray:
+    """Coerce input to a float64 array with a specific shape."""
+    data: np.ndarray = np.asarray(arr, dtype=np.float64)
+    if data.shape != shape:
+        raise MountingStateError(f"{name} must have shape {shape}")
+    if not np.all(np.isfinite(data)):
+        raise MountingStateError(f"{name} must be finite")
+    return data
+
+
+def _unit3(name: str, vec: Any) -> np.ndarray:
+    """Return a normalized 3D vector after validation."""
+    data: np.ndarray = _as_f64(name, vec, (3,))
+    norm: float = float(np.linalg.norm(data))
+    if norm <= UNIT_VEC_TOL:
+        raise MountingStateError(f"{name} must be non-zero")
+    return data / norm
+
+
+def _unit_quat_wxyz(name: str, quat: Any) -> np.ndarray:
+    """Return a normalized quaternion in [w, x, y, z] order."""
+    data: np.ndarray = _as_f64(name, quat, (4,))
+    norm: float = float(np.linalg.norm(data))
+    if norm <= QUAT_NORM_TOL:
+        raise MountingStateError(f"{name} must be non-zero")
+    return data / norm
+
+
+def _is_rotation_matrix(matrix: np.ndarray) -> bool:
+    """Return True when the input is a valid rotation matrix."""
+    if matrix.shape != (3, 3):
+        return False
+    if not np.all(np.isfinite(matrix)):
+        return False
+    det: float = float(np.linalg.det(matrix))
+    if abs(det - 1.0) > 1e-6:
+        return False
+    ident: np.ndarray = matrix @ matrix.T
+    return bool(np.allclose(ident, np.eye(3), rtol=0.0, atol=1e-6))
+
+
+@dataclass(frozen=True)
+class ImuNuisance:
+    """IMU nuisance parameters.
+
+    Attributes:
+        b_a_mps2: Accelerometer bias in meters per second squared
+        A_a: Accelerometer scale/misalignment matrix (unitless)
+        b_g_rads: Gyroscope bias in radians per second
+    """
+
+    b_a_mps2: np.ndarray
+    A_a: np.ndarray
+    b_g_rads: np.ndarray
+
+    def __post_init__(self) -> None:
+        """Validate IMU nuisance parameters."""
+        b_a_mps2: np.ndarray = _as_f64("b_a_mps2", self.b_a_mps2, (3,))
+        A_a: np.ndarray = _as_f64("A_a", self.A_a, (3, 3))
+        b_g_rads: np.ndarray = _as_f64("b_g_rads", self.b_g_rads, (3,))
+        object.__setattr__(self, "b_a_mps2", b_a_mps2)
+        object.__setattr__(self, "A_a", A_a)
+        object.__setattr__(self, "b_g_rads", b_g_rads)
+
+
+@dataclass(frozen=True)
+class MagNuisance:
+    """Magnetometer nuisance parameters.
+
+    Attributes:
+        b_m_T: Magnetometer bias in tesla
+        R_m_unitless2: Adaptive magnetic direction residual covariance
+    """
+
+    b_m_T: np.ndarray | None
+    R_m_unitless2: np.ndarray
+
+    def __post_init__(self) -> None:
+        """Validate magnetometer nuisance parameters."""
+        if self.b_m_T is None:
+            b_m_T: np.ndarray | None = None
+        else:
+            b_m_T = _as_f64("b_m_T", self.b_m_T, (3,))
+        R_m_unitless2: np.ndarray = _as_f64(
+            "R_m_unitless2",
+            self.R_m_unitless2,
+            (3, 3),
+        )
+        object.__setattr__(self, "b_m_T", b_m_T)
+        object.__setattr__(self, "R_m_unitless2", R_m_unitless2)
+
+
+@dataclass(frozen=True)
+class MountEstimate:
+    """Mounting transform estimate between sensors and the body frame.
+
+    Attributes:
+        q_BI_wxyz: IMU-to-body quaternion (w, x, y, z)
+        q_BM_wxyz: Magnetometer-to-body quaternion (w, x, y, z)
+        p_BI_m: IMU position in the body frame (meters)
+        p_BM_m: Magnetometer position in the body frame (meters)
+    """
+
+    q_BI_wxyz: np.ndarray
+    q_BM_wxyz: np.ndarray
+    p_BI_m: np.ndarray
+    p_BM_m: np.ndarray
+
+    def __post_init__(self) -> None:
+        """Validate mounting estimate parameters."""
+        q_BI_wxyz: np.ndarray = _unit_quat_wxyz("q_BI_wxyz", self.q_BI_wxyz)
+        q_BM_wxyz: np.ndarray = _unit_quat_wxyz("q_BM_wxyz", self.q_BM_wxyz)
+        p_BI_m: np.ndarray = _as_f64("p_BI_m", self.p_BI_m, (3,))
+        p_BM_m: np.ndarray = _as_f64("p_BM_m", self.p_BM_m, (3,))
+        object.__setattr__(self, "q_BI_wxyz", q_BI_wxyz)
+        object.__setattr__(self, "q_BM_wxyz", q_BM_wxyz)
+        object.__setattr__(self, "p_BI_m", p_BI_m)
+        object.__setattr__(self, "p_BM_m", p_BM_m)
+
+
+@dataclass(frozen=True)
+class KeyframeAttitude:
+    """Attitude state for a single keyframe.
+
+    Attributes:
+        keyframe_id: Unique keyframe identifier
+        q_WB_wxyz: Body attitude in the world frame (w, x, y, z)
+    """
+
+    keyframe_id: int
+    q_WB_wxyz: np.ndarray
+
+    def __post_init__(self) -> None:
+        """Validate keyframe attitude values."""
+        self.validate()
+
+    def validate(self) -> None:
+        """Validate keyframe attitude fields."""
+        if not isinstance(self.keyframe_id, int) or isinstance(self.keyframe_id, bool):
+            raise MountingStateError("keyframe_id must be an int")
+        q_WB_wxyz: np.ndarray = _unit_quat_wxyz("q_WB_wxyz", self.q_WB_wxyz)
+        object.__setattr__(self, "q_WB_wxyz", q_WB_wxyz)
+
+
+@dataclass(frozen=True)
+class MountingState:
+    """Semantic mounting calibration state.
+
+    Attributes:
+        mount: Estimated mounting transforms
+        g_W_unit: Unit gravity direction in the world frame
+        m_W_unit: Unit magnetic direction in the world frame
+        imu: IMU nuisance parameters
+        mag: Magnetometer nuisance parameters
+        keyframes: Keyframe attitude states
+        anchored: True when the state is anchored
+        mag_reference_invalid: True when mag reference is invalid
+    """
+
+    mount: MountEstimate
+    g_W_unit: np.ndarray
+    m_W_unit: np.ndarray | None
+    imu: ImuNuisance
+    mag: MagNuisance
+    keyframes: tuple[KeyframeAttitude, ...]
+    anchored: bool
+    mag_reference_invalid: bool
+
+    def __post_init__(self) -> None:
+        """Normalize and validate the mounting state."""
+        g_W_unit: np.ndarray = _unit3("g_W_unit", self.g_W_unit)
+        if self.m_W_unit is None:
+            m_W_unit: np.ndarray | None = None
+        else:
+            m_W_unit = _unit3("m_W_unit", self.m_W_unit)
+        keyframes: tuple[KeyframeAttitude, ...] = tuple(self.keyframes)
+        for attitude in keyframes:
+            if not isinstance(attitude, KeyframeAttitude):
+                raise MountingStateError("keyframes must be KeyframeAttitude values")
+        sorted_keyframes: tuple[KeyframeAttitude, ...] = tuple(
+            sorted(keyframes, key=lambda item: item.keyframe_id)
+        )
+        keyframe_ids: list[int] = [item.keyframe_id for item in sorted_keyframes]
+        if len(set(keyframe_ids)) != len(keyframe_ids):
+            raise MountingStateError("keyframe_id values must be unique")
+        object.__setattr__(self, "g_W_unit", g_W_unit)
+        object.__setattr__(self, "m_W_unit", m_W_unit)
+        object.__setattr__(self, "keyframes", sorted_keyframes)
+        self.validate()
+
+    @classmethod
+    def default(cls) -> MountingState:
+        """Return a default mounting state."""
+        mount: MountEstimate = MountEstimate(
+            q_BI_wxyz=np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float64),
+            q_BM_wxyz=np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float64),
+            p_BI_m=np.zeros(3, dtype=np.float64),
+            p_BM_m=np.zeros(3, dtype=np.float64),
+        )
+        imu: ImuNuisance = ImuNuisance(
+            b_a_mps2=np.zeros(3, dtype=np.float64),
+            A_a=np.eye(3, dtype=np.float64),
+            b_g_rads=np.zeros(3, dtype=np.float64),
+        )
+        mag: MagNuisance = MagNuisance(
+            b_m_T=None,
+            R_m_unitless2=np.diag(np.array(DEFAULT_RM_DIAG, dtype=np.float64)),
+        )
+        return cls(
+            mount=mount,
+            g_W_unit=np.array([0.0, 0.0, -1.0], dtype=np.float64),
+            m_W_unit=None,
+            imu=imu,
+            mag=mag,
+            keyframes=(),
+            anchored=False,
+            mag_reference_invalid=False,
+        )
+
+    def validate(self) -> None:
+        """Validate state shapes, values, and ordering."""
+        if not isinstance(self.anchored, bool):
+            raise MountingStateError("anchored must be a bool")
+        if not isinstance(self.mag_reference_invalid, bool):
+            raise MountingStateError("mag_reference_invalid must be a bool")
+        if not isinstance(self.mount, MountEstimate):
+            raise MountingStateError("mount must be MountEstimate")
+        if not isinstance(self.imu, ImuNuisance):
+            raise MountingStateError("imu must be ImuNuisance")
+        if not isinstance(self.mag, MagNuisance):
+            raise MountingStateError("mag must be MagNuisance")
+        _unit3("g_W_unit", self.g_W_unit)
+        if self.m_W_unit is not None:
+            _unit3("m_W_unit", self.m_W_unit)
+        keyframe_ids: list[int] = [item.keyframe_id for item in self.keyframes]
+        if keyframe_ids != sorted(keyframe_ids):
+            raise MountingStateError("keyframes must be sorted by keyframe_id")
+        if len(set(keyframe_ids)) != len(keyframe_ids):
+            raise MountingStateError("keyframe_id values must be unique")
+        for attitude in self.keyframes:
+            attitude.validate()
+
+    def replace(self, **kwargs: Any) -> MountingState:
+        """Return a new MountingState with fields replaced."""
+        return replace(self, **kwargs)
+
+    def keyframe_ids(self) -> tuple[int, ...]:
+        """Return the keyframe identifiers in deterministic order."""
+        return tuple(item.keyframe_id for item in self.keyframes)
+
+    def get_keyframe(self, keyframe_id: int) -> KeyframeAttitude:
+        """Return the keyframe attitude for the given identifier."""
+        for attitude in self.keyframes:
+            if attitude.keyframe_id == keyframe_id:
+                return attitude
+        raise MountingStateError(f"Keyframe {keyframe_id} not found")
+
+    def with_updated_keyframe(self, attitude: KeyframeAttitude) -> MountingState:
+        """Return a new state with the keyframe inserted or replaced."""
+        attitude.validate()
+        keyframes: list[KeyframeAttitude] = list(self.keyframes)
+        replaced: bool = False
+        for index, existing in enumerate(keyframes):
+            if existing.keyframe_id == attitude.keyframe_id:
+                keyframes[index] = attitude
+                replaced = True
+                break
+        if not replaced:
+            keyframes.append(attitude)
+        keyframes_sorted: tuple[KeyframeAttitude, ...] = tuple(
+            sorted(keyframes, key=lambda item: item.keyframe_id)
+        )
+        return replace(self, keyframes=keyframes_sorted)

--- a/oasis_control/oasis_control/localization/mounting/state/mounting_state.py
+++ b/oasis_control/oasis_control/localization/mounting/state/mounting_state.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/oasis_control/localization/mounting/state/state_mapping.py
+++ b/oasis_control/oasis_control/localization/mounting/state/state_mapping.py
@@ -7,3 +7,182 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+"""State vector block layout for mounting calibration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from oasis_control.localization.mounting.state.mounting_state import MountingState
+
+
+# Block name for IMU-to-body rotation increment
+BLOCK_NAME_R_BI: str = "R_BI"
+
+# Block name for magnetometer-to-body rotation increment
+BLOCK_NAME_R_BM: str = "R_BM"
+
+# Block name for gravity direction increment
+BLOCK_NAME_G_W: str = "g_W"
+
+# Block name for magnetic direction increment
+BLOCK_NAME_M_W: str = "m_W"
+
+# Block name for accelerometer bias increment
+BLOCK_NAME_B_A: str = "b_a"
+
+# Block name for accelerometer scale/misalignment increment
+BLOCK_NAME_A_A: str = "A_a"
+
+# Block name for gyroscope bias increment
+BLOCK_NAME_B_G: str = "b_g"
+
+# Block name for magnetometer bias increment
+BLOCK_NAME_B_M: str = "b_m"
+
+# Block name for IMU translation increment
+BLOCK_NAME_P_BI: str = "p_BI"
+
+# Block name for magnetometer translation increment
+BLOCK_NAME_P_BM: str = "p_BM"
+
+# Prefix for keyframe attitude block names
+BLOCK_NAME_R_WB_PREFIX: str = "R_WB"
+
+
+class StateMappingError(Exception):
+    """Raised when state mapping construction is invalid."""
+
+
+@dataclass(frozen=True)
+class StateBlock:
+    """Represents a named block in the parameter vector.
+
+    Attributes:
+        name: Block name identifier
+        start: Starting index in the parameter vector
+        dim: Block dimension
+    """
+
+    name: str
+    start: int
+    dim: int
+
+    def stop(self) -> int:
+        """Return the exclusive stop index for the block."""
+        return self.start + self.dim
+
+    def sl(self) -> slice:
+        """Return the slice covering the block indices."""
+        return slice(self.start, self.stop())
+
+    def validate(self) -> None:
+        """Validate block indices and dimensions."""
+        if not self.name:
+            raise StateMappingError("Block name must be non-empty")
+        if self.start < 0:
+            raise StateMappingError("Block start must be non-negative")
+        if self.dim <= 0:
+            raise StateMappingError("Block dim must be positive")
+
+
+@dataclass(frozen=True)
+class StateMapping:
+    """Deterministic block layout for solver state vectors."""
+
+    _blocks: tuple[StateBlock, ...]
+    _keyframe_ids: tuple[int, ...]
+
+    @classmethod
+    def from_state(
+        cls,
+        state: MountingState,
+        *,
+        include_translation_vars: bool,
+    ) -> StateMapping:
+        """Construct a state mapping from a mounting state."""
+        if not isinstance(state, MountingState):
+            raise StateMappingError("state must be a MountingState")
+        blocks: list[StateBlock] = []
+        offset: int = 0
+
+        def _add_block(name: str, dim: int) -> None:
+            nonlocal offset
+            block: StateBlock = StateBlock(name=name, start=offset, dim=dim)
+            block.validate()
+            blocks.append(block)
+            offset += dim
+
+        _add_block(BLOCK_NAME_R_BI, 3)
+        _add_block(BLOCK_NAME_R_BM, 3)
+        _add_block(BLOCK_NAME_G_W, 3)
+        if state.m_W_unit is not None:
+            _add_block(BLOCK_NAME_M_W, 3)
+        _add_block(BLOCK_NAME_B_A, 3)
+        _add_block(BLOCK_NAME_A_A, 9)
+        _add_block(BLOCK_NAME_B_G, 3)
+        if state.mag.b_m_T is not None:
+            _add_block(BLOCK_NAME_B_M, 3)
+        if include_translation_vars:
+            _add_block(BLOCK_NAME_P_BI, 3)
+            _add_block(BLOCK_NAME_P_BM, 3)
+        keyframe_ids: tuple[int, ...] = state.keyframe_ids()
+        for keyframe_id in keyframe_ids:
+            _add_block(f"{BLOCK_NAME_R_WB_PREFIX}_{keyframe_id}", 3)
+        mapping: StateMapping = cls(
+            _blocks=tuple(blocks),
+            _keyframe_ids=keyframe_ids,
+        )
+        mapping.validate()
+        return mapping
+
+    def dim(self) -> int:
+        """Return the total dimension of the parameter vector."""
+        if not self._blocks:
+            return 0
+        return self._blocks[-1].stop()
+
+    def blocks(self) -> tuple[StateBlock, ...]:
+        """Return the blocks in deterministic order."""
+        return self._blocks
+
+    def block(self, name: str) -> StateBlock:
+        """Return the block with the given name."""
+        for block in self._blocks:
+            if block.name == name:
+                return block
+        raise StateMappingError(f"Block {name} not found")
+
+    def has(self, name: str) -> bool:
+        """Return True when the mapping contains the named block."""
+        return any(block.name == name for block in self._blocks)
+
+    def keyframe_block(self, keyframe_id: int) -> StateBlock:
+        """Return the block for a keyframe attitude."""
+        name: str = f"{BLOCK_NAME_R_WB_PREFIX}_{keyframe_id}"
+        return self.block(name)
+
+    def validate(self) -> None:
+        """Validate the layout and keyframe ordering."""
+        offset: int = 0
+        for block in self._blocks:
+            block.validate()
+            if block.start != offset:
+                raise StateMappingError("Blocks must be contiguous")
+            offset = block.stop()
+        if self._blocks and offset != self.dim():
+            raise StateMappingError("Block layout does not match dimension")
+        keyframe_blocks: list[str] = [
+            block.name
+            for block in self._blocks
+            if block.name.startswith(f"{BLOCK_NAME_R_WB_PREFIX}_")
+        ]
+        expected: list[str] = [
+            f"{BLOCK_NAME_R_WB_PREFIX}_{keyframe_id}"
+            for keyframe_id in self._keyframe_ids
+        ]
+        if keyframe_blocks != expected:
+            raise StateMappingError("Keyframe blocks do not match state order")
+        if len(set(self._keyframe_ids)) != len(self._keyframe_ids):
+            raise StateMappingError("Keyframe ids must be unique")

--- a/oasis_control/oasis_control/localization/mounting/state/state_mapping.py
+++ b/oasis_control/oasis_control/localization/mounting/state/state_mapping.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/oasis_control/localization/mounting/storage/persistence.py
+++ b/oasis_control/oasis_control/localization/mounting/storage/persistence.py
@@ -7,3 +7,70 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+"""Persistence helpers for mounting calibration YAML snapshots."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from oasis_control.localization.mounting.storage.yaml_format import MountingSnapshotYaml
+from oasis_control.localization.mounting.storage.yaml_format import MountingYamlError
+from oasis_control.localization.mounting.storage.yaml_format import dumps_yaml
+from oasis_control.localization.mounting.storage.yaml_format import loads_yaml
+
+
+class MountingPersistenceError(Exception):
+    """Raised when loading or saving mounting calibration files fails."""
+
+
+def is_yaml_path(path: str | os.PathLike[str]) -> bool:
+    """Return True if the path has a YAML extension."""
+    suffix: str = Path(os.fspath(path)).suffix.lower()
+    return suffix in {".yaml", ".yml"}
+
+
+def save_yaml_snapshot(
+    path: str | os.PathLike[str],
+    snapshot: MountingSnapshotYaml,
+    *,
+    atomic_write: bool = True,
+) -> None:
+    """Save a mounting snapshot to disk as YAML."""
+    if not is_yaml_path(path):
+        raise MountingPersistenceError("Path must end with .yaml or .yml")
+
+    path_obj: Path = Path(os.fspath(path))
+    try:
+        path_obj.parent.mkdir(parents=True, exist_ok=True)
+        text: str = dumps_yaml(snapshot)
+        if atomic_write:
+            tmp_name: str = f".{path_obj.name}.tmp.{os.getpid()}"
+            tmp_path: Path = path_obj.with_name(tmp_name)
+            with tmp_path.open("w", encoding="utf-8") as handle:
+                handle.write(text)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(tmp_path, path_obj)
+        else:
+            path_obj.write_text(text, encoding="utf-8")
+    except (OSError, MountingYamlError) as exc:
+        raise MountingPersistenceError(
+            f"Failed to save YAML snapshot to {path_obj}"
+        ) from exc
+
+
+def load_yaml_snapshot(path: str | os.PathLike[str]) -> MountingSnapshotYaml:
+    """Load a mounting snapshot from a YAML file."""
+    if not is_yaml_path(path):
+        raise MountingPersistenceError("Path must end with .yaml or .yml")
+
+    path_obj: Path = Path(os.fspath(path))
+    try:
+        text: str = path_obj.read_text(encoding="utf-8")
+        return loads_yaml(text)
+    except (OSError, MountingYamlError) as exc:
+        raise MountingPersistenceError(
+            f"Failed to load YAML snapshot from {path_obj}"
+        ) from exc

--- a/oasis_control/oasis_control/localization/mounting/storage/persistence.py
+++ b/oasis_control/oasis_control/localization/mounting/storage/persistence.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/oasis_control/localization/mounting/storage/yaml_format.py
+++ b/oasis_control/oasis_control/localization/mounting/storage/yaml_format.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/oasis_control/localization/mounting/storage/yaml_format.py
+++ b/oasis_control/oasis_control/localization/mounting/storage/yaml_format.py
@@ -7,3 +7,760 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+"""YAML schema utilities for mounting calibration snapshots."""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import numbers
+from dataclasses import dataclass
+from typing import Any
+from typing import cast
+
+import numpy as np
+
+
+_yaml_spec: importlib.machinery.ModuleSpec | None = importlib.util.find_spec("yaml")
+_yaml: Any
+if _yaml_spec is not None:
+    import yaml as _yaml
+else:
+    _yaml = None
+
+yaml: Any = _yaml
+
+
+class MountingYamlError(Exception):
+    """Raised when the mounting YAML schema is invalid."""
+
+
+@dataclass(frozen=True)
+class FramesYaml:
+    """Frame identifiers used by the calibration snapshot.
+
+    Attributes:
+        base_frame: Body frame id for the robot
+        imu_frame: IMU sensor frame id
+        mag_frame: Magnetometer sensor frame id
+    """
+
+    base_frame: str
+    imu_frame: str
+    mag_frame: str
+
+    def __post_init__(self) -> None:
+        """Validate frame identifiers."""
+        object.__setattr__(
+            self, "base_frame", _require_str(self.base_frame, "base_frame")
+        )
+        object.__setattr__(self, "imu_frame", _require_str(self.imu_frame, "imu_frame"))
+        object.__setattr__(self, "mag_frame", _require_str(self.mag_frame, "mag_frame"))
+
+
+@dataclass(frozen=True)
+class FlagsYaml:
+    """Boolean state flags captured with the snapshot.
+
+    Attributes:
+        anchored: Whether the mount estimate is anchored to priors
+        mag_reference_invalid: Whether the mag reference is invalid
+        mag_disturbance_detected: Whether mag disturbances were detected
+        mag_dir_prior_from_driver_cov: Whether mag direction prior uses driver
+            covariance
+    """
+
+    anchored: bool
+    mag_reference_invalid: bool
+    mag_disturbance_detected: bool
+    mag_dir_prior_from_driver_cov: bool
+
+    def __post_init__(self) -> None:
+        """Validate flag values."""
+        object.__setattr__(self, "anchored", _require_bool(self.anchored, "anchored"))
+        object.__setattr__(
+            self,
+            "mag_reference_invalid",
+            _require_bool(self.mag_reference_invalid, "mag_reference_invalid"),
+        )
+        object.__setattr__(
+            self,
+            "mag_disturbance_detected",
+            _require_bool(self.mag_disturbance_detected, "mag_disturbance_detected"),
+        )
+        object.__setattr__(
+            self,
+            "mag_dir_prior_from_driver_cov",
+            _require_bool(
+                self.mag_dir_prior_from_driver_cov, "mag_dir_prior_from_driver_cov"
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class TransformYaml:
+    """Rigid-body transform from a sensor frame into the body frame.
+
+    Attributes:
+        translation_m: Translation in meters, ordered [x, y, z]
+        quaternion_wxyz: Unit quaternion in [w, x, y, z] order
+        rot_cov_rad2: 3x3 rotation covariance in tangent space, rad^2
+    """
+
+    translation_m: np.ndarray
+    quaternion_wxyz: np.ndarray
+    rot_cov_rad2: np.ndarray
+
+    def __post_init__(self) -> None:
+        """Coerce array types and validate shapes."""
+        translation: np.ndarray = _coerce_array(
+            self.translation_m, "translation_m", (3,)
+        )
+        quaternion: np.ndarray = _coerce_array(
+            self.quaternion_wxyz, "quaternion_wxyz", (4,)
+        )
+        rot_cov: np.ndarray = _coerce_array(self.rot_cov_rad2, "rot_cov_rad2", (3, 3))
+        object.__setattr__(self, "translation_m", translation)
+        object.__setattr__(self, "quaternion_wxyz", quaternion)
+        object.__setattr__(self, "rot_cov_rad2", rot_cov)
+
+
+@dataclass(frozen=True)
+class ImuNuisanceYaml:
+    """IMU nuisance parameters and uncertainty.
+
+    Attributes:
+        accel_bias_mps2: Accelerometer bias in m/s^2
+        accel_A_row_major: Accelerometer scale matrix A_a, row-major 3x3
+        accel_param_cov_row_major_12x12: 12x12 accel parameter covariance
+        gyro_bias_rads: Gyro bias in rad/s
+        gyro_bias_cov_row_major_3x3: 3x3 gyro bias covariance, row-major
+    """
+
+    accel_bias_mps2: np.ndarray
+    accel_A_row_major: np.ndarray
+    accel_param_cov_row_major_12x12: np.ndarray
+    gyro_bias_rads: np.ndarray
+    gyro_bias_cov_row_major_3x3: np.ndarray
+
+    def __post_init__(self) -> None:
+        """Coerce array types and validate shapes."""
+        accel_bias: np.ndarray = _coerce_array(
+            self.accel_bias_mps2, "accel_bias_mps2", (3,)
+        )
+        accel_a: np.ndarray = _coerce_array(
+            self.accel_A_row_major, "accel_A_row_major", (9,)
+        )
+        accel_cov: np.ndarray = _coerce_array(
+            self.accel_param_cov_row_major_12x12,
+            "accel_param_cov_row_major_12x12",
+            (144,),
+        )
+        gyro_bias: np.ndarray = _coerce_array(
+            self.gyro_bias_rads, "gyro_bias_rads", (3,)
+        )
+        gyro_cov: np.ndarray = _coerce_array(
+            self.gyro_bias_cov_row_major_3x3, "gyro_bias_cov_row_major_3x3", (9,)
+        )
+        object.__setattr__(self, "accel_bias_mps2", accel_bias)
+        object.__setattr__(self, "accel_A_row_major", accel_a)
+        object.__setattr__(self, "accel_param_cov_row_major_12x12", accel_cov)
+        object.__setattr__(self, "gyro_bias_rads", gyro_bias)
+        object.__setattr__(self, "gyro_bias_cov_row_major_3x3", gyro_cov)
+
+
+@dataclass(frozen=True)
+class MagNuisanceYaml:
+    """Magnetometer nuisance parameters and uncertainty.
+
+    Attributes:
+        offset_t: Magnetometer offset in tesla
+        offset_cov_row_major_3x3: 3x3 offset covariance, row-major
+        R_m_unitless2_row_major_3x3: Current mag direction noise, unitless^2
+        R_m0_unitless2_row_major_3x3: Initial mag direction noise, unitless^2
+    """
+
+    offset_t: np.ndarray
+    offset_cov_row_major_3x3: np.ndarray
+    R_m_unitless2_row_major_3x3: np.ndarray
+    R_m0_unitless2_row_major_3x3: np.ndarray
+
+    def __post_init__(self) -> None:
+        """Coerce array types and validate shapes."""
+        offset: np.ndarray = _coerce_array(self.offset_t, "offset_t", (3,))
+        offset_cov: np.ndarray = _coerce_array(
+            self.offset_cov_row_major_3x3, "offset_cov_row_major_3x3", (9,)
+        )
+        r_m: np.ndarray = _coerce_array(
+            self.R_m_unitless2_row_major_3x3,
+            "R_m_unitless2_row_major_3x3",
+            (9,),
+        )
+        r_m0: np.ndarray = _coerce_array(
+            self.R_m0_unitless2_row_major_3x3,
+            "R_m0_unitless2_row_major_3x3",
+            (9,),
+        )
+        object.__setattr__(self, "offset_t", offset)
+        object.__setattr__(self, "offset_cov_row_major_3x3", offset_cov)
+        object.__setattr__(self, "R_m_unitless2_row_major_3x3", r_m)
+        object.__setattr__(self, "R_m0_unitless2_row_major_3x3", r_m0)
+
+
+@dataclass(frozen=True)
+class DiversityYaml:
+    """Diversity metrics for the calibration dataset.
+
+    Attributes:
+        gravity_max_angle_deg: Max gravity direction span, degrees
+        mag_proj_max_angle_deg: Max mag projection span, degrees
+    """
+
+    gravity_max_angle_deg: float
+    mag_proj_max_angle_deg: float
+
+    def __post_init__(self) -> None:
+        """Validate diversity values."""
+        object.__setattr__(
+            self,
+            "gravity_max_angle_deg",
+            _require_float(self.gravity_max_angle_deg, "gravity_max_angle_deg"),
+        )
+        object.__setattr__(
+            self,
+            "mag_proj_max_angle_deg",
+            _require_float(self.mag_proj_max_angle_deg, "mag_proj_max_angle_deg"),
+        )
+
+
+@dataclass(frozen=True)
+class QualityYaml:
+    """Quality metrics for the calibration snapshot.
+
+    Attributes:
+        raw_samples: Raw samples ingested
+        steady_segments: Steady segments accepted
+        keyframes: Keyframes retained
+        total_duration_sec: Total duration used, seconds
+        accel_residual_rms: Accel direction residual RMS
+        mag_residual_rms: Mag direction residual RMS
+        diversity: Diversity metrics for conditioning
+    """
+
+    raw_samples: int
+    steady_segments: int
+    keyframes: int
+    total_duration_sec: float
+    accel_residual_rms: float
+    mag_residual_rms: float
+    diversity: DiversityYaml
+
+    def __post_init__(self) -> None:
+        """Validate quality metrics."""
+        object.__setattr__(
+            self, "raw_samples", _require_int(self.raw_samples, "raw_samples")
+        )
+        object.__setattr__(
+            self,
+            "steady_segments",
+            _require_int(self.steady_segments, "steady_segments"),
+        )
+        object.__setattr__(self, "keyframes", _require_int(self.keyframes, "keyframes"))
+        object.__setattr__(
+            self,
+            "total_duration_sec",
+            _require_float(self.total_duration_sec, "total_duration_sec"),
+        )
+        object.__setattr__(
+            self,
+            "accel_residual_rms",
+            _require_float(self.accel_residual_rms, "accel_residual_rms"),
+        )
+        object.__setattr__(
+            self,
+            "mag_residual_rms",
+            _require_float(self.mag_residual_rms, "mag_residual_rms"),
+        )
+        object.__setattr__(self, "diversity", _require_diversity(self.diversity))
+
+
+@dataclass(frozen=True)
+class MountingSnapshotYaml:
+    """Top-level mounting calibration snapshot as persisted to YAML.
+
+    Attributes:
+        format_version: Snapshot format version, must be 1
+        frames: Frame identifiers for body, IMU, and mag
+        flags: Boolean flags describing solver state
+        T_BI: IMU-to-body transform
+        T_BM: Magnetometer-to-body transform
+        imu: IMU nuisance parameters
+        mag: Magnetometer nuisance parameters
+        quality: Quality metadata
+    """
+
+    format_version: int
+    frames: FramesYaml
+    flags: FlagsYaml
+    T_BI: TransformYaml
+    T_BM: TransformYaml
+    imu: ImuNuisanceYaml
+    mag: MagNuisanceYaml
+    quality: QualityYaml
+
+    def __post_init__(self) -> None:
+        """Validate snapshot components and version."""
+        object.__setattr__(
+            self, "format_version", _require_int(self.format_version, "format_version")
+        )
+        if self.format_version != 1:
+            raise MountingYamlError("format_version must be 1")
+        object.__setattr__(self, "frames", _require_frames(self.frames))
+        object.__setattr__(self, "flags", _require_flags(self.flags))
+        object.__setattr__(self, "T_BI", _require_transform(self.T_BI, "T_BI"))
+        object.__setattr__(self, "T_BM", _require_transform(self.T_BM, "T_BM"))
+        object.__setattr__(self, "imu", _require_imu(self.imu))
+        object.__setattr__(self, "mag", _require_mag(self.mag))
+        object.__setattr__(self, "quality", _require_quality(self.quality))
+
+
+def snapshot_to_dict(snapshot: MountingSnapshotYaml) -> dict[str, object]:
+    """Convert a snapshot to a YAML-safe dictionary."""
+    mounts: dict[str, object] = {
+        "T_BI": _transform_to_dict(snapshot.T_BI),
+        "T_BM": _transform_to_dict(snapshot.T_BM),
+    }
+    nuisance: dict[str, object] = {
+        "imu": _imu_to_dict(snapshot.imu),
+        "mag": _mag_to_dict(snapshot.mag),
+    }
+    data: dict[str, object] = {
+        "format_version": snapshot.format_version,
+        "frames": {
+            "base_frame": snapshot.frames.base_frame,
+            "imu_frame": snapshot.frames.imu_frame,
+            "mag_frame": snapshot.frames.mag_frame,
+        },
+        "flags": {
+            "anchored": snapshot.flags.anchored,
+            "mag_reference_invalid": snapshot.flags.mag_reference_invalid,
+            "mag_disturbance_detected": snapshot.flags.mag_disturbance_detected,
+            "mag_dir_prior_from_driver_cov": snapshot.flags.mag_dir_prior_from_driver_cov,
+        },
+        "mounts": mounts,
+        "nuisance": nuisance,
+        "quality": {
+            "raw_samples": snapshot.quality.raw_samples,
+            "steady_segments": snapshot.quality.steady_segments,
+            "keyframes": snapshot.quality.keyframes,
+            "total_duration_sec": snapshot.quality.total_duration_sec,
+            "accel_residual_rms": snapshot.quality.accel_residual_rms,
+            "mag_residual_rms": snapshot.quality.mag_residual_rms,
+            "diversity": {
+                "gravity_max_angle_deg": snapshot.quality.diversity.gravity_max_angle_deg,
+                "mag_proj_max_angle_deg": snapshot.quality.diversity.mag_proj_max_angle_deg,
+            },
+        },
+    }
+    return data
+
+
+def snapshot_from_dict(data: dict[str, object]) -> MountingSnapshotYaml:
+    """Parse a YAML dictionary into a snapshot."""
+    if not isinstance(data, dict):
+        raise MountingYamlError("YAML root must be a mapping")
+    _require_keys(
+        "root",
+        data,
+        {"format_version", "frames", "flags", "mounts", "nuisance", "quality"},
+    )
+
+    format_version: int = _require_int(data["format_version"], "format_version")
+    frames: FramesYaml = _frames_from_dict(_require_mapping(data["frames"], "frames"))
+    flags: FlagsYaml = _flags_from_dict(_require_mapping(data["flags"], "flags"))
+    mounts_data: dict[str, object] = _require_mapping(data["mounts"], "mounts")
+    _require_keys("mounts", mounts_data, {"T_BI", "T_BM"})
+    t_bi: TransformYaml = _transform_from_dict(
+        _require_mapping(mounts_data["T_BI"], "mounts.T_BI"),
+        "mounts.T_BI",
+    )
+    t_bm: TransformYaml = _transform_from_dict(
+        _require_mapping(mounts_data["T_BM"], "mounts.T_BM"),
+        "mounts.T_BM",
+    )
+    nuisance_data: dict[str, object] = _require_mapping(data["nuisance"], "nuisance")
+    _require_keys("nuisance", nuisance_data, {"imu", "mag"})
+    imu: ImuNuisanceYaml = _imu_from_dict(
+        _require_mapping(nuisance_data["imu"], "nuisance.imu")
+    )
+    mag: MagNuisanceYaml = _mag_from_dict(
+        _require_mapping(nuisance_data["mag"], "nuisance.mag")
+    )
+    quality: QualityYaml = _quality_from_dict(
+        _require_mapping(data["quality"], "quality")
+    )
+
+    return MountingSnapshotYaml(
+        format_version=format_version,
+        frames=frames,
+        flags=flags,
+        T_BI=t_bi,
+        T_BM=t_bm,
+        imu=imu,
+        mag=mag,
+        quality=quality,
+    )
+
+
+def dumps_yaml(snapshot: MountingSnapshotYaml) -> str:
+    """Serialize a snapshot to deterministic YAML."""
+    if yaml is None:
+        raise MountingYamlError("PyYAML is required for serialization")
+
+    data: dict[str, object] = snapshot_to_dict(snapshot)
+    safe_dump: Any = cast(Any, yaml.safe_dump)
+    return safe_dump(
+        data,
+        sort_keys=False,
+        indent=2,
+        default_flow_style=False,
+    )
+
+
+def loads_yaml(text: str) -> MountingSnapshotYaml:
+    """Parse a snapshot from YAML text."""
+    if yaml is None:
+        raise MountingYamlError("PyYAML is required for parsing")
+    loaded: Any = yaml.safe_load(text)
+    if not isinstance(loaded, dict):
+        raise MountingYamlError("YAML root must be a mapping")
+    return snapshot_from_dict(loaded)
+
+
+def _require_keys(scope: str, data: dict[str, object], required: set[str]) -> None:
+    """Ensure a mapping has exactly the required keys."""
+    unknown: set[str] = {key for key in data.keys() if key not in required}
+    if unknown:
+        raise MountingYamlError(
+            f"Unexpected keys in {scope}: {', '.join(sorted(unknown))}"
+        )
+    missing: set[str] = {key for key in required if key not in data}
+    if missing:
+        raise MountingYamlError(
+            f"Missing keys in {scope}: {', '.join(sorted(missing))}"
+        )
+
+
+def _require_mapping(value: object, name: str) -> dict[str, object]:
+    """Ensure the value is a dictionary."""
+    if not isinstance(value, dict):
+        raise MountingYamlError(f"{name} must be a mapping")
+    return value
+
+
+def _require_str(value: object, name: str) -> str:
+    """Ensure the value is a string."""
+    if not isinstance(value, str):
+        raise MountingYamlError(f"{name} must be a string")
+    return value
+
+
+def _require_bool(value: object, name: str) -> bool:
+    """Ensure the value is a boolean."""
+    if not isinstance(value, bool):
+        raise MountingYamlError(f"{name} must be a boolean")
+    return value
+
+
+def _require_int(value: object, name: str) -> int:
+    """Ensure the value is an integer."""
+    if isinstance(value, bool) or not isinstance(value, numbers.Integral):
+        raise MountingYamlError(f"{name} must be an integer")
+    return int(value)
+
+
+def _require_float(value: object, name: str) -> float:
+    """Ensure the value is a float."""
+    if isinstance(value, bool) or not isinstance(value, numbers.Real):
+        raise MountingYamlError(f"{name} must be a float")
+    return float(value)
+
+
+def _coerce_array(value: object, name: str, shape: tuple[int, ...]) -> np.ndarray:
+    """Convert an input to a numpy array with the required shape."""
+    try:
+        array: np.ndarray = np.asarray(value, dtype=np.float64)
+    except (TypeError, ValueError) as exc:
+        raise MountingYamlError(f"{name} must be numeric") from exc
+    if array.shape != shape:
+        raise MountingYamlError(f"{name} must have shape {shape}")
+    return array
+
+
+def _require_frames(value: FramesYaml) -> FramesYaml:
+    """Ensure the value is a FramesYaml instance."""
+    if not isinstance(value, FramesYaml):
+        raise MountingYamlError("frames must be FramesYaml")
+    return value
+
+
+def _require_flags(value: FlagsYaml) -> FlagsYaml:
+    """Ensure the value is a FlagsYaml instance."""
+    if not isinstance(value, FlagsYaml):
+        raise MountingYamlError("flags must be FlagsYaml")
+    return value
+
+
+def _require_transform(value: TransformYaml, name: str) -> TransformYaml:
+    """Ensure the value is a TransformYaml instance."""
+    if not isinstance(value, TransformYaml):
+        raise MountingYamlError(f"{name} must be TransformYaml")
+    return value
+
+
+def _require_imu(value: ImuNuisanceYaml) -> ImuNuisanceYaml:
+    """Ensure the value is an ImuNuisanceYaml instance."""
+    if not isinstance(value, ImuNuisanceYaml):
+        raise MountingYamlError("imu must be ImuNuisanceYaml")
+    return value
+
+
+def _require_mag(value: MagNuisanceYaml) -> MagNuisanceYaml:
+    """Ensure the value is a MagNuisanceYaml instance."""
+    if not isinstance(value, MagNuisanceYaml):
+        raise MountingYamlError("mag must be MagNuisanceYaml")
+    return value
+
+
+def _require_quality(value: QualityYaml) -> QualityYaml:
+    """Ensure the value is a QualityYaml instance."""
+    if not isinstance(value, QualityYaml):
+        raise MountingYamlError("quality must be QualityYaml")
+    return value
+
+
+def _require_diversity(value: DiversityYaml) -> DiversityYaml:
+    """Ensure the value is a DiversityYaml instance."""
+    if not isinstance(value, DiversityYaml):
+        raise MountingYamlError("diversity must be DiversityYaml")
+    return value
+
+
+def _frames_from_dict(data: dict[str, object]) -> FramesYaml:
+    """Parse frames from a dictionary."""
+    _require_keys("frames", data, {"base_frame", "imu_frame", "mag_frame"})
+    return FramesYaml(
+        base_frame=_require_str(data["base_frame"], "frames.base_frame"),
+        imu_frame=_require_str(data["imu_frame"], "frames.imu_frame"),
+        mag_frame=_require_str(data["mag_frame"], "frames.mag_frame"),
+    )
+
+
+def _flags_from_dict(data: dict[str, object]) -> FlagsYaml:
+    """Parse flags from a dictionary."""
+    _require_keys(
+        "flags",
+        data,
+        {
+            "anchored",
+            "mag_reference_invalid",
+            "mag_disturbance_detected",
+            "mag_dir_prior_from_driver_cov",
+        },
+    )
+    return FlagsYaml(
+        anchored=_require_bool(data["anchored"], "flags.anchored"),
+        mag_reference_invalid=_require_bool(
+            data["mag_reference_invalid"], "flags.mag_reference_invalid"
+        ),
+        mag_disturbance_detected=_require_bool(
+            data["mag_disturbance_detected"], "flags.mag_disturbance_detected"
+        ),
+        mag_dir_prior_from_driver_cov=_require_bool(
+            data["mag_dir_prior_from_driver_cov"],
+            "flags.mag_dir_prior_from_driver_cov",
+        ),
+    )
+
+
+def _transform_from_dict(data: dict[str, object], scope: str) -> TransformYaml:
+    """Parse a transform from a dictionary."""
+    _require_keys(scope, data, {"translation_m", "quaternion_wxyz", "rot_cov_rad2"})
+    translation: np.ndarray = _coerce_array(
+        data["translation_m"], f"{scope}.translation_m", (3,)
+    )
+    quaternion: np.ndarray = _coerce_array(
+        data["quaternion_wxyz"], f"{scope}.quaternion_wxyz", (4,)
+    )
+    rot_cov: np.ndarray = _coerce_array(
+        data["rot_cov_rad2"], f"{scope}.rot_cov_rad2", (3, 3)
+    )
+    return TransformYaml(
+        translation_m=translation,
+        quaternion_wxyz=quaternion,
+        rot_cov_rad2=rot_cov,
+    )
+
+
+def _imu_from_dict(data: dict[str, object]) -> ImuNuisanceYaml:
+    """Parse IMU nuisance data from a dictionary."""
+    _require_keys(
+        "nuisance.imu",
+        data,
+        {
+            "accel_bias_mps2",
+            "accel_A_row_major",
+            "accel_param_cov_row_major_12x12",
+            "gyro_bias_rads",
+            "gyro_bias_cov_row_major_3x3",
+        },
+    )
+    accel_bias: np.ndarray = _coerce_array(
+        data["accel_bias_mps2"], "nuisance.imu.accel_bias_mps2", (3,)
+    )
+    accel_a: np.ndarray = _coerce_array(
+        data["accel_A_row_major"], "nuisance.imu.accel_A_row_major", (9,)
+    )
+    accel_cov: np.ndarray = _coerce_array(
+        data["accel_param_cov_row_major_12x12"],
+        "nuisance.imu.accel_param_cov_row_major_12x12",
+        (144,),
+    )
+    gyro_bias: np.ndarray = _coerce_array(
+        data["gyro_bias_rads"], "nuisance.imu.gyro_bias_rads", (3,)
+    )
+    gyro_cov: np.ndarray = _coerce_array(
+        data["gyro_bias_cov_row_major_3x3"],
+        "nuisance.imu.gyro_bias_cov_row_major_3x3",
+        (9,),
+    )
+    return ImuNuisanceYaml(
+        accel_bias_mps2=accel_bias,
+        accel_A_row_major=accel_a,
+        accel_param_cov_row_major_12x12=accel_cov,
+        gyro_bias_rads=gyro_bias,
+        gyro_bias_cov_row_major_3x3=gyro_cov,
+    )
+
+
+def _mag_from_dict(data: dict[str, object]) -> MagNuisanceYaml:
+    """Parse magnetometer nuisance data from a dictionary."""
+    _require_keys(
+        "nuisance.mag",
+        data,
+        {
+            "offset_t",
+            "offset_cov_row_major_3x3",
+            "R_m_unitless2_row_major_3x3",
+            "R_m0_unitless2_row_major_3x3",
+        },
+    )
+    offset_t: np.ndarray = _coerce_array(
+        data["offset_t"], "nuisance.mag.offset_t", (3,)
+    )
+    offset_cov: np.ndarray = _coerce_array(
+        data["offset_cov_row_major_3x3"],
+        "nuisance.mag.offset_cov_row_major_3x3",
+        (9,),
+    )
+    r_m: np.ndarray = _coerce_array(
+        data["R_m_unitless2_row_major_3x3"],
+        "nuisance.mag.R_m_unitless2_row_major_3x3",
+        (9,),
+    )
+    r_m0: np.ndarray = _coerce_array(
+        data["R_m0_unitless2_row_major_3x3"],
+        "nuisance.mag.R_m0_unitless2_row_major_3x3",
+        (9,),
+    )
+    return MagNuisanceYaml(
+        offset_t=offset_t,
+        offset_cov_row_major_3x3=offset_cov,
+        R_m_unitless2_row_major_3x3=r_m,
+        R_m0_unitless2_row_major_3x3=r_m0,
+    )
+
+
+def _quality_from_dict(data: dict[str, object]) -> QualityYaml:
+    """Parse quality data from a dictionary."""
+    _require_keys(
+        "quality",
+        data,
+        {
+            "raw_samples",
+            "steady_segments",
+            "keyframes",
+            "total_duration_sec",
+            "accel_residual_rms",
+            "mag_residual_rms",
+            "diversity",
+        },
+    )
+    diversity: DiversityYaml = _diversity_from_dict(
+        _require_mapping(data["diversity"], "quality.diversity")
+    )
+    return QualityYaml(
+        raw_samples=_require_int(data["raw_samples"], "quality.raw_samples"),
+        steady_segments=_require_int(
+            data["steady_segments"], "quality.steady_segments"
+        ),
+        keyframes=_require_int(data["keyframes"], "quality.keyframes"),
+        total_duration_sec=_require_float(
+            data["total_duration_sec"], "quality.total_duration_sec"
+        ),
+        accel_residual_rms=_require_float(
+            data["accel_residual_rms"], "quality.accel_residual_rms"
+        ),
+        mag_residual_rms=_require_float(
+            data["mag_residual_rms"], "quality.mag_residual_rms"
+        ),
+        diversity=diversity,
+    )
+
+
+def _diversity_from_dict(data: dict[str, object]) -> DiversityYaml:
+    """Parse diversity metrics from a dictionary."""
+    _require_keys(
+        "quality.diversity",
+        data,
+        {"gravity_max_angle_deg", "mag_proj_max_angle_deg"},
+    )
+    return DiversityYaml(
+        gravity_max_angle_deg=_require_float(
+            data["gravity_max_angle_deg"], "quality.diversity.gravity_max_angle_deg"
+        ),
+        mag_proj_max_angle_deg=_require_float(
+            data["mag_proj_max_angle_deg"], "quality.diversity.mag_proj_max_angle_deg"
+        ),
+    )
+
+
+def _transform_to_dict(transform: TransformYaml) -> dict[str, object]:
+    """Convert a transform to a YAML-safe dictionary."""
+    return {
+        "translation_m": transform.translation_m.tolist(),
+        "quaternion_wxyz": transform.quaternion_wxyz.tolist(),
+        "rot_cov_rad2": transform.rot_cov_rad2.tolist(),
+    }
+
+
+def _imu_to_dict(imu: ImuNuisanceYaml) -> dict[str, object]:
+    """Convert IMU nuisance data to a YAML-safe dictionary."""
+    return {
+        "accel_bias_mps2": imu.accel_bias_mps2.tolist(),
+        "accel_A_row_major": imu.accel_A_row_major.tolist(),
+        "accel_param_cov_row_major_12x12": imu.accel_param_cov_row_major_12x12.tolist(),
+        "gyro_bias_rads": imu.gyro_bias_rads.tolist(),
+        "gyro_bias_cov_row_major_3x3": imu.gyro_bias_cov_row_major_3x3.tolist(),
+    }
+
+
+def _mag_to_dict(mag: MagNuisanceYaml) -> dict[str, object]:
+    """Convert magnetometer nuisance data to a YAML-safe dictionary."""
+    return {
+        "offset_t": mag.offset_t.tolist(),
+        "offset_cov_row_major_3x3": mag.offset_cov_row_major_3x3.tolist(),
+        "R_m_unitless2_row_major_3x3": mag.R_m_unitless2_row_major_3x3.tolist(),
+        "R_m0_unitless2_row_major_3x3": mag.R_m0_unitless2_row_major_3x3.tolist(),
+    }

--- a/oasis_control/oasis_control/localization/mounting/tf/stability.py
+++ b/oasis_control/oasis_control/localization/mounting/tf/stability.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/oasis_control/localization/mounting/tf/tf_publisher.py
+++ b/oasis_control/oasis_control/localization/mounting/tf/tf_publisher.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/oasis_control/localization/mounting/timing/replay_engine.py
+++ b/oasis_control/oasis_control/localization/mounting/timing/replay_engine.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/oasis_control/localization/mounting/timing/ring_buffer.py
+++ b/oasis_control/oasis_control/localization/mounting/timing/ring_buffer.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/oasis_control/localization/mounting/timing/time_base.py
+++ b/oasis_control/oasis_control/localization/mounting/timing/time_base.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/oasis_control/localization/mounting/timing/timeline_node.py
+++ b/oasis_control/oasis_control/localization/mounting/timing/timeline_node.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/oasis_control/nodes/ahrs_mounting_node.py
+++ b/oasis_control/oasis_control/nodes/ahrs_mounting_node.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/test/integration/test_mounting_pipeline.py
+++ b/oasis_control/test/integration/test_mounting_pipeline.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/test/integration/test_mounting_replay_pipeline.py
+++ b/oasis_control/test/integration/test_mounting_replay_pipeline.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/test/integration/test_mounting_stability_to_tf_static.py
+++ b/oasis_control/test/integration/test_mounting_stability_to_tf_static.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/test/mounting/config/test_mounting_config.py
+++ b/oasis_control/test/mounting/config/test_mounting_config.py
@@ -7,3 +7,79 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+"""Tests for mounting configuration wrapper."""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from oasis_control.localization.mounting.config.mounting_config import MountingConfig
+from oasis_control.localization.mounting.config.mounting_config import (
+    MountingConfigError,
+)
+from oasis_control.localization.mounting.config.mounting_params import MountingParams
+
+
+def test_defaults_construct() -> None:
+    """Default parameters should construct a MountingConfig."""
+    params: MountingParams = MountingParams.defaults()
+    MountingConfig(params)
+
+
+def test_invalid_save_format() -> None:
+    """Invalid save.format should raise an error."""
+    params: MountingParams = MountingParams.defaults().replace(
+        save=dataclasses.replace(MountingParams.defaults().save, format="toml")
+    )
+    with pytest.raises(MountingConfigError):
+        MountingConfig(params)
+
+
+def test_invalid_drop_policy() -> None:
+    """Invalid cluster.drop_policy should raise an error."""
+    params: MountingParams = MountingParams.defaults().replace(
+        cluster=dataclasses.replace(
+            MountingParams.defaults().cluster, drop_policy="newest"
+        )
+    )
+    with pytest.raises(MountingConfigError):
+        MountingConfig(params)
+
+
+def test_invalid_window_type() -> None:
+    """Invalid steady.window_type should raise an error."""
+    params: MountingParams = MountingParams.defaults().replace(
+        steady=dataclasses.replace(
+            MountingParams.defaults().steady, window_type="fixed"
+        )
+    )
+    with pytest.raises(MountingConfigError):
+        MountingConfig(params)
+
+
+def test_accessors() -> None:
+    """Accessor methods should return expected values."""
+    params: MountingParams = MountingParams.defaults()
+    config: MountingConfig = MountingConfig(params)
+
+    assert config.base_frame() == params.frames.base_frame
+    assert config.imu_raw_topic() == params.topics.imu_raw
+    assert config.mag_topic() == params.topics.magnetic_field
+    assert config.baseline_enabled() == params.mount.baseline_hard_enabled
+    assert config.baseline_distance_m() == params.mount.baseline_im_to_mag_m
+
+
+def test_baseline_defense_in_depth() -> None:
+    """Baseline constraint should be enforced in MountingConfig too."""
+    params: MountingParams = MountingParams.defaults().replace(
+        mount=dataclasses.replace(
+            MountingParams.defaults().mount,
+            baseline_hard_enabled=True,
+            baseline_im_to_mag_m=None,
+        )
+    )
+    with pytest.raises(MountingConfigError):
+        MountingConfig(params)

--- a/oasis_control/test/mounting/config/test_mounting_config.py
+++ b/oasis_control/test/mounting/config/test_mounting_config.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/test/mounting/config/test_mounting_params.py
+++ b/oasis_control/test/mounting/config/test_mounting_params.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/test/mounting/config/test_mounting_params.py
+++ b/oasis_control/test/mounting/config/test_mounting_params.py
@@ -7,3 +7,161 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+"""Tests for mounting parameter schema."""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import cast
+
+import numpy as np
+import pytest
+
+from oasis_control.localization.mounting.config.mounting_params import BootstrapParams
+from oasis_control.localization.mounting.config.mounting_params import MagParams
+from oasis_control.localization.mounting.config.mounting_params import MountingParams
+from oasis_control.localization.mounting.config.mounting_params import (
+    MountingParamsError,
+)
+from oasis_control.localization.mounting.config.mounting_params import MountParams
+from oasis_control.localization.mounting.config.mounting_params import SaveParams
+from oasis_control.localization.mounting.config.mounting_params import SteadyParams
+
+
+def test_defaults_validate() -> None:
+    """Defaults should validate successfully."""
+    params: MountingParams = MountingParams.defaults()
+    params.validate()
+
+
+def test_numpy_coercion_shapes() -> None:
+    """Array-like inputs should coerce to float64 shape (3,) arrays."""
+    bi_prior: np.ndarray = cast(np.ndarray, [1.0, 2.0, 3.0])
+    bm_prior: np.ndarray = cast(np.ndarray, [4.0, 5.0, 6.0])
+    rm_init: np.ndarray = cast(np.ndarray, [1e-3, 2e-3, 3e-3])
+    rm_min: np.ndarray = cast(np.ndarray, [1e-5, 2e-5, 3e-5])
+    rm_max: np.ndarray = cast(np.ndarray, [1e-1, 2e-1, 3e-1])
+    mount_params: MountParams = MountParams(
+        p_BI_prior_m=bi_prior,
+        p_BM_prior_m=bm_prior,
+        baseline_im_to_mag_m=1.0,
+        baseline_hard_enabled=False,
+    )
+    mag_params: MagParams = MagParams(
+        Rm_init_diag=rm_init,
+        Rm_min_diag=rm_min,
+        Rm_max_diag=rm_max,
+        disturbance_gate_sigma=1.0,
+    )
+    params: MountingParams = MountingParams.defaults().replace(
+        mount=mount_params,
+        mag=mag_params,
+    )
+
+    assert isinstance(params.mount.p_BI_prior_m, np.ndarray)
+    assert params.mount.p_BI_prior_m.shape == (3,)
+    assert isinstance(params.mount.p_BM_prior_m, np.ndarray)
+    assert params.mount.p_BM_prior_m.shape == (3,)
+    assert isinstance(params.mag.Rm_init_diag, np.ndarray)
+    assert params.mag.Rm_init_diag.shape == (3,)
+    assert isinstance(params.mag.Rm_min_diag, np.ndarray)
+    assert params.mag.Rm_min_diag.shape == (3,)
+    assert isinstance(params.mag.Rm_max_diag, np.ndarray)
+    assert params.mag.Rm_max_diag.shape == (3,)
+
+
+def test_baseline_validation() -> None:
+    """Baseline validation should enforce hard constraint rules."""
+    params: MountingParams = MountingParams.defaults()
+
+    enabled_none: MountingParams = params.replace(
+        mount=dataclasses.replace(
+            params.mount,
+            baseline_hard_enabled=True,
+            baseline_im_to_mag_m=None,
+        )
+    )
+    with pytest.raises(MountingParamsError):
+        enabled_none.validate()
+
+    enabled_invalid: MountingParams = params.replace(
+        mount=dataclasses.replace(
+            params.mount,
+            baseline_hard_enabled=True,
+            baseline_im_to_mag_m=0.0,
+        )
+    )
+    with pytest.raises(MountingParamsError):
+        enabled_invalid.validate()
+
+    disabled_none: MountingParams = params.replace(
+        mount=dataclasses.replace(
+            params.mount,
+            baseline_hard_enabled=False,
+            baseline_im_to_mag_m=None,
+        )
+    )
+    disabled_none.validate()
+
+    disabled_invalid: MountingParams = params.replace(
+        mount=dataclasses.replace(
+            params.mount,
+            baseline_hard_enabled=False,
+            baseline_im_to_mag_m=-1.0,
+        )
+    )
+    with pytest.raises(MountingParamsError):
+        disabled_invalid.validate()
+
+
+def test_basic_numeric_validations() -> None:
+    """Numeric validation should reject non-positive values."""
+    params: MountingParams = MountingParams.defaults()
+
+    invalid_bootstrap: MountingParams = params.replace(
+        bootstrap=BootstrapParams(
+            bootstrap_sec=0.0,
+            require_flat_stationary=params.bootstrap.require_flat_stationary,
+            mag_reference_required=params.bootstrap.mag_reference_required,
+        )
+    )
+    with pytest.raises(MountingParamsError):
+        invalid_bootstrap.validate()
+
+    invalid_steady: MountingParams = params.replace(
+        steady=SteadyParams(
+            steady_sec=0.0,
+            window_type=params.steady.window_type,
+        )
+    )
+    with pytest.raises(MountingParamsError):
+        invalid_steady.validate()
+
+    invalid_save: MountingParams = params.replace(
+        save=SaveParams(
+            save_period_sec=0.0,
+            output_path=params.save.output_path,
+            format=params.save.format,
+            atomic_write=params.save.atomic_write,
+        )
+    )
+    with pytest.raises(MountingParamsError):
+        invalid_save.validate()
+
+    invalid_mag: MountingParams = params.replace(
+        mag=dataclasses.replace(params.mag, s_min_T=0.0)
+    )
+    with pytest.raises(MountingParamsError):
+        invalid_mag.validate()
+
+
+def test_replace_helper_immutability() -> None:
+    """Replace should return a new instance without mutating the original."""
+    params: MountingParams = MountingParams.defaults()
+    updated: MountingParams = params.replace(
+        frames=dataclasses.replace(params.frames, base_frame="base")
+    )
+
+    assert params.frames.base_frame == "base_link"
+    assert updated.frames.base_frame == "base"

--- a/oasis_control/test/mounting/io/test_persistence.py
+++ b/oasis_control/test/mounting/io/test_persistence.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/test/mounting/io/test_persistence.py
+++ b/oasis_control/test/mounting/io/test_persistence.py
@@ -1,9 +1,0 @@
-################################################################################
-#
-#  Copyright (C) 2026 Garrett Brown
-#  This file is part of OASIS - https://github.com/eigendude/OASIS
-#
-#  SPDX-License-Identifier: Apache-2.0
-#  See DOCS/LICENSING.md for more information.
-#
-################################################################################

--- a/oasis_control/test/mounting/io/test_yaml_format.py
+++ b/oasis_control/test/mounting/io/test_yaml_format.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/test/mounting/io/test_yaml_format.py
+++ b/oasis_control/test/mounting/io/test_yaml_format.py
@@ -1,9 +1,0 @@
-################################################################################
-#
-#  Copyright (C) 2026 Garrett Brown
-#  This file is part of OASIS - https://github.com/eigendude/OASIS
-#
-#  SPDX-License-Identifier: Apache-2.0
-#  See DOCS/LICENSING.md for more information.
-#
-################################################################################

--- a/oasis_control/test/mounting/math_utils/test_linalg.py
+++ b/oasis_control/test/mounting/math_utils/test_linalg.py
@@ -7,3 +7,58 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+"""Tests for SO(3) linear algebra utilities."""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+from oasis_control.localization.mounting.math_utils.linalg import SO3
+from oasis_control.localization.mounting.math_utils.linalg import Linalg
+
+
+def test_hat_vee_roundtrip() -> None:
+    """Checks hat/vee are inverses."""
+    vec: NDArray[np.float64] = np.array([0.2, -0.1, 0.3], dtype=float)
+    mat: NDArray[np.float64] = SO3.hat(vec)
+    roundtrip: NDArray[np.float64] = SO3.vee(mat)
+    assert np.allclose(roundtrip, vec)
+
+
+def test_exp_log_roundtrip_small() -> None:
+    """Checks exp/log roundtrip for small rotations."""
+    rng: np.random.Generator = np.random.default_rng(0)
+    vec: NDArray[np.float64] = rng.normal(scale=0.05, size=3)
+    R: NDArray[np.float64] = SO3.exp(vec)
+    roundtrip: NDArray[np.float64] = SO3.log(R)
+    assert np.allclose(roundtrip, vec, atol=1e-6)
+
+
+def test_project_to_so3() -> None:
+    """Checks projection to SO(3) restores det=+1."""
+    R: NDArray[np.float64] = SO3.exp(np.array([0.1, 0.2, -0.1], dtype=float))
+    R_noisy: NDArray[np.float64] = R.copy()
+    R_noisy[0, 0] += 0.01
+    R_proj: NDArray[np.float64] = SO3.project_to_so3(R_noisy)
+    det: float = float(np.linalg.det(R_proj))
+    assert np.isclose(det, 1.0)
+    assert np.allclose(R_proj.T @ R_proj, np.eye(3), atol=1e-6)
+
+
+def test_angle_known_rotations() -> None:
+    """Checks rotation angle extraction for a known rotation."""
+    vec: NDArray[np.float64] = np.array([0.0, 0.0, np.pi / 2.0], dtype=float)
+    R: NDArray[np.float64] = SO3.exp(vec)
+    angle: float = SO3.angle(R)
+    assert np.isclose(angle, np.pi / 2.0)
+
+
+def test_block_diag() -> None:
+    """Checks block diagonal assembly sizes."""
+    A: NDArray[np.float64] = np.eye(2, dtype=float)
+    B: NDArray[np.float64] = np.ones((1, 3), dtype=float)
+    result: NDArray[np.float64] = Linalg.block_diag(A, B)
+    assert result.shape == (3, 5)
+    assert np.allclose(result[:2, :2], A)
+    assert np.allclose(result[2:, 2:], B)

--- a/oasis_control/test/mounting/math_utils/test_linalg.py
+++ b/oasis_control/test/mounting/math_utils/test_linalg.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/test/mounting/math_utils/test_quat.py
+++ b/oasis_control/test/mounting/math_utils/test_quat.py
@@ -7,3 +7,57 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+"""Tests for quaternion utilities."""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+from oasis_control.localization.mounting.math_utils.linalg import SO3
+from oasis_control.localization.mounting.math_utils.quat import Quaternion
+
+
+def test_identity_properties() -> None:
+    """Checks identity quaternion properties."""
+    q: Quaternion = Quaternion.identity()
+    mat: NDArray[np.float64] = q.as_matrix()
+    assert np.allclose(mat, np.eye(3))
+
+
+def test_multiplication_inverse() -> None:
+    """Checks quaternion multiplication with inverse returns identity."""
+    q: Quaternion = Quaternion.from_rotvec(np.array([0.2, 0.0, -0.1], dtype=float))
+    identity: Quaternion = q * q.inverse()
+    assert identity.almost_equal(Quaternion.identity())
+
+
+def test_from_matrix_roundtrip() -> None:
+    """Checks conversion between matrix and quaternion."""
+    R: NDArray[np.float64] = SO3.exp(np.array([0.1, 0.2, 0.3], dtype=float))
+    q: Quaternion = Quaternion.from_matrix(R)
+    roundtrip: NDArray[np.float64] = q.as_matrix()
+    assert np.allclose(roundtrip, R, atol=1e-8)
+
+
+def test_from_rotvec_matches_exp() -> None:
+    """Checks from_rotvec matches SO3.exp."""
+    vec: NDArray[np.float64] = np.array([0.0, 0.0, 0.2], dtype=float)
+    q: Quaternion = Quaternion.from_rotvec(vec)
+    assert np.allclose(q.as_matrix(), SO3.exp(vec), atol=1e-8)
+
+
+def test_rotate_matches_matrix() -> None:
+    """Checks vector rotation matches matrix multiply."""
+    vec: NDArray[np.float64] = np.array([1.0, 2.0, 3.0], dtype=float)
+    q: Quaternion = Quaternion.from_rotvec(np.array([0.1, 0.2, 0.1], dtype=float))
+    rotated: NDArray[np.float64] = q.rotate(vec)
+    expected: NDArray[np.float64] = q.as_matrix() @ vec
+    assert np.allclose(rotated, expected)
+
+
+def test_almost_equal_sign_flip() -> None:
+    """Checks almost_equal handles sign flips."""
+    q: Quaternion = Quaternion.from_rotvec(np.array([0.1, -0.2, 0.1], dtype=float))
+    q_neg: Quaternion = Quaternion(-q.wxyz)
+    assert q.almost_equal(q_neg)

--- a/oasis_control/test/mounting/math_utils/test_quat.py
+++ b/oasis_control/test/mounting/math_utils/test_quat.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/test/mounting/math_utils/test_se3.py
+++ b/oasis_control/test/mounting/math_utils/test_se3.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/test/mounting/math_utils/test_se3.py
+++ b/oasis_control/test/mounting/math_utils/test_se3.py
@@ -7,3 +7,51 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+"""Tests for SE(3) transforms."""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+from oasis_control.localization.mounting.math_utils.quat import Quaternion
+from oasis_control.localization.mounting.math_utils.se3 import SE3
+
+
+def test_identity_inverse() -> None:
+    """Checks identity and inverse composition."""
+    identity: SE3 = SE3.identity()
+    result: SE3 = identity * identity.inverse()
+    assert np.allclose(result.R, np.eye(3))
+    assert np.allclose(result.p, np.zeros(3))
+
+
+def test_composition() -> None:
+    """Checks transform composition behavior."""
+    q1: Quaternion = Quaternion.from_rotvec(np.array([0.1, 0.0, 0.0], dtype=float))
+    q2: Quaternion = Quaternion.from_rotvec(np.array([0.0, 0.2, 0.0], dtype=float))
+    t1: SE3 = SE3.from_quat_translation(q1, np.array([1.0, 0.0, 0.0], dtype=float))
+    t2: SE3 = SE3.from_quat_translation(q2, np.array([0.0, 1.0, 0.0], dtype=float))
+    composed: SE3 = t1 * t2
+    point: NDArray[np.float64] = np.array([0.5, -0.5, 2.0], dtype=float)
+    direct: NDArray[np.float64] = t1.transform_point(t2.transform_point(point))
+    assert np.allclose(composed.transform_point(point), direct)
+
+
+def test_transform_point_matches_matrix() -> None:
+    """Checks point transform matches homogeneous matrix."""
+    q: Quaternion = Quaternion.from_rotvec(np.array([0.1, 0.1, 0.1], dtype=float))
+    t: SE3 = SE3.from_quat_translation(q, np.array([1.0, 2.0, 3.0], dtype=float))
+    point: NDArray[np.float64] = np.array([0.2, 0.3, -0.1], dtype=float)
+    point_h: NDArray[np.float64] = np.hstack([point, 1.0])
+    mat: NDArray[np.float64] = t.as_matrix4()
+    expected: NDArray[np.float64] = (mat @ point_h)[:3]
+    assert np.allclose(t.transform_point(point), expected)
+
+
+def test_transform_vector_ignores_translation() -> None:
+    """Checks vector transform ignores translation."""
+    q: Quaternion = Quaternion.from_rotvec(np.array([0.0, 0.0, 0.2], dtype=float))
+    t: SE3 = SE3.from_quat_translation(q, np.array([10.0, -5.0, 3.0], dtype=float))
+    vec: NDArray[np.float64] = np.array([1.0, 0.0, 0.0], dtype=float)
+    assert np.allclose(t.transform_vector(vec), q.as_matrix() @ vec)

--- a/oasis_control/test/mounting/math_utils/test_small_linalg3.py
+++ b/oasis_control/test/mounting/math_utils/test_small_linalg3.py
@@ -1,0 +1,66 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+"""Tests for small 3D linear algebra helpers."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from numpy.typing import NDArray
+
+from oasis_control.localization.mounting.math_utils.small_linalg3 import Mat3
+from oasis_control.localization.mounting.math_utils.small_linalg3 import Vec3
+
+
+def test_normalize_unit_norm() -> None:
+    """Checks normalization yields unit norm."""
+    vec: NDArray[np.float64] = np.array([3.0, 0.0, 4.0], dtype=float)
+    result: NDArray[np.float64] = Vec3.normalize(vec)
+    assert np.isclose(float(np.linalg.norm(result)), 1.0)
+
+
+def test_normalize_zero_raises() -> None:
+    """Checks normalize rejects zero vectors."""
+    vec: NDArray[np.float64] = np.zeros(3, dtype=float)
+    with pytest.raises(ValueError):
+        Vec3.normalize(vec)
+
+
+def test_angle_between_limits() -> None:
+    """Checks angle between identical and opposite vectors."""
+    u: NDArray[np.float64] = np.array([1.0, 0.0, 0.0], dtype=float)
+    v: NDArray[np.float64] = np.array([1.0, 0.0, 0.0], dtype=float)
+    w: NDArray[np.float64] = np.array([-1.0, 0.0, 0.0], dtype=float)
+    assert np.isclose(Vec3.angle_between(u, v), 0.0)
+    assert np.isclose(Vec3.angle_between(u, w), np.pi)
+
+
+def test_is_spd() -> None:
+    """Checks SPD detection for valid and invalid matrices."""
+    spd: NDArray[np.float64] = np.array(
+        [[2.0, 0.0, 0.0], [0.0, 3.0, 0.0], [0.0, 0.0, 4.0]], dtype=float
+    )
+    non_spd: NDArray[np.float64] = np.array(
+        [[0.0, 1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, -1.0]], dtype=float
+    )
+    assert Mat3.is_spd(spd)
+    assert not Mat3.is_spd(non_spd)
+
+
+def test_clamp_spd_symmetry() -> None:
+    """Checks eigenvalue clamping and symmetry."""
+    mat: NDArray[np.float64] = np.array(
+        [[3.0, 1.0, 0.0], [1.0, 0.5, 0.0], [0.0, 0.0, 0.1]], dtype=float
+    )
+    clamped: NDArray[np.float64] = Mat3.clamp_spd(mat, eig_min=0.2, eig_max=2.0)
+    eigvals: NDArray[np.float64] = np.asarray(np.linalg.eigvalsh(clamped), dtype=float)
+    assert np.all(eigvals >= 0.2 - 1e-12)
+    assert np.all(eigvals <= 2.0 + 1e-12)
+    assert np.allclose(clamped, clamped.T)

--- a/oasis_control/test/mounting/math_utils/test_stats.py
+++ b/oasis_control/test/mounting/math_utils/test_stats.py
@@ -7,3 +7,67 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+"""Tests for running statistics utilities."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from numpy.typing import NDArray
+
+from oasis_control.localization.mounting.math_utils.stats import RunningMoments3
+from oasis_control.localization.mounting.math_utils.stats import SlidingWindowMoments3
+
+
+def test_running_moments_matches_numpy() -> None:
+    """Checks running moments against numpy mean/cov."""
+    data: NDArray[np.float64] = np.array(
+        [
+            [1.0, 2.0, 3.0],
+            [2.0, 0.0, 4.0],
+            [3.0, 1.0, 5.0],
+        ],
+        dtype=float,
+    )
+    moments: RunningMoments3 = RunningMoments3()
+    for row in data:
+        row_vec: NDArray[np.float64] = row
+        moments.update(row_vec)
+    mean_expected: NDArray[np.float64] = np.mean(data, axis=0)
+    cov_expected: NDArray[np.float64] = np.cov(data, rowvar=False, ddof=0)
+    assert np.allclose(moments.mean(), mean_expected)
+    assert np.allclose(moments.covariance(ddof=0), cov_expected)
+
+
+def test_sliding_window_behavior() -> None:
+    """Checks sliding window drops old samples."""
+    window: SlidingWindowMoments3 = SlidingWindowMoments3(window_size=2)
+    window.push(np.array([1.0, 0.0, 0.0], dtype=float))
+    window.push(np.array([3.0, 0.0, 0.0], dtype=float))
+    window.push(np.array([5.0, 0.0, 0.0], dtype=float))
+    mean: NDArray[np.float64] = window.mean()
+    assert np.allclose(mean, np.array([4.0, 0.0, 0.0], dtype=float))
+
+
+def test_covariance_shapes_and_symmetry() -> None:
+    """Checks covariance shapes and symmetry."""
+    moments: RunningMoments3 = RunningMoments3()
+    samples: NDArray[np.float64] = np.array(
+        [[1.0, 0.0, 0.0], [2.0, 1.0, 0.0], [3.0, 0.0, 1.0]], dtype=float
+    )
+    for row in samples:
+        row_vec: NDArray[np.float64] = row
+        moments.update(row_vec)
+    cov: NDArray[np.float64] = moments.covariance(ddof=0)
+    assert cov.shape == (3, 3)
+    assert np.allclose(cov, cov.T)
+
+
+def test_invalid_shape_raises() -> None:
+    """Checks invalid shapes raise errors."""
+    moments: RunningMoments3 = RunningMoments3()
+    with pytest.raises(ValueError):
+        moments.update(np.array([1.0, 2.0], dtype=float))
+    window: SlidingWindowMoments3 = SlidingWindowMoments3(window_size=3)
+    with pytest.raises(ValueError):
+        window.push(np.array([1.0, 2.0], dtype=float))

--- a/oasis_control/test/mounting/math_utils/test_stats.py
+++ b/oasis_control/test/mounting/math_utils/test_stats.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/test/mounting/math_utils/test_units.py
+++ b/oasis_control/test/mounting/math_utils/test_units.py
@@ -7,3 +7,47 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+"""Tests for units helpers."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from numpy.typing import NDArray
+
+from oasis_control.localization.mounting.math_utils.units import Angle
+from oasis_control.localization.mounting.math_utils.units import PhysicalConstants
+from oasis_control.localization.mounting.math_utils.units import assert_finite
+
+
+def test_deg_rad_roundtrip_scalar() -> None:
+    """Checks scalar deg/rad conversion roundtrip."""
+    value_deg: float = 45.0
+    value_rad: float = float(Angle.deg2rad(value_deg))
+    roundtrip: float = float(Angle.rad2deg(value_rad))
+    assert np.isclose(roundtrip, value_deg)
+
+
+def test_deg_rad_roundtrip_array() -> None:
+    """Checks array deg/rad conversion roundtrip."""
+    values_deg: NDArray[np.float64] = np.array([0.0, 90.0, 180.0], dtype=float)
+    values_rad: NDArray[np.float64] = np.asarray(Angle.deg2rad(values_deg), dtype=float)
+    roundtrip: NDArray[np.float64] = np.asarray(Angle.rad2deg(values_rad), dtype=float)
+    assert np.allclose(roundtrip, values_deg)
+
+
+def test_constants_finite() -> None:
+    """Ensures constants are finite."""
+    gravity: float = PhysicalConstants.GRAVITY_MPS2
+    eps: float = PhysicalConstants.EPS
+    assert np.isfinite(gravity)
+    assert np.isfinite(eps)
+
+
+def test_assert_finite() -> None:
+    """Ensures assert_finite rejects non-finite inputs."""
+    good: NDArray[np.float64] = np.array([1.0, 2.0, 3.0], dtype=float)
+    assert_finite(good, "good")
+    bad: NDArray[np.float64] = np.array([1.0, np.nan, 3.0], dtype=float)
+    with pytest.raises(ValueError):
+        assert_finite(bad, "bad")

--- a/oasis_control/test/mounting/math_utils/test_units.py
+++ b/oasis_control/test/mounting/math_utils/test_units.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/test/mounting/models/test_anchor_model.py
+++ b/oasis_control/test/mounting/models/test_anchor_model.py
@@ -7,3 +7,58 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+"""Tests for the anchor model."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from oasis_control.localization.mounting.models.anchor_model import AnchorModel
+from oasis_control.localization.mounting.models.anchor_model import AnchorModelError
+
+
+def test_anchor_capture_and_flags() -> None:
+    """Verify capture stores references and flags."""
+    model: AnchorModel = AnchorModel()
+    g_ref: np.ndarray = np.array([0.0, 0.0, 1.0], dtype=np.float64)
+    m_ref: np.ndarray = np.array([1.0, 0.0, 0.0], dtype=np.float64)
+
+    model.capture(g_ref_W=g_ref, m_ref_W=m_ref)
+
+    assert model.captured
+    assert model.has_mag_reference()
+    np.testing.assert_allclose(model.gravity_ref_W(), g_ref)
+    np.testing.assert_allclose(model.mag_ref_W(), m_ref)
+
+
+def test_anchor_capture_without_mag() -> None:
+    """Verify capture without mag marks mag reference invalid."""
+    model: AnchorModel = AnchorModel()
+    g_ref: np.ndarray = np.array([0.0, 1.0, 0.0], dtype=np.float64)
+
+    model.capture(g_ref_W=g_ref, m_ref_W=None)
+
+    assert model.captured
+    assert not model.has_mag_reference()
+    assert model.mag_reference_invalid
+
+
+def test_anchor_double_capture_raises() -> None:
+    """Ensure capturing twice without reset raises an error."""
+    model: AnchorModel = AnchorModel()
+    g_ref: np.ndarray = np.array([0.0, 0.0, 1.0], dtype=np.float64)
+
+    model.capture(g_ref_W=g_ref, m_ref_W=None)
+    with pytest.raises(AnchorModelError):
+        model.capture(g_ref_W=g_ref, m_ref_W=None)
+
+
+def test_anchor_access_before_capture_raises() -> None:
+    """Ensure access before capture raises errors."""
+    model: AnchorModel = AnchorModel()
+    with pytest.raises(AnchorModelError):
+        model.gravity_ref_W()
+    with pytest.raises(AnchorModelError):
+        model.mag_ref_W()

--- a/oasis_control/test/mounting/models/test_anchor_model.py
+++ b/oasis_control/test/mounting/models/test_anchor_model.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/test/mounting/models/test_diversity_metrics.py
+++ b/oasis_control/test/mounting/models/test_diversity_metrics.py
@@ -7,3 +7,87 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+"""Tests for diversity metrics."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from oasis_control.localization.mounting.models.diversity_metrics import (
+    gravity_max_angle_deg,
+)
+from oasis_control.localization.mounting.models.diversity_metrics import (
+    mag_proj_max_angle_deg,
+)
+from oasis_control.localization.mounting.mounting_types import Keyframe
+
+
+def _keyframe_with_dirs(
+    keyframe_id: int,
+    gravity_dir: np.ndarray,
+    mag_dir: np.ndarray | None = None,
+) -> Keyframe:
+    """Create a keyframe with specified mean directions."""
+    gravity_vec: np.ndarray = np.asarray(gravity_dir, dtype=np.float64)
+    gravity_unit: np.ndarray = gravity_vec / float(np.linalg.norm(gravity_vec))
+    if mag_dir is None:
+        mag_mean: np.ndarray | None = None
+        mag_cov: np.ndarray | None = None
+        mag_weight: int = 0
+    else:
+        mag_vec: np.ndarray = np.asarray(mag_dir, dtype=np.float64)
+        mag_mean = mag_vec / float(np.linalg.norm(mag_vec))
+        mag_cov = np.zeros((3, 3), dtype=np.float64)
+        mag_weight = 1
+    return Keyframe(
+        keyframe_id=keyframe_id,
+        gravity_mean_dir_I=gravity_unit,
+        gravity_cov_dir_I=np.zeros((3, 3), dtype=np.float64),
+        gravity_weight=1,
+        mag_mean_dir_M=mag_mean,
+        mag_cov_dir_M=mag_cov,
+        mag_weight=mag_weight,
+        segment_count=1,
+    )
+
+
+def test_gravity_max_angle() -> None:
+    """Ensure gravity angle metric returns expected values."""
+    keyframes: list[Keyframe] = [
+        _keyframe_with_dirs(0, np.array([1.0, 0.0, 0.0], dtype=np.float64)),
+        _keyframe_with_dirs(1, np.array([0.0, 1.0, 0.0], dtype=np.float64)),
+        _keyframe_with_dirs(2, np.array([-1.0, 0.0, 0.0], dtype=np.float64)),
+    ]
+    angle: float | None = gravity_max_angle_deg(keyframes)
+    assert angle is not None
+    assert angle == 180.0
+
+
+def test_mag_proj_max_angle() -> None:
+    """Ensure mag angle metric returns expected values."""
+    keyframes: list[Keyframe] = [
+        _keyframe_with_dirs(
+            0,
+            np.array([0.0, 0.0, 1.0], dtype=np.float64),
+            mag_dir=np.array([1.0, 0.0, 0.0], dtype=np.float64),
+        ),
+        _keyframe_with_dirs(
+            1,
+            np.array([0.0, 0.0, 1.0], dtype=np.float64),
+            mag_dir=np.array([0.0, 1.0, 0.0], dtype=np.float64),
+        ),
+    ]
+    angle: float | None = mag_proj_max_angle_deg(keyframes)
+    assert angle is not None
+    assert angle == 90.0
+
+
+def test_diversity_none_cases() -> None:
+    """Ensure metrics return None when insufficient keyframes exist."""
+    keyframe: Keyframe = _keyframe_with_dirs(
+        0,
+        np.array([1.0, 0.0, 0.0], dtype=np.float64),
+    )
+    assert gravity_max_angle_deg([keyframe]) is None
+    assert mag_proj_max_angle_deg([keyframe]) is None

--- a/oasis_control/test/mounting/models/test_diversity_metrics.py
+++ b/oasis_control/test/mounting/models/test_diversity_metrics.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/test/mounting/models/test_imu_calibration_model.py
+++ b/oasis_control/test/mounting/models/test_imu_calibration_model.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/test/mounting/models/test_imu_calibration_model.py
+++ b/oasis_control/test/mounting/models/test_imu_calibration_model.py
@@ -7,3 +7,101 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+"""Tests for the IMU calibration model."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from oasis_control.localization.mounting.models.imu_calibration_model import (
+    ImuCalibrationModel,
+)
+from oasis_control.localization.mounting.models.imu_calibration_model import (
+    ImuCalibrationModelError,
+)
+from oasis_control.localization.mounting.models.imu_calibration_model import (
+    ImuNuisanceState,
+)
+from oasis_control.localization.mounting.mounting_types import ImuCalibrationPrior
+
+
+def test_state_from_prior_valid() -> None:
+    """Verify that a valid prior maps into a nuisance state."""
+    prior: ImuCalibrationPrior = ImuCalibrationPrior(
+        valid=True,
+        frame_id="imu",
+        b_a_mps2=np.array([0.1, 0.2, 0.3], dtype=np.float64),
+        A_a=np.array(
+            [[1.0, 0.0, 0.0], [0.0, 1.1, 0.0], [0.0, 0.0, 0.9]],
+            dtype=np.float64,
+        ),
+        b_g_rads=np.array([0.01, -0.02, 0.03], dtype=np.float64),
+        cov_a_params=None,
+        cov_b_g=None,
+    )
+
+    state: ImuNuisanceState = ImuCalibrationModel.state_from_prior(prior)
+
+    np.testing.assert_allclose(state.b_a_mps2, prior.b_a_mps2)
+    np.testing.assert_allclose(state.A_a, prior.A_a)
+    np.testing.assert_allclose(state.b_g_rads, prior.b_g_rads)
+
+
+def test_state_from_prior_invalid_returns_default() -> None:
+    """Verify that an invalid prior returns the default state."""
+    prior: ImuCalibrationPrior = ImuCalibrationPrior(
+        valid=False,
+        frame_id="imu",
+        b_a_mps2=np.zeros(3, dtype=np.float64),
+        A_a=np.eye(3, dtype=np.float64),
+        b_g_rads=np.zeros(3, dtype=np.float64),
+        cov_a_params=None,
+        cov_b_g=None,
+    )
+
+    state: ImuNuisanceState = ImuCalibrationModel.state_from_prior(prior)
+
+    np.testing.assert_allclose(state.b_a_mps2, np.zeros(3, dtype=np.float64))
+    np.testing.assert_allclose(state.A_a, np.eye(3, dtype=np.float64))
+    np.testing.assert_allclose(state.b_g_rads, np.zeros(3, dtype=np.float64))
+
+
+def test_nuisance_state_validation() -> None:
+    """Ensure that invalid nuisance states raise errors."""
+    with pytest.raises(ImuCalibrationModelError):
+        ImuNuisanceState(
+            b_a_mps2=np.zeros(2, dtype=np.float64),
+            A_a=np.eye(3, dtype=np.float64),
+            b_g_rads=np.zeros(3, dtype=np.float64),
+        )
+    with pytest.raises(ImuCalibrationModelError):
+        ImuNuisanceState(
+            b_a_mps2=np.zeros(3, dtype=np.float64),
+            A_a=np.eye(3, dtype=np.float64),
+            b_g_rads=np.array([np.nan, 0.0, 0.0], dtype=np.float64),
+        )
+
+
+def test_correction_formulas() -> None:
+    """Verify accelerometer and gyro correction formulas."""
+    state: ImuNuisanceState = ImuNuisanceState(
+        b_a_mps2=np.array([0.5, -0.5, 1.0], dtype=np.float64),
+        A_a=np.array(
+            [[1.0, 0.0, 0.0], [0.1, 1.0, 0.0], [0.0, 0.0, 1.0]],
+            dtype=np.float64,
+        ),
+        b_g_rads=np.array([0.01, 0.02, 0.03], dtype=np.float64),
+    )
+    a_raw: np.ndarray = np.array([1.5, -0.5, 2.0], dtype=np.float64)
+    omega_raw: np.ndarray = np.array([0.1, 0.2, 0.3], dtype=np.float64)
+
+    a_corr: np.ndarray = state.correct_accel(a_raw)
+    omega_corr: np.ndarray = state.correct_gyro(omega_raw)
+
+    expected_a: np.ndarray = state.A_a @ (a_raw - state.b_a_mps2)
+    expected_omega: np.ndarray = omega_raw - state.b_g_rads
+
+    np.testing.assert_allclose(a_corr, expected_a)
+    np.testing.assert_allclose(omega_corr, expected_omega)

--- a/oasis_control/test/mounting/models/test_keyframe_clustering.py
+++ b/oasis_control/test/mounting/models/test_keyframe_clustering.py
@@ -7,3 +7,244 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+"""Tests for keyframe clustering."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+from oasis_control.localization.mounting.config.mounting_params import ClusterParams
+from oasis_control.localization.mounting.config.mounting_params import MountingParams
+from oasis_control.localization.mounting.models.keyframe_clustering import (
+    KeyframeClustering,
+)
+from oasis_control.localization.mounting.models.keyframe_clustering import (
+    KeyframeClusteringError,
+)
+from oasis_control.localization.mounting.mounting_types import SteadySegment
+
+
+def _segment_from_dirs(
+    *,
+    t_start_ns: int,
+    gravity_dir_I: np.ndarray,
+    mag_dir_M: np.ndarray | None = None,
+) -> SteadySegment:
+    """Create a steady segment from direction inputs."""
+    gravity_unit: np.ndarray = gravity_dir_I / float(np.linalg.norm(gravity_dir_I))
+    a_mean: np.ndarray = -gravity_unit * 9.81
+    cov: np.ndarray = np.eye(3, dtype=np.float64) * 1e-3
+    if mag_dir_M is None:
+        m_mean: np.ndarray | None = None
+        cov_m: np.ndarray | None = None
+        mag_frame_id: str | None = None
+    else:
+        m_mean = mag_dir_M / float(np.linalg.norm(mag_dir_M))
+        cov_m = np.eye(3, dtype=np.float64) * 1e-4
+        mag_frame_id = "mag"
+    t_end_ns: int = t_start_ns + int(1e9)
+    return SteadySegment(
+        t_start_ns=t_start_ns,
+        t_end_ns=t_end_ns,
+        t_meas_ns=(t_start_ns + t_end_ns) // 2,
+        imu_frame_id="imu",
+        mag_frame_id=mag_frame_id,
+        a_mean_mps2=a_mean,
+        cov_a=cov,
+        m_mean_T=m_mean,
+        cov_m=cov_m,
+        sample_count=10,
+        duration_ns=t_end_ns - t_start_ns,
+    )
+
+
+def _params_with_cluster(cluster: ClusterParams) -> MountingParams:
+    """Return mounting params with custom cluster parameters."""
+    base_params: MountingParams = MountingParams.defaults()
+    return replace(base_params, cluster=cluster)
+
+
+def test_cluster_assigns_nearby_segments() -> None:
+    """Ensure nearby segments are assigned to the same keyframe."""
+    cluster_params: ClusterParams = ClusterParams(
+        cluster_g_deg=15.0, cluster_h_deg=20.0
+    )
+    params: MountingParams = _params_with_cluster(cluster_params)
+    clustering: KeyframeClustering = KeyframeClustering(params)
+
+    seg0: SteadySegment = _segment_from_dirs(
+        t_start_ns=0,
+        gravity_dir_I=np.array([0.0, 0.0, 1.0], dtype=np.float64),
+    )
+    key_id0, keyframe0 = clustering.add_segment(seg0)
+    assert key_id0 == 0
+
+    seg1: SteadySegment = _segment_from_dirs(
+        t_start_ns=int(2e9),
+        gravity_dir_I=np.array([0.0, 0.1, 0.995], dtype=np.float64),
+    )
+    key_id1, keyframe1 = clustering.add_segment(seg1)
+    assert key_id1 == key_id0
+    assert keyframe1.segment_count == keyframe0.segment_count + 1
+
+    seg2: SteadySegment = _segment_from_dirs(
+        t_start_ns=int(4e9),
+        gravity_dir_I=np.array([1.0, 0.0, 0.0], dtype=np.float64),
+    )
+    key_id2, _ = clustering.add_segment(seg2)
+    assert key_id2 != key_id0
+
+
+def test_mag_threshold_affects_clustering() -> None:
+    """Ensure mag angular threshold influences keyframe assignment."""
+    cluster_params: ClusterParams = ClusterParams(cluster_g_deg=20.0, cluster_h_deg=5.0)
+    params: MountingParams = _params_with_cluster(cluster_params)
+    clustering: KeyframeClustering = KeyframeClustering(params)
+
+    seg0: SteadySegment = _segment_from_dirs(
+        t_start_ns=0,
+        gravity_dir_I=np.array([0.0, 0.0, 1.0], dtype=np.float64),
+        mag_dir_M=np.array([1.0, 0.0, 0.0], dtype=np.float64),
+    )
+    clustering.add_segment(seg0)
+
+    seg1: SteadySegment = _segment_from_dirs(
+        t_start_ns=int(2e9),
+        gravity_dir_I=np.array([0.0, 0.0, 1.0], dtype=np.float64),
+        mag_dir_M=np.array([-1.0, 0.0, 0.0], dtype=np.float64),
+    )
+    key_id1, _ = clustering.add_segment(seg1)
+    assert key_id1 == 1
+
+
+def test_kmax_oldest_policy() -> None:
+    """Ensure the oldest keyframe is dropped when exceeding K_max."""
+    cluster_params: ClusterParams = ClusterParams(
+        cluster_g_deg=5.0,
+        cluster_h_deg=5.0,
+        K_max=2,
+        drop_policy="oldest",
+    )
+    params: MountingParams = _params_with_cluster(cluster_params)
+    clustering: KeyframeClustering = KeyframeClustering(params)
+
+    clustering.add_segment(
+        _segment_from_dirs(
+            t_start_ns=0,
+            gravity_dir_I=np.array([0.0, 0.0, 1.0], dtype=np.float64),
+        )
+    )
+    clustering.add_segment(
+        _segment_from_dirs(
+            t_start_ns=int(2e9),
+            gravity_dir_I=np.array([1.0, 0.0, 0.0], dtype=np.float64),
+        )
+    )
+    clustering.add_segment(
+        _segment_from_dirs(
+            t_start_ns=int(4e9),
+            gravity_dir_I=np.array([0.0, 1.0, 0.0], dtype=np.float64),
+        )
+    )
+
+    keyframe_ids: list[int] = [key.keyframe_id for key in clustering.keyframes()]
+    assert keyframe_ids == [1, 2]
+
+
+def test_kmax_lowest_information_policy() -> None:
+    """Ensure lowest information keyframe is dropped when full."""
+    cluster_params: ClusterParams = ClusterParams(
+        cluster_g_deg=5.0,
+        cluster_h_deg=5.0,
+        K_max=2,
+        drop_policy="lowest_information",
+    )
+    params: MountingParams = _params_with_cluster(cluster_params)
+    clustering: KeyframeClustering = KeyframeClustering(params)
+
+    seg0: SteadySegment = _segment_from_dirs(
+        t_start_ns=0,
+        gravity_dir_I=np.array([0.0, 0.0, 1.0], dtype=np.float64),
+    )
+    clustering.add_segment(seg0)
+    clustering.add_segment(seg0)
+
+    clustering.add_segment(
+        _segment_from_dirs(
+            t_start_ns=int(2e9),
+            gravity_dir_I=np.array([1.0, 0.0, 0.0], dtype=np.float64),
+        )
+    )
+    clustering.add_segment(
+        _segment_from_dirs(
+            t_start_ns=int(4e9),
+            gravity_dir_I=np.array([0.0, 1.0, 0.0], dtype=np.float64),
+        )
+    )
+
+    keyframe_ids: list[int] = [key.keyframe_id for key in clustering.keyframes()]
+    assert keyframe_ids == [0, 2]
+
+
+def test_kmax_redundant_policy() -> None:
+    """Ensure redundant keyframes are dropped deterministically."""
+    cluster_params: ClusterParams = ClusterParams(
+        cluster_g_deg=1.0,
+        cluster_h_deg=5.0,
+        K_max=2,
+        drop_policy="redundant",
+    )
+    params: MountingParams = _params_with_cluster(cluster_params)
+    clustering: KeyframeClustering = KeyframeClustering(params)
+
+    clustering.add_segment(
+        _segment_from_dirs(
+            t_start_ns=0,
+            gravity_dir_I=np.array([0.0, 0.0, 1.0], dtype=np.float64),
+        )
+    )
+    clustering.add_segment(
+        _segment_from_dirs(
+            t_start_ns=int(2e9),
+            gravity_dir_I=np.array([0.0, 0.035, 0.9994], dtype=np.float64),
+        )
+    )
+    clustering.add_segment(
+        _segment_from_dirs(
+            t_start_ns=int(4e9),
+            gravity_dir_I=np.array([1.0, 0.0, 0.0], dtype=np.float64),
+        )
+    )
+
+    keyframe_ids: list[int] = [key.keyframe_id for key in clustering.keyframes()]
+    assert keyframe_ids == [1, 2]
+
+
+def test_unknown_drop_policy_raises() -> None:
+    """Ensure invalid drop policies raise errors."""
+    cluster_params: ClusterParams = ClusterParams(
+        cluster_g_deg=5.0,
+        cluster_h_deg=5.0,
+        K_max=1,
+        drop_policy="unknown",
+    )
+    params: MountingParams = _params_with_cluster(cluster_params)
+    clustering: KeyframeClustering = KeyframeClustering(params)
+
+    clustering.add_segment(
+        _segment_from_dirs(
+            t_start_ns=0,
+            gravity_dir_I=np.array([0.0, 0.0, 1.0], dtype=np.float64),
+        )
+    )
+    with pytest.raises(KeyframeClusteringError):
+        clustering.add_segment(
+            _segment_from_dirs(
+                t_start_ns=int(2e9),
+                gravity_dir_I=np.array([1.0, 0.0, 0.0], dtype=np.float64),
+            )
+        )

--- a/oasis_control/test/mounting/models/test_keyframe_clustering.py
+++ b/oasis_control/test/mounting/models/test_keyframe_clustering.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/test/mounting/models/test_mag_direction_model.py
+++ b/oasis_control/test/mounting/models/test_mag_direction_model.py
@@ -7,3 +7,63 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+"""Tests for magnetometer direction modeling."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from oasis_control.localization.mounting.models.mag_direction_model import (
+    MagDirectionModelError,
+)
+from oasis_control.localization.mounting.models.mag_direction_model import (
+    direction_covariance_from_raw,
+)
+from oasis_control.localization.mounting.models.mag_direction_model import (
+    direction_residual_cross,
+)
+from oasis_control.localization.mounting.models.mag_direction_model import normalize
+
+
+def test_direction_covariance_from_raw() -> None:
+    """Validate covariance conversion for a simple case."""
+    m_raw: np.ndarray = np.array([1.0, 0.0, 0.0], dtype=np.float64)
+    cov_raw: np.ndarray = np.diag([1.0, 2.0, 3.0]).astype(np.float64)
+
+    cov_dir: np.ndarray = direction_covariance_from_raw(
+        m_raw_T=m_raw,
+        cov_m_raw_T2=cov_raw,
+        s_min_T=1e-6,
+    )
+
+    expected: np.ndarray = np.diag([0.0, 2.0, 3.0]).astype(np.float64)
+    np.testing.assert_allclose(cov_dir, expected)
+
+
+def test_direction_covariance_minimum_norm() -> None:
+    """Ensure too-small magnitudes raise errors."""
+    m_raw: np.ndarray = np.array([1e-7, 0.0, 0.0], dtype=np.float64)
+    cov_raw: np.ndarray = np.eye(3, dtype=np.float64)
+
+    with pytest.raises(MagDirectionModelError):
+        direction_covariance_from_raw(
+            m_raw_T=m_raw,
+            cov_m_raw_T2=cov_raw,
+            s_min_T=1e-6,
+        )
+
+
+def test_direction_residual_cross() -> None:
+    """Verify cross-product residual computation."""
+    u_meas: np.ndarray = np.array([1.0, 0.0, 0.0], dtype=np.float64)
+    u_pred: np.ndarray = np.array([0.0, 1.0, 0.0], dtype=np.float64)
+    residual: np.ndarray = direction_residual_cross(u_meas, u_pred)
+    np.testing.assert_allclose(residual, np.array([0.0, 0.0, 1.0], dtype=np.float64))
+
+
+def test_normalize_invalid() -> None:
+    """Ensure invalid normalize inputs raise errors."""
+    with pytest.raises(MagDirectionModelError):
+        normalize(np.array([0.0, 0.0, 0.0], dtype=np.float64))

--- a/oasis_control/test/mounting/models/test_mag_direction_model.py
+++ b/oasis_control/test/mounting/models/test_mag_direction_model.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/test/mounting/models/test_noise_adaptation.py
+++ b/oasis_control/test/mounting/models/test_noise_adaptation.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/test/mounting/models/test_noise_adaptation.py
+++ b/oasis_control/test/mounting/models/test_noise_adaptation.py
@@ -7,3 +7,63 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+"""Tests for adaptive noise modeling."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from oasis_control.localization.mounting.models.noise_adaptation import (
+    DirectionNoiseAdapter,
+)
+from oasis_control.localization.mounting.models.noise_adaptation import (
+    NoiseAdaptationError,
+)
+
+
+def test_noise_adapter_update_moves_r() -> None:
+    """Ensure the update nudges R toward the residual covariance."""
+    adapter: DirectionNoiseAdapter = DirectionNoiseAdapter(
+        R_init=np.eye(3, dtype=np.float64) * 0.1,
+        R_min=np.eye(3, dtype=np.float64) * 0.01,
+        R_max=np.eye(3, dtype=np.float64) * 1.0,
+        alpha=1.0,
+    )
+    residual: np.ndarray = np.array([1.0, 0.0, 0.0], dtype=np.float64)
+    S_hat: np.ndarray = np.zeros((3, 3), dtype=np.float64)
+
+    updated: np.ndarray = adapter.update(r=residual, S_hat=S_hat)
+
+    expected_diag: np.ndarray = np.array([1.0, 0.01, 0.01], dtype=np.float64)
+    np.testing.assert_allclose(np.diag(updated), expected_diag)
+
+
+def test_noise_adapter_clamps_bounds() -> None:
+    """Ensure eigenvalue bounds are enforced."""
+    adapter: DirectionNoiseAdapter = DirectionNoiseAdapter(
+        R_init=np.eye(3, dtype=np.float64) * 0.1,
+        R_min=np.eye(3, dtype=np.float64) * 0.05,
+        R_max=np.eye(3, dtype=np.float64) * 0.2,
+        alpha=1.0,
+    )
+    residual: np.ndarray = np.array([0.0, 0.0, 0.0], dtype=np.float64)
+    S_hat: np.ndarray = np.eye(3, dtype=np.float64) * 1.0
+
+    updated: np.ndarray = adapter.update(r=residual, S_hat=S_hat)
+
+    diag: np.ndarray = np.diag(updated)
+    assert np.all(diag >= 0.05)
+    assert np.all(diag <= 0.2)
+
+
+def test_noise_adapter_invalid_alpha() -> None:
+    """Ensure invalid alpha values raise errors."""
+    with pytest.raises(NoiseAdaptationError):
+        DirectionNoiseAdapter(
+            R_init=np.eye(3, dtype=np.float64),
+            R_min=np.eye(3, dtype=np.float64),
+            R_max=np.eye(3, dtype=np.float64),
+            alpha=0.0,
+        )

--- a/oasis_control/test/mounting/models/test_steady_detector.py
+++ b/oasis_control/test/mounting/models/test_steady_detector.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/test/mounting/models/test_steady_detector.py
+++ b/oasis_control/test/mounting/models/test_steady_detector.py
@@ -7,3 +7,230 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+"""Tests for the steady detector."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+from oasis_control.localization.mounting.config.mounting_params import MountingParams
+from oasis_control.localization.mounting.config.mounting_params import SteadyParams
+from oasis_control.localization.mounting.models.steady_detector import SteadyDetector
+from oasis_control.localization.mounting.models.steady_detector import (
+    SteadyDetectorError,
+)
+from oasis_control.localization.mounting.mounting_types import MagPacket
+from oasis_control.localization.mounting.mounting_types import SteadySegment
+
+
+def _steady_params() -> MountingParams:
+    """Create mounting params configured for steady detection tests."""
+    base_params: MountingParams = MountingParams.defaults()
+    steady: SteadyParams = replace(
+        base_params.steady,
+        steady_sec=1.0,
+        omega_mean_thresh=0.1,
+        omega_cov_thresh=0.01,
+        a_cov_thresh=0.01,
+        a_norm_min=9.0,
+        a_norm_max=10.5,
+        window_type="sliding",
+    )
+    return replace(base_params, steady=steady)
+
+
+def _push_sample(
+    detector: SteadyDetector,
+    *,
+    t_ns: int,
+    omega: np.ndarray,
+    accel: np.ndarray,
+    mag: MagPacket | None = None,
+) -> None:
+    """Push a sample and ignore the result."""
+    detector.push(
+        t_ns=t_ns,
+        omega_corr_rads=omega,
+        a_corr_mps2=accel,
+        imu_frame_id="imu",
+        mag=mag,
+    )
+
+
+def test_sliding_window_emits_once() -> None:
+    """Ensure the detector emits once after steady duration."""
+    params: MountingParams = _steady_params()
+    detector: SteadyDetector = SteadyDetector(params)
+    omega: np.ndarray = np.zeros(3, dtype=np.float64)
+    accel: np.ndarray = np.array([0.0, 0.0, -9.81], dtype=np.float64)
+
+    segment: SteadySegment | None = detector.push(
+        t_ns=0,
+        omega_corr_rads=omega,
+        a_corr_mps2=accel,
+        imu_frame_id="imu",
+    )
+    assert segment is None
+
+    segment = detector.push(
+        t_ns=int(0.5e9),
+        omega_corr_rads=omega,
+        a_corr_mps2=accel,
+        imu_frame_id="imu",
+    )
+    assert segment is None
+
+    segment = detector.push(
+        t_ns=int(1.0e9),
+        omega_corr_rads=omega,
+        a_corr_mps2=accel,
+        imu_frame_id="imu",
+    )
+    assert segment is None
+
+    segment = detector.push(
+        t_ns=int(1.5e9),
+        omega_corr_rads=omega,
+        a_corr_mps2=accel,
+        imu_frame_id="imu",
+    )
+    assert segment is None
+
+    segment = detector.push(
+        t_ns=int(2.0e9),
+        omega_corr_rads=omega,
+        a_corr_mps2=accel,
+        imu_frame_id="imu",
+    )
+    assert segment is not None
+
+    segment_again: SteadySegment | None = detector.push(
+        t_ns=int(2.5e9),
+        omega_corr_rads=omega,
+        a_corr_mps2=accel,
+        imu_frame_id="imu",
+    )
+    assert segment_again is None
+
+
+def test_exit_and_reenter_steady() -> None:
+    """Ensure re-entering steady emits a new segment."""
+    params: MountingParams = _steady_params()
+    detector: SteadyDetector = SteadyDetector(params)
+    omega_ok: np.ndarray = np.zeros(3, dtype=np.float64)
+    accel_ok: np.ndarray = np.array([0.0, 0.0, -9.81], dtype=np.float64)
+    omega_bad: np.ndarray = np.array([1.0, 0.0, 0.0], dtype=np.float64)
+
+    _push_sample(detector, t_ns=0, omega=omega_ok, accel=accel_ok)
+    _push_sample(detector, t_ns=int(1.0e9), omega=omega_ok, accel=accel_ok)
+    segment: SteadySegment | None = detector.push(
+        t_ns=int(2.0e9),
+        omega_corr_rads=omega_ok,
+        a_corr_mps2=accel_ok,
+        imu_frame_id="imu",
+    )
+    assert segment is not None
+
+    segment = detector.push(
+        t_ns=int(2.5e9),
+        omega_corr_rads=omega_bad,
+        a_corr_mps2=accel_ok,
+        imu_frame_id="imu",
+    )
+    assert segment is None
+
+    _push_sample(detector, t_ns=int(3.6e9), omega=omega_ok, accel=accel_ok)
+    _push_sample(detector, t_ns=int(4.6e9), omega=omega_ok, accel=accel_ok)
+    segment = detector.push(
+        t_ns=int(5.6e9),
+        omega_corr_rads=omega_ok,
+        a_corr_mps2=accel_ok,
+        imu_frame_id="imu",
+    )
+    assert segment is not None
+
+
+def test_threshold_failure_prevents_emission() -> None:
+    """Ensure threshold violations block emission."""
+    params: MountingParams = _steady_params()
+    detector: SteadyDetector = SteadyDetector(params)
+    omega: np.ndarray = np.array([0.2, 0.0, 0.0], dtype=np.float64)
+    accel: np.ndarray = np.array([0.0, 0.0, -9.81], dtype=np.float64)
+
+    _push_sample(detector, t_ns=0, omega=omega, accel=accel)
+    segment = detector.push(
+        t_ns=int(1.0e9),
+        omega_corr_rads=omega,
+        a_corr_mps2=accel,
+        imu_frame_id="imu",
+    )
+    assert segment is None
+
+
+def test_mag_samples_included() -> None:
+    """Ensure magnetometer samples are aggregated when available."""
+    params: MountingParams = _steady_params()
+    detector: SteadyDetector = SteadyDetector(params)
+    omega: np.ndarray = np.zeros(3, dtype=np.float64)
+    accel: np.ndarray = np.array([0.0, 0.0, -9.81], dtype=np.float64)
+    mag_cov: np.ndarray = np.eye(3, dtype=np.float64) * 0.01
+
+    mag0: MagPacket = MagPacket(
+        t_meas_ns=0,
+        frame_id="mag",
+        m_raw_T=np.array([0.1, 0.0, 0.0], dtype=np.float64),
+        cov_m_raw_T2=mag_cov,
+    )
+    mag1: MagPacket = MagPacket(
+        t_meas_ns=int(1.0e9),
+        frame_id="mag",
+        m_raw_T=np.array([0.2, 0.0, 0.0], dtype=np.float64),
+        cov_m_raw_T2=mag_cov,
+    )
+
+    detector.push(
+        t_ns=0,
+        omega_corr_rads=omega,
+        a_corr_mps2=accel,
+        imu_frame_id="imu",
+        mag=mag0,
+    )
+    detector.push(
+        t_ns=int(1.0e9),
+        omega_corr_rads=omega,
+        a_corr_mps2=accel,
+        imu_frame_id="imu",
+        mag=mag1,
+    )
+    segment = detector.push(
+        t_ns=int(2.0e9),
+        omega_corr_rads=omega,
+        a_corr_mps2=accel,
+        imu_frame_id="imu",
+        mag=MagPacket(
+            t_meas_ns=int(2.0e9),
+            frame_id="mag",
+            m_raw_T=np.array([0.3, 0.0, 0.0], dtype=np.float64),
+            cov_m_raw_T2=mag_cov,
+        ),
+    )
+    assert segment is not None
+    assert segment.mag_frame_id == "mag"
+    assert segment.m_mean_T is not None
+    np.testing.assert_allclose(segment.m_mean_T, np.array([0.25, 0.0, 0.0]))
+
+
+def test_non_monotonic_time_raises() -> None:
+    """Ensure non-monotonic time raises a detector error."""
+    params: MountingParams = _steady_params()
+    detector: SteadyDetector = SteadyDetector(params)
+    omega: np.ndarray = np.zeros(3, dtype=np.float64)
+    accel: np.ndarray = np.array([0.0, 0.0, -9.81], dtype=np.float64)
+
+    _push_sample(detector, t_ns=0, omega=omega, accel=accel)
+    with pytest.raises(SteadyDetectorError):
+        _push_sample(detector, t_ns=0, omega=omega, accel=accel)

--- a/oasis_control/test/mounting/mounting_types/test_diagnostics.py
+++ b/oasis_control/test/mounting/mounting_types/test_diagnostics.py
@@ -7,3 +7,98 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+"""Tests for diagnostics types."""
+
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+
+from oasis_control.localization.mounting.mounting_types.diagnostics import Diagnostics
+from oasis_control.localization.mounting.mounting_types.update_report import (
+    UpdateReport,
+)
+
+
+def test_diagnostics_to_dict() -> None:
+    """Ensure diagnostics export to a dictionary."""
+    report: UpdateReport = UpdateReport(
+        did_update=True,
+        iterations=1,
+        step_norm=0.1,
+        residual_rms=0.2,
+        need_more_tilt=False,
+        need_more_yaw=False,
+        dropped_segments=0,
+        dropped_mags=0,
+        message=None,
+    )
+    diag: Diagnostics = Diagnostics(
+        t_meas_ns=0,
+        pipeline_state="running",
+        update_report=report,
+        segment_count=2,
+        keyframe_count=1,
+        diversity_tilt_deg=5.0,
+        diversity_yaw_deg=None,
+        warnings=("warn",),
+        errors=(),
+        info=("info",),
+        dropped_packets=0,
+    )
+    data: dict[str, object] = diag.to_dict()
+    assert data["pipeline_state"] == "running"
+    assert data["update_report"] == report.to_dict()
+
+
+def test_diagnostics_validation() -> None:
+    """Ensure invalid diagnostic fields raise errors."""
+    with pytest.raises(ValueError):
+        Diagnostics(
+            t_meas_ns=0,
+            pipeline_state="state",
+            update_report=None,
+            segment_count=-1,
+            keyframe_count=0,
+            diversity_tilt_deg=None,
+            diversity_yaw_deg=None,
+            warnings=(),
+            errors=(),
+            info=(),
+            dropped_packets=0,
+        )
+
+    with pytest.raises(ValueError):
+        Diagnostics(
+            t_meas_ns=0,
+            pipeline_state="state",
+            update_report=None,
+            segment_count=0,
+            keyframe_count=0,
+            diversity_tilt_deg=None,
+            diversity_yaw_deg=None,
+            warnings=cast(tuple[str, ...], ("ok", 1)),
+            errors=(),
+            info=(),
+            dropped_packets=0,
+        )
+
+
+def test_diagnostics_has_errors() -> None:
+    """Ensure error detection works."""
+    diag: Diagnostics = Diagnostics(
+        t_meas_ns=0,
+        pipeline_state="state",
+        update_report=None,
+        segment_count=0,
+        keyframe_count=0,
+        diversity_tilt_deg=None,
+        diversity_yaw_deg=None,
+        warnings=(),
+        errors=("err",),
+        info=(),
+        dropped_packets=0,
+    )
+    assert diag.has_errors()

--- a/oasis_control/test/mounting/mounting_types/test_diagnostics.py
+++ b/oasis_control/test/mounting/mounting_types/test_diagnostics.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/test/mounting/mounting_types/test_imu_packet.py
+++ b/oasis_control/test/mounting/mounting_types/test_imu_packet.py
@@ -7,3 +7,125 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+"""Tests for IMU packet types."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from oasis_control.localization.mounting.mounting_types.imu_packet import (
+    ImuCalibrationPrior,
+)
+from oasis_control.localization.mounting.mounting_types.imu_packet import ImuPacket
+
+
+def _make_prior() -> ImuCalibrationPrior:
+    """Create a valid ImuCalibrationPrior for tests."""
+    b_a_mps2: np.ndarray = np.array([0.1, -0.2, 0.05], dtype=np.float64)
+    A_a: np.ndarray = np.eye(3, dtype=np.float64)
+    b_g_rads: np.ndarray = np.array([0.01, 0.02, -0.01], dtype=np.float64)
+    cov_a_params: np.ndarray = np.eye(12, dtype=np.float64)
+    cov_b_g: np.ndarray = np.eye(3, dtype=np.float64)
+    return ImuCalibrationPrior(
+        valid=True,
+        frame_id="imu",
+        b_a_mps2=b_a_mps2,
+        A_a=A_a,
+        b_g_rads=b_g_rads,
+        cov_a_params=cov_a_params,
+        cov_b_g=cov_b_g,
+    )
+
+
+def test_imu_packet_has_calibration() -> None:
+    """Ensure calibration presence is reported correctly."""
+    prior: ImuCalibrationPrior = _make_prior()
+    packet_with: ImuPacket = ImuPacket(
+        t_meas_ns=100,
+        frame_id="imu",
+        omega_raw_rads=np.array([0.0, 0.1, 0.2], dtype=np.float64),
+        cov_omega_raw=np.eye(3, dtype=np.float64),
+        a_raw_mps2=np.array([0.0, 0.0, 9.81], dtype=np.float64),
+        cov_a_raw=np.eye(3, dtype=np.float64),
+        calibration=prior,
+    )
+    packet_without: ImuPacket = ImuPacket(
+        t_meas_ns=101,
+        frame_id="imu",
+        omega_raw_rads=np.array([0.0, 0.1, 0.2], dtype=np.float64),
+        cov_omega_raw=np.eye(3, dtype=np.float64),
+        a_raw_mps2=np.array([0.0, 0.0, 9.81], dtype=np.float64),
+        cov_a_raw=np.eye(3, dtype=np.float64),
+        calibration=None,
+    )
+    assert packet_with.has_calibration()
+    assert not packet_without.has_calibration()
+
+
+def test_imu_packet_shape_validation() -> None:
+    """Ensure shape validation rejects invalid arrays."""
+    with pytest.raises(ValueError):
+        ImuPacket(
+            t_meas_ns=0,
+            frame_id="imu",
+            omega_raw_rads=np.array([0.0, 0.0, 0.0], dtype=np.float64),
+            cov_omega_raw=np.eye(2, dtype=np.float64),
+            a_raw_mps2=np.array([0.0, 0.0, 9.81], dtype=np.float64),
+            cov_a_raw=np.eye(3, dtype=np.float64),
+            calibration=None,
+        )
+
+
+def test_imu_packet_calibration_frame_mismatch() -> None:
+    """Ensure calibration frame mismatch raises an error."""
+    prior: ImuCalibrationPrior = ImuCalibrationPrior(
+        valid=True,
+        frame_id="imu_other",
+        b_a_mps2=np.array([0.1, -0.2, 0.05], dtype=np.float64),
+        A_a=np.eye(3, dtype=np.float64),
+        b_g_rads=np.array([0.01, 0.02, -0.01], dtype=np.float64),
+        cov_a_params=np.eye(12, dtype=np.float64),
+        cov_b_g=np.eye(3, dtype=np.float64),
+    )
+    with pytest.raises(ValueError):
+        ImuPacket(
+            t_meas_ns=100,
+            frame_id="imu",
+            omega_raw_rads=np.array([0.0, 0.1, 0.2], dtype=np.float64),
+            cov_omega_raw=np.eye(3, dtype=np.float64),
+            a_raw_mps2=np.array([0.0, 0.0, 9.81], dtype=np.float64),
+            cov_a_raw=np.eye(3, dtype=np.float64),
+            calibration=prior,
+        )
+
+
+def test_imu_calibration_prior_finite_validation() -> None:
+    """Ensure finite validation rejects NaN values."""
+    A_a: np.ndarray = np.eye(3, dtype=np.float64)
+    A_a[0, 0] = np.nan
+    with pytest.raises(ValueError):
+        ImuCalibrationPrior(
+            valid=True,
+            frame_id="imu",
+            b_a_mps2=np.zeros(3, dtype=np.float64),
+            A_a=A_a,
+            b_g_rads=np.zeros(3, dtype=np.float64),
+            cov_a_params=None,
+            cov_b_g=None,
+        )
+
+
+def test_imu_calibration_prior_shape_validation() -> None:
+    """Ensure covariance shapes are validated."""
+    with pytest.raises(ValueError):
+        ImuCalibrationPrior(
+            valid=True,
+            frame_id="imu",
+            b_a_mps2=np.zeros(3, dtype=np.float64),
+            A_a=np.eye(3, dtype=np.float64),
+            b_g_rads=np.zeros(3, dtype=np.float64),
+            cov_a_params=np.eye(3, dtype=np.float64),
+            cov_b_g=None,
+        )

--- a/oasis_control/test/mounting/mounting_types/test_imu_packet.py
+++ b/oasis_control/test/mounting/mounting_types/test_imu_packet.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/test/mounting/mounting_types/test_keyframe.py
+++ b/oasis_control/test/mounting/mounting_types/test_keyframe.py
@@ -7,3 +7,89 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+"""Tests for keyframe aggregation types."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from oasis_control.localization.mounting.mounting_types.keyframe import Keyframe
+from oasis_control.localization.mounting.mounting_types.steady_segment import (
+    SteadySegment,
+)
+
+
+def _empty_keyframe() -> Keyframe:
+    """Create an empty keyframe with zero counts."""
+    return Keyframe(
+        keyframe_id=0,
+        gravity_mean_dir_I=np.zeros(3, dtype=np.float64),
+        gravity_cov_dir_I=np.zeros((3, 3), dtype=np.float64),
+        gravity_weight=0,
+        mag_mean_dir_M=None,
+        mag_cov_dir_M=None,
+        mag_weight=0,
+        segment_count=0,
+    )
+
+
+def test_keyframe_update_with_directions() -> None:
+    """Ensure updates adjust counts and mean directions."""
+    keyframe: Keyframe = _empty_keyframe()
+    keyframe = keyframe.update_with_directions(np.array([1.0, 0.0, 0.0]))
+    assert keyframe.gravity_weight == 1
+    assert keyframe.segment_count == 1
+    np.testing.assert_allclose(keyframe.gravity_mean_dir_I, np.array([1.0, 0.0, 0.0]))
+
+    keyframe = keyframe.update_with_directions(np.array([0.0, 1.0, 0.0]))
+    assert keyframe.gravity_weight == 2
+    assert keyframe.segment_count == 2
+    np.testing.assert_allclose(
+        keyframe.gravity_mean_dir_I,
+        np.array([0.5, 0.5, 0.0]),
+    )
+    unit_mean: np.ndarray = keyframe.gravity_unit_mean_dir_I()
+    np.testing.assert_allclose(
+        unit_mean,
+        np.array([1.0, 1.0, 0.0]) / np.sqrt(2.0),
+    )
+
+
+def test_keyframe_update_with_segment() -> None:
+    """Ensure segments update gravity and mag aggregates."""
+    keyframe: Keyframe = _empty_keyframe()
+    segment: SteadySegment = SteadySegment(
+        t_start_ns=0,
+        t_end_ns=10,
+        t_meas_ns=5,
+        imu_frame_id="imu",
+        mag_frame_id="mag",
+        a_mean_mps2=np.array([0.0, 0.0, 9.81], dtype=np.float64),
+        cov_a=np.eye(3, dtype=np.float64),
+        m_mean_T=np.array([1.0, 0.0, 0.0], dtype=np.float64),
+        cov_m=np.eye(3, dtype=np.float64),
+        sample_count=2,
+        duration_ns=10,
+    )
+    keyframe = keyframe.update_with_segment(segment)
+    assert keyframe.gravity_weight == 1
+    assert keyframe.mag_weight == 1
+    assert keyframe.segment_count == 1
+    assert keyframe.mag_mean_dir_M is not None
+
+
+def test_keyframe_requires_non_zero_mean_when_weighted() -> None:
+    """Ensure non-zero mean vectors are required with positive weight."""
+    with pytest.raises(ValueError):
+        Keyframe(
+            keyframe_id=1,
+            gravity_mean_dir_I=np.zeros(3, dtype=np.float64),
+            gravity_cov_dir_I=np.zeros((3, 3), dtype=np.float64),
+            gravity_weight=1,
+            mag_mean_dir_M=None,
+            mag_cov_dir_M=None,
+            mag_weight=0,
+            segment_count=0,
+        )

--- a/oasis_control/test/mounting/mounting_types/test_keyframe.py
+++ b/oasis_control/test/mounting/mounting_types/test_keyframe.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/test/mounting/mounting_types/test_mag_packet.py
+++ b/oasis_control/test/mounting/mounting_types/test_mag_packet.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/test/mounting/mounting_types/test_mag_packet.py
+++ b/oasis_control/test/mounting/mounting_types/test_mag_packet.py
@@ -7,3 +7,49 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+"""Tests for magnetometer packet types."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from oasis_control.localization.mounting.mounting_types.mag_packet import MagPacket
+
+
+def test_mag_packet_helpers() -> None:
+    """Verify magnitude and unit direction helpers."""
+    packet: MagPacket = MagPacket(
+        t_meas_ns=10,
+        frame_id="mag",
+        m_raw_T=np.array([1.0, 2.0, 2.0], dtype=np.float64),
+        cov_m_raw_T2=np.eye(3, dtype=np.float64),
+    )
+    magnitude: float = packet.magnitude_T()
+    assert magnitude == pytest.approx(3.0)
+    unit_dir: np.ndarray = packet.unit_direction()
+    np.testing.assert_allclose(unit_dir, np.array([1.0, 2.0, 2.0]) / 3.0)
+
+
+def test_mag_packet_shape_validation() -> None:
+    """Ensure invalid shapes raise a ValueError."""
+    with pytest.raises(ValueError):
+        MagPacket(
+            t_meas_ns=0,
+            frame_id="mag",
+            m_raw_T=np.array([0.0, 0.0, 0.0], dtype=np.float64),
+            cov_m_raw_T2=np.eye(2, dtype=np.float64),
+        )
+
+
+def test_mag_packet_finite_validation() -> None:
+    """Ensure NaN values are rejected."""
+    m_raw_T: np.ndarray = np.array([1.0, np.nan, 0.0], dtype=np.float64)
+    with pytest.raises(ValueError):
+        MagPacket(
+            t_meas_ns=0,
+            frame_id="mag",
+            m_raw_T=m_raw_T,
+            cov_m_raw_T2=np.eye(3, dtype=np.float64),
+        )

--- a/oasis_control/test/mounting/mounting_types/test_result_snapshot.py
+++ b/oasis_control/test/mounting/mounting_types/test_result_snapshot.py
@@ -7,3 +7,104 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+"""Tests for result snapshot types."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from oasis_control.localization.mounting.math_utils.se3 import SE3
+from oasis_control.localization.mounting.mounting_types.result_snapshot import (
+    ResultSnapshot,
+)
+
+
+def _make_se3() -> SE3:
+    """Create a valid SE3 pose for tests."""
+    return SE3(R=np.eye(3, dtype=np.float64), p=np.zeros(3, dtype=np.float64))
+
+
+def test_result_snapshot_validation() -> None:
+    """Ensure snapshot validates required shapes."""
+    T_BI: SE3 = _make_se3()
+    with pytest.raises(ValueError):
+        ResultSnapshot(
+            t_meas_ns=0,
+            frame_base="base",
+            frame_imu="imu",
+            frame_mag=None,
+            T_BI=T_BI,
+            T_BM=None,
+            cov_rot_BI=np.eye(2, dtype=np.float64),
+            cov_trans_BI=np.eye(3, dtype=np.float64),
+            cov_rot_BM=None,
+            cov_trans_BM=None,
+            b_a_mps2=np.zeros(3, dtype=np.float64),
+            A_a=np.eye(3, dtype=np.float64),
+            b_g_rads=np.zeros(3, dtype=np.float64),
+            b_m_T=None,
+            R_m=None,
+            segment_count=0,
+            keyframe_count=0,
+            diversity_tilt_deg=None,
+            diversity_yaw_deg=None,
+            is_stable=False,
+            quality_score=None,
+        )
+
+
+def test_result_snapshot_mag_consistency() -> None:
+    """Ensure mag fields are consistent with mag frame."""
+    T_BI: SE3 = _make_se3()
+    T_BM: SE3 = _make_se3()
+    snapshot: ResultSnapshot = ResultSnapshot(
+        t_meas_ns=0,
+        frame_base="base",
+        frame_imu="imu",
+        frame_mag="mag",
+        T_BI=T_BI,
+        T_BM=T_BM,
+        cov_rot_BI=np.eye(3, dtype=np.float64),
+        cov_trans_BI=np.eye(3, dtype=np.float64),
+        cov_rot_BM=np.eye(3, dtype=np.float64),
+        cov_trans_BM=np.eye(3, dtype=np.float64),
+        b_a_mps2=np.zeros(3, dtype=np.float64),
+        A_a=np.eye(3, dtype=np.float64),
+        b_g_rads=np.zeros(3, dtype=np.float64),
+        b_m_T=np.zeros(3, dtype=np.float64),
+        R_m=np.eye(3, dtype=np.float64),
+        segment_count=2,
+        keyframe_count=1,
+        diversity_tilt_deg=10.0,
+        diversity_yaw_deg=20.0,
+        is_stable=True,
+        quality_score=0.9,
+    )
+    assert snapshot.frame_mag == "mag"
+
+    with pytest.raises(ValueError):
+        ResultSnapshot(
+            t_meas_ns=0,
+            frame_base="base",
+            frame_imu="imu",
+            frame_mag=None,
+            T_BI=T_BI,
+            T_BM=T_BM,
+            cov_rot_BI=np.eye(3, dtype=np.float64),
+            cov_trans_BI=np.eye(3, dtype=np.float64),
+            cov_rot_BM=np.eye(3, dtype=np.float64),
+            cov_trans_BM=np.eye(3, dtype=np.float64),
+            b_a_mps2=np.zeros(3, dtype=np.float64),
+            A_a=np.eye(3, dtype=np.float64),
+            b_g_rads=np.zeros(3, dtype=np.float64),
+            b_m_T=None,
+            R_m=None,
+            segment_count=2,
+            keyframe_count=1,
+            diversity_tilt_deg=None,
+            diversity_yaw_deg=None,
+            is_stable=False,
+            quality_score=None,
+        )

--- a/oasis_control/test/mounting/mounting_types/test_result_snapshot.py
+++ b/oasis_control/test/mounting/mounting_types/test_result_snapshot.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/test/mounting/mounting_types/test_steady_segment.py
+++ b/oasis_control/test/mounting/mounting_types/test_steady_segment.py
@@ -7,3 +7,71 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+"""Tests for steady segment types."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from oasis_control.localization.mounting.mounting_types.steady_segment import (
+    SteadySegment,
+)
+
+
+def test_steady_segment_gravity_direction() -> None:
+    """Ensure gravity direction helper normalizes -a_mean."""
+    segment: SteadySegment = SteadySegment(
+        t_start_ns=0,
+        t_end_ns=100,
+        t_meas_ns=50,
+        imu_frame_id="imu",
+        mag_frame_id=None,
+        a_mean_mps2=np.array([0.0, 0.0, -9.81], dtype=np.float64),
+        cov_a=np.eye(3, dtype=np.float64),
+        m_mean_T=None,
+        cov_m=None,
+        sample_count=5,
+        duration_ns=100,
+    )
+    gravity_dir: np.ndarray = segment.gravity_up_dir_I()
+    np.testing.assert_allclose(gravity_dir, np.array([0.0, 0.0, 1.0]))
+
+
+def test_steady_segment_mag_consistency_validation() -> None:
+    """Ensure mag fields require a mag frame."""
+    with pytest.raises(ValueError):
+        SteadySegment(
+            t_start_ns=0,
+            t_end_ns=10,
+            t_meas_ns=5,
+            imu_frame_id="imu",
+            mag_frame_id=None,
+            a_mean_mps2=np.array([0.0, 0.0, 9.81], dtype=np.float64),
+            cov_a=np.eye(3, dtype=np.float64),
+            m_mean_T=np.array([1.0, 0.0, 0.0], dtype=np.float64),
+            cov_m=np.eye(3, dtype=np.float64),
+            sample_count=3,
+            duration_ns=10,
+        )
+
+
+def test_steady_segment_finite_validation() -> None:
+    """Ensure invalid values are rejected."""
+    cov_a: np.ndarray = np.eye(3, dtype=np.float64)
+    cov_a[0, 0] = np.nan
+    with pytest.raises(ValueError):
+        SteadySegment(
+            t_start_ns=0,
+            t_end_ns=10,
+            t_meas_ns=5,
+            imu_frame_id="imu",
+            mag_frame_id=None,
+            a_mean_mps2=np.array([0.0, 0.0, 9.81], dtype=np.float64),
+            cov_a=cov_a,
+            m_mean_T=None,
+            cov_m=None,
+            sample_count=3,
+            duration_ns=10,
+        )

--- a/oasis_control/test/mounting/mounting_types/test_steady_segment.py
+++ b/oasis_control/test/mounting/mounting_types/test_steady_segment.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/test/mounting/mounting_types/test_update_report.py
+++ b/oasis_control/test/mounting/mounting_types/test_update_report.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/test/mounting/mounting_types/test_update_report.py
+++ b/oasis_control/test/mounting/mounting_types/test_update_report.py
@@ -7,3 +7,59 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+"""Tests for update report types."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from oasis_control.localization.mounting.mounting_types.update_report import (
+    UpdateReport,
+)
+
+
+def test_update_report_validation() -> None:
+    """Ensure invalid fields raise errors."""
+    with pytest.raises(ValueError):
+        UpdateReport(
+            did_update=True,
+            iterations=-1,
+            step_norm=None,
+            residual_rms=None,
+            need_more_tilt=False,
+            need_more_yaw=False,
+            dropped_segments=0,
+            dropped_mags=0,
+            message=None,
+        )
+
+    with pytest.raises(ValueError):
+        UpdateReport(
+            did_update=True,
+            iterations=1,
+            step_norm=float(np.nan),
+            residual_rms=None,
+            need_more_tilt=False,
+            need_more_yaw=False,
+            dropped_segments=0,
+            dropped_mags=0,
+            message=None,
+        )
+
+
+def test_update_report_success() -> None:
+    """Ensure a valid report is accepted."""
+    report: UpdateReport = UpdateReport(
+        did_update=True,
+        iterations=3,
+        step_norm=0.1,
+        residual_rms=0.5,
+        need_more_tilt=False,
+        need_more_yaw=True,
+        dropped_segments=1,
+        dropped_mags=0,
+        message="ok",
+    )
+    assert report.did_update

--- a/oasis_control/test/mounting/solver/test_initialization.py
+++ b/oasis_control/test/mounting/solver/test_initialization.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/test/mounting/solver/test_optimizer.py
+++ b/oasis_control/test/mounting/solver/test_optimizer.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/test/mounting/solver/test_problem.py
+++ b/oasis_control/test/mounting/solver/test_problem.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/test/mounting/solver/test_problem_and_optimizer.py
+++ b/oasis_control/test/mounting/solver/test_problem_and_optimizer.py
@@ -1,0 +1,138 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""Tests for problem linearization and optimizer integration."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+from numpy.typing import NDArray
+
+from oasis_control.localization.mounting.config.mounting_params import MountingParams
+from oasis_control.localization.mounting.config.mounting_params import SolverParams
+from oasis_control.localization.mounting.math_utils.quat import Quaternion
+from oasis_control.localization.mounting.mounting_types.keyframe import Keyframe
+from oasis_control.localization.mounting.solver.optimizer import optimize
+from oasis_control.localization.mounting.solver.problem import build_linearization
+from oasis_control.localization.mounting.state.mounting_state import ImuNuisance
+from oasis_control.localization.mounting.state.mounting_state import KeyframeAttitude
+from oasis_control.localization.mounting.state.mounting_state import MagNuisance
+from oasis_control.localization.mounting.state.mounting_state import MountEstimate
+from oasis_control.localization.mounting.state.mounting_state import MountingState
+
+
+# Units: unitless^2. Meaning: covariance diagonal for synthetic gravity data
+_GRAVITY_COV_DIAG: float = 1e-4
+
+
+def _make_keyframe(
+    keyframe_id: int,
+    q_WB_wxyz: NDArray[np.float64],
+    g_W_unit: NDArray[np.float64],
+    q_BI_wxyz: NDArray[np.float64],
+) -> Keyframe:
+    R_WB: NDArray[np.float64] = Quaternion(q_WB_wxyz).as_matrix()
+    R_BI: NDArray[np.float64] = Quaternion(q_BI_wxyz).as_matrix()
+    a_hat_I: NDArray[np.float64] = (R_WB.T @ R_BI) @ g_W_unit
+    gravity_cov: NDArray[np.float64] = np.eye(3, dtype=np.float64) * _GRAVITY_COV_DIAG
+    return Keyframe(
+        keyframe_id=keyframe_id,
+        gravity_mean_dir_I=a_hat_I,
+        gravity_cov_dir_I=gravity_cov,
+        gravity_weight=1,
+        mag_mean_dir_M=None,
+        mag_cov_dir_M=None,
+        mag_weight=0,
+        segment_count=1,
+    )
+
+
+def test_optimizer_reduces_cost_and_handles_mag_optional() -> None:
+    """Check a Gauss-Newton step lowers cost without mag variables."""
+    g_W_unit: NDArray[np.float64] = np.array([0.0, 0.0, -1.0], dtype=np.float64)
+    q_BI_true: NDArray[np.float64] = np.array(
+        [1.0, 0.0, 0.0, 0.0],
+        dtype=np.float64,
+    )
+    q_BI_init: NDArray[np.float64] = Quaternion.from_rotvec(
+        np.array([0.05, 0.0, 0.0], dtype=np.float64)
+    ).to_wxyz()
+    q_WB_0: NDArray[np.float64] = np.array(
+        [1.0, 0.0, 0.0, 0.0],
+        dtype=np.float64,
+    )
+    tilt_rad: float = float(np.deg2rad(30.0))
+    q_WB_1: NDArray[np.float64] = Quaternion.from_rotvec(
+        np.array([tilt_rad, 0.0, 0.0], dtype=np.float64)
+    ).to_wxyz()
+
+    keyframes: tuple[Keyframe, ...] = (
+        _make_keyframe(0, q_WB_0, g_W_unit, q_BI_true),
+        _make_keyframe(1, q_WB_1, g_W_unit, q_BI_true),
+    )
+    mount: MountEstimate = MountEstimate(
+        q_BI_wxyz=q_BI_init,
+        q_BM_wxyz=np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float64),
+        p_BI_m=np.zeros(3, dtype=np.float64),
+        p_BM_m=np.zeros(3, dtype=np.float64),
+    )
+    imu: ImuNuisance = ImuNuisance(
+        b_a_mps2=np.zeros(3, dtype=np.float64),
+        A_a=np.eye(3, dtype=np.float64),
+        b_g_rads=np.zeros(3, dtype=np.float64),
+    )
+    mag: MagNuisance = MagNuisance(
+        b_m_T=None,
+        R_m_unitless2=np.eye(3, dtype=np.float64),
+    )
+    state: MountingState = MountingState(
+        mount=mount,
+        g_W_unit=g_W_unit,
+        m_W_unit=None,
+        imu=imu,
+        mag=mag,
+        keyframes=(
+            KeyframeAttitude(keyframe_id=0, q_WB_wxyz=q_WB_0),
+            KeyframeAttitude(keyframe_id=1, q_WB_wxyz=q_WB_1),
+        ),
+        anchored=False,
+        mag_reference_invalid=False,
+    )
+
+    params: MountingParams = MountingParams.defaults()
+    solver: SolverParams = replace(params.solver, max_iters=1)
+    params = replace(params, solver=solver)
+
+    cost_initial: float
+    _, _, cost_initial, _ = build_linearization(
+        state,
+        keyframes,
+        params,
+        include_translation_vars=False,
+    )
+    updated_state: MountingState
+    updated_state, _ = optimize(
+        state,
+        keyframes,
+        params,
+        include_translation_vars=False,
+    )
+    cost_updated: float
+    _, _, cost_updated, _ = build_linearization(
+        updated_state,
+        keyframes,
+        params,
+        include_translation_vars=False,
+    )
+
+    assert cost_initial > 0.0
+    assert cost_updated < cost_initial

--- a/oasis_control/test/mounting/solver/test_problem_and_optimizer.py
+++ b/oasis_control/test/mounting/solver/test_problem_and_optimizer.py
@@ -33,6 +33,9 @@ from oasis_control.localization.mounting.state.mounting_state import MountingSta
 # Units: unitless^2. Meaning: covariance diagonal for synthetic gravity data
 _GRAVITY_COV_DIAG: float = 1e-4
 
+# Units: unitless^2. Meaning: covariance diagonal for synthetic mag data
+_MAG_COV_DIAG: float = 1e-4
+
 
 def _make_keyframe(
     keyframe_id: int,
@@ -52,6 +55,33 @@ def _make_keyframe(
         mag_mean_dir_M=None,
         mag_cov_dir_M=None,
         mag_weight=0,
+        segment_count=1,
+    )
+
+
+def _make_mag_keyframe(
+    keyframe_id: int,
+    q_WB_wxyz: NDArray[np.float64],
+    g_W_unit: NDArray[np.float64],
+    q_BI_wxyz: NDArray[np.float64],
+    m_W_unit: NDArray[np.float64],
+    q_BM_wxyz: NDArray[np.float64],
+) -> Keyframe:
+    R_WB: NDArray[np.float64] = Quaternion(q_WB_wxyz).as_matrix()
+    R_BI: NDArray[np.float64] = Quaternion(q_BI_wxyz).as_matrix()
+    R_BM: NDArray[np.float64] = Quaternion(q_BM_wxyz).as_matrix()
+    a_hat_I: NDArray[np.float64] = (R_WB.T @ R_BI) @ g_W_unit
+    m_hat_M: NDArray[np.float64] = (R_WB.T @ R_BM) @ m_W_unit
+    gravity_cov: NDArray[np.float64] = np.eye(3, dtype=np.float64) * _GRAVITY_COV_DIAG
+    mag_cov: NDArray[np.float64] = np.eye(3, dtype=np.float64) * _MAG_COV_DIAG
+    return Keyframe(
+        keyframe_id=keyframe_id,
+        gravity_mean_dir_I=a_hat_I,
+        gravity_cov_dir_I=gravity_cov,
+        gravity_weight=1,
+        mag_mean_dir_M=m_hat_M,
+        mag_cov_dir_M=mag_cov,
+        mag_weight=1,
         segment_count=1,
     )
 
@@ -136,3 +166,242 @@ def test_optimizer_reduces_cost_and_handles_mag_optional() -> None:
 
     assert cost_initial > 0.0
     assert cost_updated < cost_initial
+
+
+def test_optimizer_robust_loss_reduces_outlier_cost() -> None:
+    """Ensure robust loss still reduces cost with a gravity outlier."""
+    g_W_unit: NDArray[np.float64] = np.array([0.0, 0.0, -1.0], dtype=np.float64)
+    q_BI_true: NDArray[np.float64] = np.array(
+        [1.0, 0.0, 0.0, 0.0],
+        dtype=np.float64,
+    )
+    q_BI_init: NDArray[np.float64] = Quaternion.from_rotvec(
+        np.array([0.1, 0.0, 0.0], dtype=np.float64)
+    ).to_wxyz()
+    q_WB_0: NDArray[np.float64] = np.array(
+        [1.0, 0.0, 0.0, 0.0],
+        dtype=np.float64,
+    )
+    tilt_rad: float = float(np.deg2rad(20.0))
+    q_WB_1: NDArray[np.float64] = Quaternion.from_rotvec(
+        np.array([tilt_rad, 0.0, 0.0], dtype=np.float64)
+    ).to_wxyz()
+    q_WB_2: NDArray[np.float64] = np.array(
+        [1.0, 0.0, 0.0, 0.0],
+        dtype=np.float64,
+    )
+    outlier_dir_I: NDArray[np.float64] = np.array(
+        [1.0, 0.0, 0.0],
+        dtype=np.float64,
+    )
+    gravity_cov: NDArray[np.float64] = np.eye(3, dtype=np.float64) * _GRAVITY_COV_DIAG
+    keyframes: tuple[Keyframe, ...] = (
+        _make_keyframe(0, q_WB_0, g_W_unit, q_BI_true),
+        _make_keyframe(1, q_WB_1, g_W_unit, q_BI_true),
+        Keyframe(
+            keyframe_id=2,
+            gravity_mean_dir_I=outlier_dir_I,
+            gravity_cov_dir_I=gravity_cov,
+            gravity_weight=1,
+            mag_mean_dir_M=None,
+            mag_cov_dir_M=None,
+            mag_weight=0,
+            segment_count=1,
+        ),
+    )
+    mount: MountEstimate = MountEstimate(
+        q_BI_wxyz=q_BI_init,
+        q_BM_wxyz=np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float64),
+        p_BI_m=np.zeros(3, dtype=np.float64),
+        p_BM_m=np.zeros(3, dtype=np.float64),
+    )
+    imu: ImuNuisance = ImuNuisance(
+        b_a_mps2=np.zeros(3, dtype=np.float64),
+        A_a=np.eye(3, dtype=np.float64),
+        b_g_rads=np.zeros(3, dtype=np.float64),
+    )
+    mag: MagNuisance = MagNuisance(
+        b_m_T=None,
+        R_m_unitless2=np.eye(3, dtype=np.float64),
+    )
+    state: MountingState = MountingState(
+        mount=mount,
+        g_W_unit=g_W_unit,
+        m_W_unit=None,
+        imu=imu,
+        mag=mag,
+        keyframes=(
+            KeyframeAttitude(keyframe_id=0, q_WB_wxyz=q_WB_0),
+            KeyframeAttitude(keyframe_id=1, q_WB_wxyz=q_WB_1),
+            KeyframeAttitude(keyframe_id=2, q_WB_wxyz=q_WB_2),
+        ),
+        anchored=False,
+        mag_reference_invalid=False,
+    )
+    params: MountingParams = MountingParams.defaults()
+    solver: SolverParams = replace(
+        params.solver,
+        max_iters=1,
+        robust_loss="huber",
+        robust_scale_a=0.5,
+    )
+    params = replace(params, solver=solver)
+    cost_initial: float
+    _, _, cost_initial, _ = build_linearization(
+        state,
+        keyframes,
+        params,
+        include_translation_vars=False,
+    )
+    updated_state: MountingState
+    updated_state, _ = optimize(
+        state,
+        keyframes,
+        params,
+        include_translation_vars=False,
+    )
+    cost_updated: float
+    _, _, cost_updated, _ = build_linearization(
+        updated_state,
+        keyframes,
+        params,
+        include_translation_vars=False,
+    )
+
+    assert cost_initial > 0.0
+    assert cost_updated < cost_initial
+
+
+def test_gravity_weight_scales_cost() -> None:
+    """Check gravity weight scales cost contribution."""
+    g_W_unit: NDArray[np.float64] = np.array([0.0, 0.0, -1.0], dtype=np.float64)
+    q_BI_true: NDArray[np.float64] = np.array(
+        [1.0, 0.0, 0.0, 0.0],
+        dtype=np.float64,
+    )
+    q_BI_init: NDArray[np.float64] = Quaternion.from_rotvec(
+        np.array([0.08, 0.0, 0.0], dtype=np.float64)
+    ).to_wxyz()
+    q_WB_0: NDArray[np.float64] = np.array(
+        [1.0, 0.0, 0.0, 0.0],
+        dtype=np.float64,
+    )
+    keyframe_low: Keyframe = _make_keyframe(0, q_WB_0, g_W_unit, q_BI_true)
+    keyframe_high: Keyframe = replace(keyframe_low, gravity_weight=4)
+    mount: MountEstimate = MountEstimate(
+        q_BI_wxyz=q_BI_init,
+        q_BM_wxyz=np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float64),
+        p_BI_m=np.zeros(3, dtype=np.float64),
+        p_BM_m=np.zeros(3, dtype=np.float64),
+    )
+    imu: ImuNuisance = ImuNuisance(
+        b_a_mps2=np.zeros(3, dtype=np.float64),
+        A_a=np.eye(3, dtype=np.float64),
+        b_g_rads=np.zeros(3, dtype=np.float64),
+    )
+    mag: MagNuisance = MagNuisance(
+        b_m_T=None,
+        R_m_unitless2=np.eye(3, dtype=np.float64),
+    )
+    state: MountingState = MountingState(
+        mount=mount,
+        g_W_unit=g_W_unit,
+        m_W_unit=None,
+        imu=imu,
+        mag=mag,
+        keyframes=(KeyframeAttitude(keyframe_id=0, q_WB_wxyz=q_WB_0),),
+        anchored=False,
+        mag_reference_invalid=False,
+    )
+    params: MountingParams = MountingParams.defaults()
+    cost_low: float
+    _, _, cost_low, _ = build_linearization(
+        state,
+        (keyframe_low,),
+        params,
+        include_translation_vars=False,
+    )
+    cost_high: float
+    _, _, cost_high, _ = build_linearization(
+        state,
+        (keyframe_high,),
+        params,
+        include_translation_vars=False,
+    )
+
+    assert cost_low > 0.0
+    assert cost_high > cost_low * 2.0
+
+
+def test_build_linearization_hessian_is_solvable() -> None:
+    """Ensure weak priors keep the Hessian solvable."""
+    g_W_unit: NDArray[np.float64] = np.array([0.0, 0.0, -1.0], dtype=np.float64)
+    m_W_unit: NDArray[np.float64] = np.array([1.0, 0.0, 0.0], dtype=np.float64)
+    q_BI_true: NDArray[np.float64] = np.array(
+        [1.0, 0.0, 0.0, 0.0],
+        dtype=np.float64,
+    )
+    q_BM_true: NDArray[np.float64] = np.array(
+        [1.0, 0.0, 0.0, 0.0],
+        dtype=np.float64,
+    )
+    q_BI_init: NDArray[np.float64] = Quaternion.from_rotvec(
+        np.array([0.05, 0.02, 0.0], dtype=np.float64)
+    ).to_wxyz()
+    q_BM_init: NDArray[np.float64] = Quaternion.from_rotvec(
+        np.array([0.01, -0.03, 0.0], dtype=np.float64)
+    ).to_wxyz()
+    q_WB_0: NDArray[np.float64] = np.array(
+        [1.0, 0.0, 0.0, 0.0],
+        dtype=np.float64,
+    )
+    q_WB_1: NDArray[np.float64] = Quaternion.from_rotvec(
+        np.array([0.0, 0.3, 0.0], dtype=np.float64)
+    ).to_wxyz()
+    keyframes: tuple[Keyframe, ...] = (
+        _make_mag_keyframe(0, q_WB_0, g_W_unit, q_BI_true, m_W_unit, q_BM_true),
+        _make_mag_keyframe(1, q_WB_1, g_W_unit, q_BI_true, m_W_unit, q_BM_true),
+    )
+    mount: MountEstimate = MountEstimate(
+        q_BI_wxyz=q_BI_init,
+        q_BM_wxyz=q_BM_init,
+        p_BI_m=np.zeros(3, dtype=np.float64),
+        p_BM_m=np.zeros(3, dtype=np.float64),
+    )
+    imu: ImuNuisance = ImuNuisance(
+        b_a_mps2=np.zeros(3, dtype=np.float64),
+        A_a=np.eye(3, dtype=np.float64),
+        b_g_rads=np.zeros(3, dtype=np.float64),
+    )
+    mag: MagNuisance = MagNuisance(
+        b_m_T=np.zeros(3, dtype=np.float64),
+        R_m_unitless2=np.eye(3, dtype=np.float64),
+    )
+    state: MountingState = MountingState(
+        mount=mount,
+        g_W_unit=g_W_unit,
+        m_W_unit=m_W_unit,
+        imu=imu,
+        mag=mag,
+        keyframes=(
+            KeyframeAttitude(keyframe_id=0, q_WB_wxyz=q_WB_0),
+            KeyframeAttitude(keyframe_id=1, q_WB_wxyz=q_WB_1),
+        ),
+        anchored=False,
+        mag_reference_invalid=False,
+    )
+    params: MountingParams = MountingParams.defaults()
+    H: NDArray[np.float64]
+    b: NDArray[np.float64]
+    H, b, _, _ = build_linearization(
+        state,
+        keyframes,
+        params,
+        include_translation_vars=False,
+    )
+    delta: NDArray[np.float64] = np.asarray(
+        np.linalg.solve(H, -b),
+        dtype=np.float64,
+    )
+
+    assert np.all(np.isfinite(delta))

--- a/oasis_control/test/mounting/solver/test_residuals.py
+++ b/oasis_control/test/mounting/solver/test_residuals.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/test/mounting/solver/test_residuals.py
+++ b/oasis_control/test/mounting/solver/test_residuals.py
@@ -7,3 +7,69 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+"""Tests for residual computations."""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+from oasis_control.localization.mounting.math_utils.quat import Quaternion
+from oasis_control.localization.mounting.solver.residuals import AccelResidual
+from oasis_control.localization.mounting.solver.residuals import accel_residual
+from oasis_control.localization.mounting.solver.residuals import (
+    accel_residual_with_jacobians,
+)
+from oasis_control.localization.mounting.solver.residuals import mag_residual
+
+
+def test_accel_residual_zero_when_aligned() -> None:
+    """Check accel residual vanishes when aligned."""
+    q_identity: NDArray[np.float64] = np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float64)
+    g_W_unit: NDArray[np.float64] = np.array([0.0, 0.0, -1.0], dtype=np.float64)
+    a_hat_meas: NDArray[np.float64] = np.array([0.0, 0.0, -1.0], dtype=np.float64)
+    residual, prediction = accel_residual(a_hat_meas, q_identity, q_identity, g_W_unit)
+    assert np.allclose(residual, np.zeros(3, dtype=np.float64), atol=1e-12)
+    assert np.allclose(prediction, a_hat_meas, atol=1e-12)
+
+
+def test_mag_residual_zero_when_aligned() -> None:
+    """Check mag residual vanishes when aligned."""
+    q_identity: NDArray[np.float64] = np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float64)
+    m_W_unit: NDArray[np.float64] = np.array([1.0, 0.0, 0.0], dtype=np.float64)
+    m_hat_meas: NDArray[np.float64] = np.array([1.0, 0.0, 0.0], dtype=np.float64)
+    residual, prediction = mag_residual(m_hat_meas, q_identity, q_identity, m_W_unit)
+    assert np.allclose(residual, np.zeros(3, dtype=np.float64), atol=1e-12)
+    assert np.allclose(prediction, m_hat_meas, atol=1e-12)
+
+
+def test_small_angle_jacobian_sanity() -> None:
+    """Check Jacobian matches finite differences for a small perturbation."""
+    rng: np.random.Generator = np.random.default_rng(0)
+    rotvec: NDArray[np.float64] = rng.normal(size=3).astype(np.float64)
+    q_WB: NDArray[np.float64] = Quaternion.from_rotvec(rotvec).to_wxyz()
+    q_BI: NDArray[np.float64] = Quaternion.from_rotvec(
+        rng.normal(size=3).astype(np.float64)
+    ).to_wxyz()
+    g_W_unit: NDArray[np.float64] = rng.normal(size=3).astype(np.float64)
+    g_W_unit = g_W_unit / np.linalg.norm(g_W_unit)
+    a_meas: NDArray[np.float64] = rng.normal(size=3).astype(np.float64)
+    a_meas = a_meas / np.linalg.norm(a_meas)
+
+    residual0: NDArray[np.float64]
+    residual0, _ = accel_residual(a_meas, q_WB, q_BI, g_W_unit)
+    jac: AccelResidual = accel_residual_with_jacobians(
+        a_meas,
+        q_WB,
+        q_BI,
+        g_W_unit,
+    )
+    delta: NDArray[np.float64] = np.array([1e-6, -2e-6, 1e-6], dtype=np.float64)
+    q_WB_perturbed: NDArray[np.float64] = (
+        (Quaternion.from_rotvec(delta) * Quaternion(q_WB)).normalized().to_wxyz()
+    )
+    residual1: NDArray[np.float64]
+    residual1, _ = accel_residual(a_meas, q_WB_perturbed, q_BI, g_W_unit)
+    residual_lin: NDArray[np.float64] = residual0 + jac.J_wb @ delta
+    assert np.allclose(residual1, residual_lin, atol=1e-6)

--- a/oasis_control/test/mounting/solver/test_robust_loss.py
+++ b/oasis_control/test/mounting/solver/test_robust_loss.py
@@ -7,3 +7,35 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+"""Tests for robust loss weights."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from oasis_control.localization.mounting.solver.robust_loss import cauchy_weight
+from oasis_control.localization.mounting.solver.robust_loss import huber_weight
+
+
+def test_huber_weight_limits() -> None:
+    """Check Huber weights for small and large residuals."""
+    scale: float = 1.0
+    small_sq: float = 1e-4
+    large_sq: float = 100.0
+    small_weight: float = huber_weight(small_sq, scale)
+    large_weight: float = huber_weight(large_sq, scale)
+    assert np.isclose(small_weight, 1.0, atol=1e-12)
+    assert np.isclose(large_weight, scale / np.sqrt(large_sq), atol=1e-12)
+
+
+def test_cauchy_weight_monotonic() -> None:
+    """Check Cauchy weights decrease monotonically with residual size."""
+    scale: float = 0.5
+    weights: list[float] = [
+        cauchy_weight(0.0, scale),
+        cauchy_weight(0.1, scale),
+        cauchy_weight(1.0, scale),
+        cauchy_weight(10.0, scale),
+    ]
+    assert all(weights[i] >= weights[i + 1] for i in range(len(weights) - 1))

--- a/oasis_control/test/mounting/solver/test_robust_loss.py
+++ b/oasis_control/test/mounting/solver/test_robust_loss.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/test/mounting/state/test_covariance.py
+++ b/oasis_control/test/mounting/state/test_covariance.py
@@ -1,0 +1,49 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""Tests for covariance utilities."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from oasis_control.localization.mounting.state.covariance import Covariance
+from oasis_control.localization.mounting.state.covariance import CovarianceError
+
+
+def test_covariance_zeros() -> None:
+    """Ensure zero covariances are valid and symmetric."""
+    cov: Covariance = Covariance.zeros(3)
+    mat: np.ndarray = cov.as_array()
+    assert mat.shape == (3, 3)
+    np.testing.assert_allclose(mat, np.zeros((3, 3), dtype=np.float64))
+
+
+def test_covariance_rejects_non_symmetric() -> None:
+    """Ensure non-symmetric covariance matrices raise."""
+    mat: np.ndarray = np.array(
+        [[1.0, 2.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+        dtype=np.float64,
+    )
+    with pytest.raises(CovarianceError):
+        Covariance(mat)
+
+
+def test_covariance_psd_checks() -> None:
+    """Ensure PSD checks are consistent."""
+    cov: Covariance = Covariance.eye(3)
+    assert cov.is_psd()
+    cov.assert_psd()
+
+    bad: Covariance = Covariance(np.diag(np.array([1.0, -0.5, 2.0], dtype=np.float64)))
+    assert not bad.is_psd()
+    with pytest.raises(CovarianceError):
+        bad.assert_psd()

--- a/oasis_control/test/mounting/state/test_mounting_state.py
+++ b/oasis_control/test/mounting/state/test_mounting_state.py
@@ -1,0 +1,85 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""Tests for mounting calibration state containers."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import numpy as np
+import pytest
+
+from oasis_control.localization.mounting.state.mounting_state import KeyframeAttitude
+from oasis_control.localization.mounting.state.mounting_state import MountEstimate
+from oasis_control.localization.mounting.state.mounting_state import MountingState
+from oasis_control.localization.mounting.state.mounting_state import MountingStateError
+
+
+def test_mounting_state_default_validates() -> None:
+    """Ensure the default state validates."""
+    state: MountingState = MountingState.default()
+    state.validate()
+
+
+def test_mount_estimate_normalizes_quaternion() -> None:
+    """Ensure quaternions are normalized on construction."""
+    mount: MountEstimate = MountEstimate(
+        q_BI_wxyz=np.array([2.0, 0.0, 0.0, 0.0], dtype=np.float64),
+        q_BM_wxyz=np.array([0.0, 0.0, 0.0, -3.0], dtype=np.float64),
+        p_BI_m=np.zeros(3, dtype=np.float64),
+        p_BM_m=np.zeros(3, dtype=np.float64),
+    )
+    assert np.isclose(np.linalg.norm(mount.q_BI_wxyz), 1.0)
+    assert np.isclose(np.linalg.norm(mount.q_BM_wxyz), 1.0)
+
+
+def test_keyframe_ordering_and_uniqueness() -> None:
+    """Ensure keyframes are sorted and unique."""
+    kf_1: KeyframeAttitude = KeyframeAttitude(
+        keyframe_id=2,
+        q_WB_wxyz=np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float64),
+    )
+    kf_2: KeyframeAttitude = KeyframeAttitude(
+        keyframe_id=1,
+        q_WB_wxyz=np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float64),
+    )
+    state: MountingState = MountingState.default().replace(keyframes=(kf_1, kf_2))
+    assert state.keyframe_ids() == (1, 2)
+
+    with pytest.raises(MountingStateError):
+        MountingState.default().replace(keyframes=(kf_2, kf_2))
+
+
+def test_with_updated_keyframe_inserts_and_replaces() -> None:
+    """Ensure keyframe insertion and replacement are deterministic."""
+    state: MountingState = MountingState.default()
+    kf_1: KeyframeAttitude = KeyframeAttitude(
+        keyframe_id=5,
+        q_WB_wxyz=np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float64),
+    )
+    state = state.with_updated_keyframe(kf_1)
+    assert state.keyframe_ids() == (5,)
+
+    kf_1_updated: KeyframeAttitude = KeyframeAttitude(
+        keyframe_id=5,
+        q_WB_wxyz=np.array([0.0, 1.0, 0.0, 0.0], dtype=np.float64),
+    )
+    state = state.with_updated_keyframe(kf_1_updated)
+    assert state.get_keyframe(5).q_WB_wxyz[1] == pytest.approx(1.0)
+
+
+def test_mounting_state_replace_and_frozen() -> None:
+    """Ensure replace works and state remains frozen."""
+    state: MountingState = MountingState.default()
+    updated: MountingState = state.replace(anchored=True)
+    assert updated.anchored is True
+    with pytest.raises(FrozenInstanceError):
+        state.anchored = True  # type: ignore[misc]

--- a/oasis_control/test/mounting/state/test_state_mapping.py
+++ b/oasis_control/test/mounting/state/test_state_mapping.py
@@ -1,0 +1,84 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""Tests for state mapping block layout."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from oasis_control.localization.mounting.state.mounting_state import KeyframeAttitude
+from oasis_control.localization.mounting.state.mounting_state import MountingState
+from oasis_control.localization.mounting.state.state_mapping import BLOCK_NAME_A_A
+from oasis_control.localization.mounting.state.state_mapping import BLOCK_NAME_B_A
+from oasis_control.localization.mounting.state.state_mapping import BLOCK_NAME_B_G
+from oasis_control.localization.mounting.state.state_mapping import BLOCK_NAME_G_W
+from oasis_control.localization.mounting.state.state_mapping import BLOCK_NAME_P_BI
+from oasis_control.localization.mounting.state.state_mapping import BLOCK_NAME_P_BM
+from oasis_control.localization.mounting.state.state_mapping import BLOCK_NAME_R_BI
+from oasis_control.localization.mounting.state.state_mapping import BLOCK_NAME_R_BM
+from oasis_control.localization.mounting.state.state_mapping import StateMapping
+
+
+def test_state_mapping_default_blocks() -> None:
+    """Ensure default state mapping contains expected blocks."""
+    state: MountingState = MountingState.default()
+    mapping: StateMapping = StateMapping.from_state(
+        state,
+        include_translation_vars=False,
+    )
+    assert mapping.has(BLOCK_NAME_R_BI)
+    assert mapping.has(BLOCK_NAME_R_BM)
+    assert mapping.has(BLOCK_NAME_G_W)
+    assert mapping.has(BLOCK_NAME_B_A)
+    assert mapping.has(BLOCK_NAME_A_A)
+    assert mapping.has(BLOCK_NAME_B_G)
+    assert not mapping.has(BLOCK_NAME_P_BI)
+    assert not mapping.has(BLOCK_NAME_P_BM)
+    blocks = mapping.blocks()
+    assert mapping.dim() == sum(block.dim for block in blocks)
+    for index, block in enumerate(blocks):
+        if index == 0:
+            assert block.start == 0
+        else:
+            assert block.start == blocks[index - 1].stop()
+
+
+def test_state_mapping_keyframes_ordered() -> None:
+    """Ensure keyframe blocks are ordered by identifier."""
+    kf_a: KeyframeAttitude = KeyframeAttitude(
+        keyframe_id=10,
+        q_WB_wxyz=np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float64),
+    )
+    kf_b: KeyframeAttitude = KeyframeAttitude(
+        keyframe_id=2,
+        q_WB_wxyz=np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float64),
+    )
+    state: MountingState = MountingState.default().replace(keyframes=(kf_a, kf_b))
+    mapping: StateMapping = StateMapping.from_state(
+        state,
+        include_translation_vars=False,
+    )
+    assert mapping.keyframe_block(2).dim == 3
+    assert mapping.keyframe_block(10).dim == 3
+    blocks = mapping.blocks()
+    keyframe_names = [block.name for block in blocks if block.name.startswith("R_WB_")]
+    assert keyframe_names == ["R_WB_2", "R_WB_10"]
+
+
+def test_state_mapping_translation_blocks() -> None:
+    """Ensure translation blocks are included when requested."""
+    state: MountingState = MountingState.default()
+    mapping: StateMapping = StateMapping.from_state(
+        state,
+        include_translation_vars=True,
+    )
+    assert mapping.has(BLOCK_NAME_P_BI)
+    assert mapping.has(BLOCK_NAME_P_BM)

--- a/oasis_control/test/mounting/storage/test_persistence.py
+++ b/oasis_control/test/mounting/storage/test_persistence.py
@@ -1,0 +1,165 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""Tests for mounting YAML persistence."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from oasis_control.localization.mounting.storage.persistence import (
+    MountingPersistenceError,
+)
+from oasis_control.localization.mounting.storage.persistence import load_yaml_snapshot
+from oasis_control.localization.mounting.storage.persistence import save_yaml_snapshot
+from oasis_control.localization.mounting.storage.yaml_format import DiversityYaml
+from oasis_control.localization.mounting.storage.yaml_format import FlagsYaml
+from oasis_control.localization.mounting.storage.yaml_format import FramesYaml
+from oasis_control.localization.mounting.storage.yaml_format import ImuNuisanceYaml
+from oasis_control.localization.mounting.storage.yaml_format import MagNuisanceYaml
+from oasis_control.localization.mounting.storage.yaml_format import MountingSnapshotYaml
+from oasis_control.localization.mounting.storage.yaml_format import QualityYaml
+from oasis_control.localization.mounting.storage.yaml_format import TransformYaml
+
+
+def _build_snapshot() -> MountingSnapshotYaml:
+    """Create a snapshot for persistence tests."""
+    frames: FramesYaml = FramesYaml(
+        base_frame="base_link",
+        imu_frame="imu_link",
+        mag_frame="mag_link",
+    )
+    flags: FlagsYaml = FlagsYaml(
+        anchored=False,
+        mag_reference_invalid=False,
+        mag_disturbance_detected=False,
+        mag_dir_prior_from_driver_cov=True,
+    )
+    t_bi: TransformYaml = TransformYaml(
+        translation_m=np.array([0.0, 0.1, 0.2], dtype=np.float64),
+        quaternion_wxyz=np.array([0.5, 0.5, 0.5, 0.5], dtype=np.float64),
+        rot_cov_rad2=np.eye(3, dtype=np.float64) * 0.05,
+    )
+    t_bm: TransformYaml = TransformYaml(
+        translation_m=np.array([0.3, -0.4, 0.5], dtype=np.float64),
+        quaternion_wxyz=np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float64),
+        rot_cov_rad2=np.eye(3, dtype=np.float64) * 0.06,
+    )
+    imu: ImuNuisanceYaml = ImuNuisanceYaml(
+        accel_bias_mps2=np.array([0.2, 0.1, -0.1], dtype=np.float64),
+        accel_A_row_major=np.arange(9, dtype=np.float64) * 0.02,
+        accel_param_cov_row_major_12x12=np.arange(144, dtype=np.float64) * 0.002,
+        gyro_bias_rads=np.array([0.01, -0.02, 0.03], dtype=np.float64),
+        gyro_bias_cov_row_major_3x3=np.arange(9, dtype=np.float64) * 0.003,
+    )
+    mag: MagNuisanceYaml = MagNuisanceYaml(
+        offset_t=np.array([2e-6, 1e-6, -1e-6], dtype=np.float64),
+        offset_cov_row_major_3x3=np.arange(9, dtype=np.float64) * 2e-8,
+        R_m_unitless2_row_major_3x3=np.arange(9, dtype=np.float64) * 0.007,
+        R_m0_unitless2_row_major_3x3=np.arange(9, dtype=np.float64) * 0.008,
+    )
+    diversity: DiversityYaml = DiversityYaml(
+        gravity_max_angle_deg=10.0,
+        mag_proj_max_angle_deg=5.0,
+    )
+    quality: QualityYaml = QualityYaml(
+        raw_samples=10,
+        steady_segments=2,
+        keyframes=1,
+        total_duration_sec=3.0,
+        accel_residual_rms=0.2,
+        mag_residual_rms=0.3,
+        diversity=diversity,
+    )
+    return MountingSnapshotYaml(
+        format_version=1,
+        frames=frames,
+        flags=flags,
+        T_BI=t_bi,
+        T_BM=t_bm,
+        imu=imu,
+        mag=mag,
+        quality=quality,
+    )
+
+
+def _assert_snapshot_equivalent(
+    left: MountingSnapshotYaml, right: MountingSnapshotYaml
+) -> None:
+    """Assert two snapshots are equivalent."""
+    assert left.format_version == right.format_version
+    assert left.frames == right.frames
+    assert left.flags == right.flags
+    np.testing.assert_allclose(left.T_BI.translation_m, right.T_BI.translation_m)
+    np.testing.assert_allclose(left.T_BI.quaternion_wxyz, right.T_BI.quaternion_wxyz)
+    np.testing.assert_allclose(left.T_BI.rot_cov_rad2, right.T_BI.rot_cov_rad2)
+    np.testing.assert_allclose(left.T_BM.translation_m, right.T_BM.translation_m)
+    np.testing.assert_allclose(left.T_BM.quaternion_wxyz, right.T_BM.quaternion_wxyz)
+    np.testing.assert_allclose(left.T_BM.rot_cov_rad2, right.T_BM.rot_cov_rad2)
+    np.testing.assert_allclose(left.imu.accel_bias_mps2, right.imu.accel_bias_mps2)
+    np.testing.assert_allclose(left.imu.accel_A_row_major, right.imu.accel_A_row_major)
+    np.testing.assert_allclose(
+        left.imu.accel_param_cov_row_major_12x12,
+        right.imu.accel_param_cov_row_major_12x12,
+    )
+    np.testing.assert_allclose(left.imu.gyro_bias_rads, right.imu.gyro_bias_rads)
+    np.testing.assert_allclose(
+        left.imu.gyro_bias_cov_row_major_3x3,
+        right.imu.gyro_bias_cov_row_major_3x3,
+    )
+    np.testing.assert_allclose(left.mag.offset_t, right.mag.offset_t)
+    np.testing.assert_allclose(
+        left.mag.offset_cov_row_major_3x3, right.mag.offset_cov_row_major_3x3
+    )
+    np.testing.assert_allclose(
+        left.mag.R_m_unitless2_row_major_3x3, right.mag.R_m_unitless2_row_major_3x3
+    )
+    np.testing.assert_allclose(
+        left.mag.R_m0_unitless2_row_major_3x3, right.mag.R_m0_unitless2_row_major_3x3
+    )
+    assert left.quality == right.quality
+
+
+def test_save_and_load_snapshot(tmp_path: Path) -> None:
+    """Ensure snapshots are persisted and loaded correctly."""
+    snapshot: MountingSnapshotYaml = _build_snapshot()
+    path: Path = tmp_path / "mount.yaml"
+
+    save_yaml_snapshot(path, snapshot)
+    loaded: MountingSnapshotYaml = load_yaml_snapshot(path)
+
+    _assert_snapshot_equivalent(snapshot, loaded)
+
+
+def test_atomic_write(tmp_path: Path) -> None:
+    """Ensure atomic writes create a valid YAML file."""
+    snapshot: MountingSnapshotYaml = _build_snapshot()
+    path: Path = tmp_path / "atomic.yaml"
+
+    save_yaml_snapshot(path, snapshot, atomic_write=True)
+
+    assert path.exists()
+    loaded: MountingSnapshotYaml = load_yaml_snapshot(path)
+    _assert_snapshot_equivalent(snapshot, loaded)
+
+
+def test_extension_gating(tmp_path: Path) -> None:
+    """Ensure only YAML extensions are accepted."""
+    snapshot: MountingSnapshotYaml = _build_snapshot()
+    invalid_path: Path = tmp_path / "mount.json"
+
+    with pytest.raises(MountingPersistenceError):
+        save_yaml_snapshot(invalid_path, snapshot)
+
+    with pytest.raises(MountingPersistenceError):
+        load_yaml_snapshot(invalid_path)

--- a/oasis_control/test/mounting/storage/test_yaml_format.py
+++ b/oasis_control/test/mounting/storage/test_yaml_format.py
@@ -1,0 +1,213 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""Tests for mounting YAML formatting."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from oasis_control.localization.mounting.storage.yaml_format import DiversityYaml
+from oasis_control.localization.mounting.storage.yaml_format import FlagsYaml
+from oasis_control.localization.mounting.storage.yaml_format import FramesYaml
+from oasis_control.localization.mounting.storage.yaml_format import ImuNuisanceYaml
+from oasis_control.localization.mounting.storage.yaml_format import MagNuisanceYaml
+from oasis_control.localization.mounting.storage.yaml_format import MountingSnapshotYaml
+from oasis_control.localization.mounting.storage.yaml_format import MountingYamlError
+from oasis_control.localization.mounting.storage.yaml_format import QualityYaml
+from oasis_control.localization.mounting.storage.yaml_format import TransformYaml
+from oasis_control.localization.mounting.storage.yaml_format import dumps_yaml
+from oasis_control.localization.mounting.storage.yaml_format import loads_yaml
+from oasis_control.localization.mounting.storage.yaml_format import snapshot_to_dict
+
+
+def _build_snapshot() -> MountingSnapshotYaml:
+    """Create a nontrivial snapshot for tests."""
+    frames: FramesYaml = FramesYaml(
+        base_frame="base_link",
+        imu_frame="imu_link",
+        mag_frame="mag_link",
+    )
+    flags: FlagsYaml = FlagsYaml(
+        anchored=True,
+        mag_reference_invalid=False,
+        mag_disturbance_detected=True,
+        mag_dir_prior_from_driver_cov=False,
+    )
+    t_bi: TransformYaml = TransformYaml(
+        translation_m=np.array([0.1, -0.2, 0.3], dtype=np.float64),
+        quaternion_wxyz=np.array([0.707, 0.0, 0.707, 0.0], dtype=np.float64),
+        rot_cov_rad2=np.eye(3, dtype=np.float64) * 0.01,
+    )
+    t_bm: TransformYaml = TransformYaml(
+        translation_m=np.array([0.4, 0.5, -0.6], dtype=np.float64),
+        quaternion_wxyz=np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float64),
+        rot_cov_rad2=np.eye(3, dtype=np.float64) * 0.02,
+    )
+    imu: ImuNuisanceYaml = ImuNuisanceYaml(
+        accel_bias_mps2=np.array([0.01, -0.02, 0.03], dtype=np.float64),
+        accel_A_row_major=np.arange(9, dtype=np.float64) * 0.01,
+        accel_param_cov_row_major_12x12=np.arange(144, dtype=np.float64) * 0.001,
+        gyro_bias_rads=np.array([0.001, 0.002, -0.003], dtype=np.float64),
+        gyro_bias_cov_row_major_3x3=np.arange(9, dtype=np.float64) * 0.002,
+    )
+    mag: MagNuisanceYaml = MagNuisanceYaml(
+        offset_t=np.array([1e-6, -2e-6, 3e-6], dtype=np.float64),
+        offset_cov_row_major_3x3=np.arange(9, dtype=np.float64) * 1e-8,
+        R_m_unitless2_row_major_3x3=np.arange(9, dtype=np.float64) * 0.003,
+        R_m0_unitless2_row_major_3x3=np.arange(9, dtype=np.float64) * 0.004,
+    )
+    diversity: DiversityYaml = DiversityYaml(
+        gravity_max_angle_deg=35.0,
+        mag_proj_max_angle_deg=20.0,
+    )
+    quality: QualityYaml = QualityYaml(
+        raw_samples=120,
+        steady_segments=8,
+        keyframes=4,
+        total_duration_sec=42.5,
+        accel_residual_rms=0.12,
+        mag_residual_rms=0.08,
+        diversity=diversity,
+    )
+    return MountingSnapshotYaml(
+        format_version=1,
+        frames=frames,
+        flags=flags,
+        T_BI=t_bi,
+        T_BM=t_bm,
+        imu=imu,
+        mag=mag,
+        quality=quality,
+    )
+
+
+def _assert_snapshots_equal(
+    left: MountingSnapshotYaml, right: MountingSnapshotYaml
+) -> None:
+    """Assert two snapshots are equivalent."""
+    assert left.format_version == right.format_version
+    assert left.frames == right.frames
+    assert left.flags == right.flags
+    np.testing.assert_allclose(left.T_BI.translation_m, right.T_BI.translation_m)
+    np.testing.assert_allclose(left.T_BI.quaternion_wxyz, right.T_BI.quaternion_wxyz)
+    np.testing.assert_allclose(left.T_BI.rot_cov_rad2, right.T_BI.rot_cov_rad2)
+    np.testing.assert_allclose(left.T_BM.translation_m, right.T_BM.translation_m)
+    np.testing.assert_allclose(left.T_BM.quaternion_wxyz, right.T_BM.quaternion_wxyz)
+    np.testing.assert_allclose(left.T_BM.rot_cov_rad2, right.T_BM.rot_cov_rad2)
+    np.testing.assert_allclose(left.imu.accel_bias_mps2, right.imu.accel_bias_mps2)
+    np.testing.assert_allclose(left.imu.accel_A_row_major, right.imu.accel_A_row_major)
+    np.testing.assert_allclose(
+        left.imu.accel_param_cov_row_major_12x12,
+        right.imu.accel_param_cov_row_major_12x12,
+    )
+    np.testing.assert_allclose(left.imu.gyro_bias_rads, right.imu.gyro_bias_rads)
+    np.testing.assert_allclose(
+        left.imu.gyro_bias_cov_row_major_3x3,
+        right.imu.gyro_bias_cov_row_major_3x3,
+    )
+    np.testing.assert_allclose(left.mag.offset_t, right.mag.offset_t)
+    np.testing.assert_allclose(
+        left.mag.offset_cov_row_major_3x3, right.mag.offset_cov_row_major_3x3
+    )
+    np.testing.assert_allclose(
+        left.mag.R_m_unitless2_row_major_3x3, right.mag.R_m_unitless2_row_major_3x3
+    )
+    np.testing.assert_allclose(
+        left.mag.R_m0_unitless2_row_major_3x3, right.mag.R_m0_unitless2_row_major_3x3
+    )
+    assert left.quality == right.quality
+
+
+def test_round_trip_yaml() -> None:
+    """Ensure YAML dumps/loads round-trips preserve data."""
+    snapshot: MountingSnapshotYaml = _build_snapshot()
+
+    text: str = dumps_yaml(snapshot)
+    loaded: MountingSnapshotYaml = loads_yaml(text)
+
+    _assert_snapshots_equal(snapshot, loaded)
+
+
+def test_schema_missing_key() -> None:
+    """Ensure missing keys raise errors."""
+    snapshot: MountingSnapshotYaml = _build_snapshot()
+    data: dict[str, object] = snapshot_to_dict(snapshot)
+    data.pop("frames")
+
+    from oasis_control.localization.mounting.storage.yaml_format import (
+        snapshot_from_dict,
+    )
+
+    with pytest.raises(MountingYamlError):
+        snapshot_from_dict(data)
+
+
+def test_schema_wrong_shapes() -> None:
+    """Ensure wrong shapes raise errors."""
+    with pytest.raises(MountingYamlError):
+        TransformYaml(
+            translation_m=np.array([0.0, 0.0], dtype=np.float64),
+            quaternion_wxyz=np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float64),
+            rot_cov_rad2=np.eye(3, dtype=np.float64),
+        )
+
+    with pytest.raises(MountingYamlError):
+        TransformYaml(
+            translation_m=np.array([0.0, 0.0, 0.0], dtype=np.float64),
+            quaternion_wxyz=np.array([1.0, 0.0, 0.0], dtype=np.float64),
+            rot_cov_rad2=np.eye(3, dtype=np.float64),
+        )
+
+    with pytest.raises(MountingYamlError):
+        TransformYaml(
+            translation_m=np.array([0.0, 0.0, 0.0], dtype=np.float64),
+            quaternion_wxyz=np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float64),
+            rot_cov_rad2=np.eye(2, dtype=np.float64),
+        )
+
+
+def test_schema_format_version() -> None:
+    """Ensure format_version must be 1."""
+    snapshot: MountingSnapshotYaml = _build_snapshot()
+    data: dict[str, object] = snapshot_to_dict(snapshot)
+    data["format_version"] = 2
+
+    from oasis_control.localization.mounting.storage.yaml_format import (
+        snapshot_from_dict,
+    )
+
+    with pytest.raises(MountingYamlError):
+        snapshot_from_dict(data)
+
+
+def test_schema_unknown_top_level_key() -> None:
+    """Ensure unknown top-level keys are rejected."""
+    snapshot: MountingSnapshotYaml = _build_snapshot()
+    data: dict[str, object] = snapshot_to_dict(snapshot)
+    data["unexpected"] = "value"
+
+    from oasis_control.localization.mounting.storage.yaml_format import (
+        snapshot_from_dict,
+    )
+
+    with pytest.raises(MountingYamlError):
+        snapshot_from_dict(data)
+
+
+def test_dump_deterministic() -> None:
+    """Ensure YAML dumps are deterministic."""
+    snapshot: MountingSnapshotYaml = _build_snapshot()
+
+    first: str = dumps_yaml(snapshot)
+    second: str = dumps_yaml(snapshot)
+
+    assert first == second

--- a/oasis_control/test/mounting/tf/test_stability.py
+++ b/oasis_control/test/mounting/tf/test_stability.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/test/mounting/tf/test_tf_publisher.py
+++ b/oasis_control/test/mounting/tf/test_tf_publisher.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/test/mounting/timing/test_replay_engine.py
+++ b/oasis_control/test/mounting/timing/test_replay_engine.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/test/mounting/timing/test_ring_buffer.py
+++ b/oasis_control/test/mounting/timing/test_ring_buffer.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/test/mounting/timing/test_time_base.py
+++ b/oasis_control/test/mounting/timing/test_time_base.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/oasis_control/test/mounting/timing/test_timeline_node.py
+++ b/oasis_control/test/mounting/timing/test_timeline_node.py
@@ -1,0 +1,9 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################

--- a/requirements-tox.txt
+++ b/requirements-tox.txt
@@ -25,6 +25,7 @@ pydocstyle==6.3.0
 pyflakes==3.4.0
 Pygments==2.19.2
 pytest==9.0.2
+PyYAML==6.0.2
 pytokens==0.3.0
 setuptools==80.9.0
 snowballstemmer==3.0.1

--- a/requirements-tox.txt.in
+++ b/requirements-tox.txt.in
@@ -11,6 +11,7 @@ flake8-quotes
 isort
 mypy
 numpy
+PyYAML
 pytest
 types-paho-mqtt
 types-psutil


### PR DESCRIPTION
### Motivation
- Provide a strict, deterministic, YAML-only on-disk format for AHRS mounting calibration snapshots per `docs/AHRS_Mounting.md` so the AHRS node can reliably load mount TFs and nuisance parameters.
- Ensure persisted files are validated, stable across runs, and can be written atomically to avoid partial writes on disk.

### Description
- Implement a typed, frozen dataclass model and strict parser/serializer in `yaml_format.py` including `FramesYaml`, `FlagsYaml`, `TransformYaml`, `ImuNuisanceYaml`, `MagNuisanceYaml`, `DiversityYaml`, `QualityYaml`, and `MountingSnapshotYaml`, with shape/type coercion and `MountingYamlError` for validation failures.
- Add strict conversion utilities `snapshot_to_dict` and `snapshot_from_dict` that enforce required keys, reject unknown top-level keys, require `format_version == 1`, and convert numpy arrays to YAML-safe lists with explicit `quaternion_wxyz` convention, plus deterministic `dumps_yaml`/`loads_yaml` helpers (uses `PyYAML`).
- Implement disk IO in `persistence.py` with `is_yaml_path`, `save_yaml_snapshot` supporting `atomic_write` (temp file in same dir + `fsync()` + `os.replace`) and `load_yaml_snapshot`, and raise `MountingPersistenceError` on filesystem/format errors.
- Add unit tests `oasis_control/test/mounting/storage/test_yaml_format.py` and `oasis_control/test/mounting/storage/test_persistence.py` that cover YAML round-trip, strict schema checks (missing keys, wrong shapes, unknown keys, bad `format_version`), determinism, atomic write behavior, and extension gating.
- Include `PyYAML` in tox requirements so YAML serialization is exercised during CI.

### Testing
- Ran the full test matrix via `tox` and the package test suite; all tests passed.
- Pytest run exercised the new storage tests; collected 118 tests and all passed (storage tests included).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977c1c67d3483268d3235ca97e06edd)