### PR TITLE
Fix IMU covariance fallback logic and update IMU defaults for AHRS mounting

### DIFF
--- a/oasis_control/launch/control_launch.py
+++ b/oasis_control/launch/control_launch.py
@@ -68,8 +68,9 @@ def generate_launch_description() -> LaunchDescription:
 
     # Navigation
     if HOST_ID == "falcon":
-        ControlDescriptions.add_imu_fuser(ld, HOST_ID)
-        ControlDescriptions.add_speedometer(ld, HOST_ID)
+        ControlDescriptions.add_ahrs_mounting_node(ld, HOST_ID)
+        # ControlDescriptions.add_imu_fuser(ld, HOST_ID)
+        # ControlDescriptions.add_speedometer(ld, HOST_ID)
         ControlDescriptions.add_tilt_sensor(ld, HOST_ID)
 
     # Microcontroller nodes

--- a/oasis_control/oasis_control/cli/ahrs_mounting_cli.py
+++ b/oasis_control/oasis_control/cli/ahrs_mounting_cli.py
@@ -7,3 +7,32 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+"""
+ROS entry point for the AHRS node
+"""
+
+from typing import Optional
+
+import rclpy
+
+from oasis_control.nodes.ahrs_mounting_node import AhrsMountingNode
+
+
+################################################################################
+# ROS entry point
+################################################################################
+
+
+def main(args: Optional[list[str]] = None) -> None:
+    rclpy.init(args=args)
+
+    node: AhrsMountingNode = AhrsMountingNode()
+
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.stop()
+        rclpy.shutdown()

--- a/oasis_control/oasis_control/launch/control_descriptions.py
+++ b/oasis_control/oasis_control/launch/control_descriptions.py
@@ -29,6 +29,29 @@ CONTROL_PACKAGE_NAME: str = "oasis_control"
 
 class ControlDescriptions:
     #
+    # AHRS mounting
+    #
+
+    @staticmethod
+    def add_ahrs_mounting_node(ld: LaunchDescription, host_id: str) -> None:
+        ahrs_mounting_node: Node = Node(
+            namespace=ROS_NAMESPACE,
+            package=CONTROL_PACKAGE_NAME,
+            executable="ahrs_mounting",
+            name=f"ahrs_mounting_{host_id}",
+            output="screen",
+            remappings=[
+                ("ahrs_mount", f"{host_id}/ahrs_mount"),
+                ("ahrs_mount_diagnostics", f"{host_id}/ahrs_mount_diagnostics"),
+                ("ahrs_mount_transform", f"{host_id}/ahrs_mount_transform"),
+                ("imu_calibration", f"{host_id}/imu_calibration"),
+                ("imu_raw", f"{host_id}/imu_raw"),
+                ("magnetic_field", f"{host_id}/magnetic_field"),
+            ],
+        )
+        ld.add_action(ahrs_mounting_node)
+
+    #
     # Home manager
     #
 

--- a/oasis_control/oasis_control/localization/mounting/config/mounting_params.py
+++ b/oasis_control/oasis_control/localization/mounting/config/mounting_params.py
@@ -58,11 +58,13 @@ STEADY_A_NORM_MAX: float | None = None
 # Scale factor applied to bootstrap gyro covariance
 STEADY_K_OMEGA: float | None = None
 
-# Default gyro noise covariance diagonal in (rad/s)^2
-IMU_OMEGA_COV_DIAG: np.ndarray = np.array([1e-4, 1e-4, 1e-4], dtype=np.float64)
+# Observed driver gyro covariance diag
+# ~[2.30e-06, 3.55e-06, 2.78e-06] (rad/s)^2
+IMU_OMEGA_COV_DIAG: np.ndarray = np.array([5e-06, 5e-06, 5e-06], dtype=np.float64)
 
-# Default accel noise covariance diagonal in (m/s^2)^2
-IMU_ACCEL_COV_DIAG: np.ndarray = np.array([1e-2, 1e-2, 1e-2], dtype=np.float64)
+# Observed driver accel covariance diag
+# ~[2.67e-03, 1.23e-03, 2.20e-03] (m/s^2)^2
+IMU_ACCEL_COV_DIAG: np.ndarray = np.array([3.5e-03, 3.5e-03, 3.5e-03], dtype=np.float64)
 
 # Gravity direction cluster threshold in degrees
 CLUSTER_G_DEG: float = 7.5

--- a/oasis_control/oasis_control/localization/mounting/diagnostics/__init__.py
+++ b/oasis_control/oasis_control/localization/mounting/diagnostics/__init__.py
@@ -1,0 +1,18 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""Diagnostics helpers for mounting calibration."""
+
+from oasis_control.localization.mounting.diagnostics.imu_pair_tracker import (
+    ImuPairTracker,
+)
+
+
+__all__ = ["ImuPairTracker"]

--- a/oasis_control/oasis_control/localization/mounting/diagnostics/imu_pair_tracker.py
+++ b/oasis_control/oasis_control/localization/mounting/diagnostics/imu_pair_tracker.py
@@ -1,0 +1,90 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""IMU pairing counters for diagnostics."""
+
+from __future__ import annotations
+
+
+# Warmup duration in seconds for unpaired IMU accounting
+_IMU_PAIR_WARMUP_SEC: float = 2.0
+
+
+class ImuPairTracker:
+    """Track IMU pairing counts for diagnostics.
+
+    Attributes:
+        raw_msgs_seen: Count of raw IMU messages observed
+        cal_msgs_seen: Count of calibration messages observed
+        imu_pairs_received: Count of exact-time IMU pairs observed
+        imu_pairs_rejected_invalid_cal: Rejections due to invalid calibration
+        imu_pairs_rejected_frame_mismatch: Rejections due to frame mismatch
+        imu_pairs_rejected_bad_cov: Rejections due to invalid covariance
+        imu_pairs_rejected_other: Rejections due to other exceptions
+    """
+
+    def __init__(self, *, warmup_sec: float = _IMU_PAIR_WARMUP_SEC) -> None:
+        if warmup_sec < 0.0:
+            raise ValueError("warmup_sec must be non-negative")
+        self._warmup_ns: int = int(warmup_sec * 1e9)
+        self._warmup_start_ns: int | None = None
+        self.raw_msgs_seen: int = 0
+        self.cal_msgs_seen: int = 0
+        self.imu_pairs_received: int = 0
+        self.imu_pairs_rejected_invalid_cal: int = 0
+        self.imu_pairs_rejected_frame_mismatch: int = 0
+        self.imu_pairs_rejected_bad_cov: int = 0
+        self.imu_pairs_rejected_other: int = 0
+
+    def record_raw(self, t_ns: int) -> None:
+        """Record a raw IMU message arrival."""
+        self._update_warmup_start(t_ns)
+        self.raw_msgs_seen += 1
+
+    def record_calibration(self, t_ns: int) -> None:
+        """Record an IMU calibration message arrival."""
+        self._update_warmup_start(t_ns)
+        self.cal_msgs_seen += 1
+
+    def record_pair(self, t_ns: int) -> None:
+        """Record an exact-time IMU pair arrival."""
+        self._update_warmup_start(t_ns)
+        self.imu_pairs_received += 1
+
+    def reject_invalid_cal(self) -> None:
+        """Record a rejection due to invalid calibration."""
+        self.imu_pairs_rejected_invalid_cal += 1
+
+    def reject_frame_mismatch(self) -> None:
+        """Record a rejection due to a frame mismatch."""
+        self.imu_pairs_rejected_frame_mismatch += 1
+
+    def reject_bad_cov(self) -> None:
+        """Record a rejection due to invalid covariance."""
+        self.imu_pairs_rejected_bad_cov += 1
+
+    def reject_other(self) -> None:
+        """Record a rejection due to an unexpected exception."""
+        self.imu_pairs_rejected_other += 1
+
+    def unpaired_raw(self, t_ns: int) -> int:
+        """Return the count of raw IMU messages without a calibration match."""
+        if not self._warmup_elapsed(t_ns):
+            return 0
+        return max(0, self.raw_msgs_seen - self.imu_pairs_received)
+
+    def _update_warmup_start(self, t_ns: int) -> None:
+        if self._warmup_start_ns is None:
+            self._warmup_start_ns = t_ns
+
+    def _warmup_elapsed(self, t_ns: int) -> bool:
+        if self._warmup_start_ns is None:
+            return False
+        return t_ns - self._warmup_start_ns >= self._warmup_ns

--- a/oasis_control/oasis_control/localization/mounting/math_utils/validation.py
+++ b/oasis_control/oasis_control/localization/mounting/math_utils/validation.py
@@ -1,0 +1,85 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""Validation helpers for mounting calibration inputs."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+
+
+# Quaternion normalization tolerance for near-zero checks
+QUAT_NORM_EPS: float = 1e-12
+
+# Covariance symmetry tolerance for soft symmetrization
+COV_SYMMETRY_ATOL: float = 1e-8
+COV_SYMMETRY_RTOL: float = 1e-5
+
+
+def reshape_matrix(
+    values: Sequence[float],
+    shape: tuple[int, int],
+    name: str,
+) -> np.ndarray:
+    """Return a finite matrix reshaped to the target shape."""
+    array: np.ndarray = np.asarray(values, dtype=np.float64)
+    if array.size != shape[0] * shape[1]:
+        raise ValueError(f"{name} must have {shape[0] * shape[1]} elements")
+
+    matrix: np.ndarray = array.reshape(shape)
+    if not np.all(np.isfinite(matrix)):
+        raise ValueError(f"{name} must be finite")
+
+    return matrix
+
+
+def reshape_covariance(
+    values: Sequence[float],
+    shape: tuple[int, int],
+    name: str,
+) -> np.ndarray:
+    """Return a finite covariance matrix with basic validation."""
+    matrix: np.ndarray = reshape_matrix(values, shape, name)
+    if np.all(matrix == -1.0) or np.all(np.diag(matrix) == -1.0):
+        raise ValueError(f"{name} unknown (-1); full covariance required")
+
+    if not np.allclose(
+        matrix,
+        matrix.T,
+        atol=COV_SYMMETRY_ATOL,
+        rtol=COV_SYMMETRY_RTOL,
+    ):
+        # Symmetrize slightly asymmetric covariances from drivers
+        matrix = 0.5 * (matrix + matrix.T)
+
+    if np.any(np.diag(matrix) < 0.0):
+        raise ValueError(f"{name} diagonal must be non-negative")
+
+    return matrix
+
+
+def normalize_quaternion_wxyz(wxyz: Sequence[float]) -> np.ndarray:
+    """Return a unit quaternion from wxyz input."""
+    if len(wxyz) != 4:
+        raise ValueError("Quaternion must have 4 elements")
+
+    array: np.ndarray = np.asarray(wxyz, dtype=np.float64)
+    if array.shape != (4,):
+        array = array.reshape((4,))
+    if not np.all(np.isfinite(array)):
+        raise ValueError("Quaternion must be finite")
+
+    norm: float = float(np.linalg.norm(array))
+    if not np.isfinite(norm) or norm <= QUAT_NORM_EPS:
+        raise ValueError("Quaternion norm must be positive")
+
+    return array / norm

--- a/oasis_control/oasis_control/localization/mounting/pipeline/mounting_pipeline.py
+++ b/oasis_control/oasis_control/localization/mounting/pipeline/mounting_pipeline.py
@@ -456,9 +456,32 @@ class MountingPipeline:
         """Return the current number of keyframes."""
         return len(self._keyframe_cluster.keyframes())
 
+    def raw_sample_count(self) -> int:
+        """Return the total number of IMU samples ingested."""
+        return self._raw_sample_count
+
+    def segment_count(self) -> int:
+        """Return the number of steady segments processed."""
+        return self._segment_count
+
     def last_save_time_ns(self) -> int | None:
         """Return the last save timestamp in nanoseconds."""
         return self._last_save_time_ns
+
+    def save_fail_count(self) -> int:
+        """Return the total number of snapshot save failures."""
+        return self._save_fail_count
+
+    def bootstrap_remaining_sec(self, t_now_ns: int) -> float:
+        """Return remaining bootstrap time in seconds."""
+        if not self._bootstrapping or self._bootstrap_start_ns is None:
+            return 0.0
+        elapsed_ns: int = max(0, t_now_ns - self._bootstrap_start_ns)
+        remaining_ns: int = max(
+            0,
+            sec_to_ns(self._params.bootstrap.bootstrap_sec) - elapsed_ns,
+        )
+        return float(remaining_ns) / 1e9
 
     def _drop_packet(self, message: str) -> None:
         """Record a dropped packet diagnostic."""

--- a/oasis_control/oasis_control/localization/mounting/ros/__init__.py
+++ b/oasis_control/oasis_control/localization/mounting/ros/__init__.py
@@ -1,0 +1,11 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""ROS integration helpers for mounting calibration"""

--- a/oasis_control/oasis_control/localization/mounting/ros/imu_packet_builder.py
+++ b/oasis_control/oasis_control/localization/mounting/ros/imu_packet_builder.py
@@ -1,0 +1,158 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""Helpers for building mounting packets from IMU-related messages"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from oasis_control.localization.mounting.config.mounting_params import MountingParams
+from oasis_control.localization.mounting.math_utils.validation import (
+    reshape_covariance as _reshape_covariance,
+)
+from oasis_control.localization.mounting.math_utils.validation import (
+    reshape_matrix as _reshape_matrix,
+)
+from oasis_control.localization.mounting.mounting_types import ImuCalibrationPrior
+from oasis_control.localization.mounting.mounting_types import ImuPacket
+from oasis_control.localization.mounting.mounting_types import MagPacket
+
+
+if TYPE_CHECKING:
+    from builtin_interfaces.msg import Time as TimeMsg
+    from sensor_msgs.msg import Imu as ImuMsg
+    from sensor_msgs.msg import MagneticField as MagneticFieldMsg
+
+    from oasis_msgs.msg import ImuCalibration as ImuCalibrationMsg
+
+
+def _time_to_ns(stamp: TimeMsg) -> int:
+    sec_ns: int = int(stamp.sec) * int(1e9)
+
+    return sec_ns + int(stamp.nanosec)
+
+
+def build_imu_packet(
+    imu_msg: ImuMsg,
+    cal_msg: ImuCalibrationMsg,
+    *,
+    params: MountingParams,
+) -> ImuPacket:
+    imu_frame: str = imu_msg.header.frame_id
+    t_ns: int = _time_to_ns(imu_msg.header.stamp)
+
+    omega_raw: np.ndarray = np.array(
+        [
+            imu_msg.angular_velocity.x,
+            imu_msg.angular_velocity.y,
+            imu_msg.angular_velocity.z,
+        ],
+        dtype=np.float64,
+    )
+    accel_raw: np.ndarray = np.array(
+        [
+            imu_msg.linear_acceleration.x,
+            imu_msg.linear_acceleration.y,
+            imu_msg.linear_acceleration.z,
+        ],
+        dtype=np.float64,
+    )
+
+    b_a_mps2: np.ndarray = np.array(
+        [
+            cal_msg.accel_bias.x,
+            cal_msg.accel_bias.y,
+            cal_msg.accel_bias.z,
+        ],
+        dtype=np.float64,
+    )
+    A_a: np.ndarray = _reshape_matrix(cal_msg.accel_a, (3, 3), "accel_a")
+    b_g_rads: np.ndarray = np.array(
+        [
+            cal_msg.gyro_bias.x,
+            cal_msg.gyro_bias.y,
+            cal_msg.gyro_bias.z,
+        ],
+        dtype=np.float64,
+    )
+
+    cov_a_params: np.ndarray = _reshape_covariance(
+        cal_msg.accel_param_cov,
+        (12, 12),
+        "accel_param_cov",
+    )
+    cov_b_g: np.ndarray = _reshape_covariance(
+        cal_msg.gyro_bias_cov,
+        (3, 3),
+        "gyro_bias_cov",
+    )
+
+    omega_cov_default: np.ndarray = np.diag(params.imu.omega_cov_diag)
+    accel_cov_default: np.ndarray = np.diag(params.imu.accel_cov_diag)
+
+    cov_omega_raw: np.ndarray = _reshape_covariance(
+        imu_msg.angular_velocity_covariance,
+        (3, 3),
+        "angular_velocity_covariance",
+        fallback=omega_cov_default,
+    )
+    cov_accel_raw: np.ndarray = _reshape_covariance(
+        imu_msg.linear_acceleration_covariance,
+        (3, 3),
+        "linear_acceleration_covariance",
+        fallback=accel_cov_default,
+    )
+
+    calibration: ImuCalibrationPrior = ImuCalibrationPrior(
+        valid=bool(cal_msg.valid),
+        frame_id=imu_frame,
+        b_a_mps2=b_a_mps2,
+        A_a=A_a,
+        b_g_rads=b_g_rads,
+        cov_a_params=cov_a_params,
+        cov_b_g=cov_b_g,
+    )
+
+    return ImuPacket(
+        t_meas_ns=t_ns,
+        frame_id=imu_frame,
+        omega_raw_rads=omega_raw,
+        cov_omega_raw=cov_omega_raw,
+        a_raw_mps2=accel_raw,
+        cov_a_raw=cov_accel_raw,
+        calibration=calibration,
+    )
+
+
+def build_mag_packet(message: MagneticFieldMsg) -> MagPacket:
+    t_ns: int = _time_to_ns(message.header.stamp)
+    m_raw: np.ndarray = np.array(
+        [
+            message.magnetic_field.x,
+            message.magnetic_field.y,
+            message.magnetic_field.z,
+        ],
+        dtype=np.float64,
+    )
+    cov_m_raw: np.ndarray = _reshape_covariance(
+        message.magnetic_field_covariance,
+        (3, 3),
+        "magnetic_field_covariance",
+    )
+
+    return MagPacket(
+        t_meas_ns=t_ns,
+        frame_id=message.header.frame_id,
+        m_raw_T=m_raw,
+        cov_m_raw_T2=cov_m_raw,
+    )

--- a/oasis_control/oasis_control/nodes/ahrs_mounting_node.py
+++ b/oasis_control/oasis_control/nodes/ahrs_mounting_node.py
@@ -8,25 +8,45 @@
 #
 ################################################################################
 
-import math
-from typing import Protocol
+from collections import deque
+from dataclasses import replace
+from typing import Deque
+from typing import Dict
 from typing import Sequence
 
 import message_filters
+import numpy as np
 import rclpy.node
 import rclpy.publisher
 import rclpy.qos
 import rclpy.subscription
 import tf2_ros
 from builtin_interfaces.msg import Time as TimeMsg
-from geometry_msgs.msg import Point as PointMsg
-from geometry_msgs.msg import Pose as PoseMsg
 from geometry_msgs.msg import Quaternion as QuaternionMsg
 from geometry_msgs.msg import TransformStamped as TransformStampedMsg
-from geometry_msgs.msg import Vector3 as Vector3Msg
 from sensor_msgs.msg import Imu as ImuMsg
 from sensor_msgs.msg import MagneticField as MagneticFieldMsg
 
+from oasis_control.localization.mounting.config.mounting_config import MountingConfig
+from oasis_control.localization.mounting.config.mounting_params import MountingParams
+from oasis_control.localization.mounting.math_utils.quat import Quaternion
+from oasis_control.localization.mounting.mounting_types import ImuCalibrationPrior
+from oasis_control.localization.mounting.mounting_types import ImuPacket
+from oasis_control.localization.mounting.mounting_types import MagPacket
+from oasis_control.localization.mounting.mounting_types import ResultSnapshot
+from oasis_control.localization.mounting.pipeline.mounting_pipeline import (
+    MountingPipeline,
+)
+from oasis_control.localization.mounting.pipeline.mounting_pipeline import (
+    MountingPipelineError,
+)
+from oasis_control.localization.mounting.pipeline.mounting_pipeline import (
+    PipelineOutputs,
+)
+from oasis_control.localization.mounting.storage.yaml_format import FlagsYaml
+from oasis_control.localization.mounting.tf.tf_publisher import PublishedTransform
+from oasis_msgs.msg import AhrsMount as AhrsMountMsg
+from oasis_msgs.msg import AhrsMountDiagnostics as AhrsMountDiagnosticsMsg
 from oasis_msgs.msg import ImuCalibration as ImuCalibrationMsg
 
 
@@ -45,8 +65,17 @@ IMU_CAL_TOPIC: str = "imu_calibration"
 IMU_RAW_TOPIC: str = "imu_raw"
 MAG_TOPIC: str = "magnetic_field"
 
-# TF topics
-# TODO
+# Default base frame identifier
+DEFAULT_BASE_FRAME: str = "base_link"
+
+# Default world frame identifier
+DEFAULT_WORLD_FRAME: str = "world"
+
+# Default bootstrap duration in seconds
+DEFAULT_BOOTSTRAP_SEC: float = 5.0
+
+# Default persistence save period in seconds
+DEFAULT_SAVE_PERIOD_SEC: float = 2.0
 
 
 ################################################################################
@@ -68,13 +97,53 @@ class AhrsMountingNode(rclpy.node.Node):
         )
 
         # ROS Publishers
-        # TODO
+        self._ahrs_mount_pub: rclpy.publisher.Publisher = self.create_publisher(
+            msg_type=AhrsMountMsg,
+            topic=AHRS_MOUNT_TOPIC,
+            qos_profile=qos_profile,
+        )
+        self._ahrs_mount_diag_pub: rclpy.publisher.Publisher = self.create_publisher(
+            msg_type=AhrsMountDiagnosticsMsg,
+            topic=AHRS_MOUNT_DIAGNOSTICS_TOPIC,
+            qos_profile=qos_profile,
+        )
+        self._ahrs_mount_tf_pub: rclpy.publisher.Publisher = self.create_publisher(
+            msg_type=TransformStampedMsg,
+            topic=AHRS_MOUNT_TRANSFORM_TOPIC,
+            qos_profile=qos_profile,
+        )
+        self._tf_broadcaster: tf2_ros.TransformBroadcaster = (
+            tf2_ros.TransformBroadcaster(self)
+        )
+        self._tf_static_broadcaster: tf2_ros.StaticTransformBroadcaster = (
+            tf2_ros.StaticTransformBroadcaster(self)
+        )
 
         # AHRS filter
-        # TODO
+        params: MountingParams = MountingParams.defaults()
+        params = params.replace(
+            frames=replace(
+                params.frames,
+                base_frame=DEFAULT_BASE_FRAME,
+                world_frame=DEFAULT_WORLD_FRAME,
+            ),
+            bootstrap=replace(
+                params.bootstrap,
+                bootstrap_sec=DEFAULT_BOOTSTRAP_SEC,
+            ),
+            save=replace(
+                params.save,
+                save_period_sec=DEFAULT_SAVE_PERIOD_SEC,
+            ),
+        )
+        self._params: MountingParams = params
+        self._config: MountingConfig = MountingConfig(params)
+        self._pipeline: MountingPipeline = MountingPipeline(config=self._config)
+
+        if not self._params.save.output_path:
+            self.get_logger().info("Persistence disabled for AHRS mounting calibration")
 
         # ROS Subscribers
-        # TODO: AHRS topics
         self._imu_cal_filter_sub: message_filters.Subscriber = (
             message_filters.Subscriber(
                 self,
@@ -106,20 +175,477 @@ class AhrsMountingNode(rclpy.node.Node):
             )
         )
         self._imu_sync.registerCallback(self._handle_imu_raw_with_calibration)
+        self._imu_raw_filter_sub.registerCallback(self._record_imu_raw)
+        self._imu_cal_filter_sub.registerCallback(self._record_imu_calibration)
 
-        self.get_logger().info("AHRS node initialized")
+
+        # Pending IMU messages
+        self._pending_raw_stamps: Deque[int] = deque()
+        self._pending_raw_counts: Dict[int, int] = {}
+        self._pending_cal_stamps: Deque[int] = deque()
+        self._pending_cal_counts: Dict[int, int] = {}
+
+        # Statistics
+        self._imu_raw_dropped_no_calibration: int = 0
+        self._mag_dropped_bad_cov: int = 0
+        self._time_sync_slop_max_ns: int = 0
+
+        self.get_logger().info("AHRS mounting node initialized")
 
     def stop(self) -> None:
-        self.get_logger().info("AHRS node deinitialized")
+        self.get_logger().info("AHRS mounting node deinitialized")
 
         self.destroy_node()
+
+    def _record_imu_raw(self, message: ImuMsg) -> None:
+        t_ns: int = _time_to_ns(message.header.stamp)
+
+        self._add_pending_stamp(
+            self._pending_raw_stamps,
+            self._pending_raw_counts,
+            t_ns,
+        )
+        self._drop_pending_older_than(
+            self._pending_cal_stamps,
+            self._pending_cal_counts,
+            t_ns,
+            count_raw_drops=False,
+        )
+
+    def _record_imu_calibration(self, message: ImuCalibrationMsg) -> None:
+        t_ns: int = _time_to_ns(message.header.stamp)
+
+        self._add_pending_stamp(
+            self._pending_cal_stamps,
+            self._pending_cal_counts,
+            t_ns,
+        )
+        self._drop_pending_older_than(
+            self._pending_raw_stamps,
+            self._pending_raw_counts,
+            t_ns,
+            count_raw_drops=True,
+        )
+
+    def _add_pending_stamp(
+        self,
+        stamps: Deque[int],
+        counts: Dict[int, int],
+        t_ns: int,
+    ) -> None:
+        counts[t_ns] = counts.get(t_ns, 0) + 1
+        stamps.append(t_ns)
+
+    def _drop_pending_older_than(
+        self,
+        stamps: Deque[int],
+        counts: Dict[int, int],
+        cutoff_ns: int,
+        *,
+        count_raw_drops: bool,
+    ) -> None:
+        while stamps and stamps[0] < cutoff_ns:
+            t_ns: int = stamps.popleft()
+            if t_ns in counts:
+                counts[t_ns] -= 1
+                if counts[t_ns] <= 0:
+                    counts.pop(t_ns, None)
+            if count_raw_drops:
+                self._imu_raw_dropped_no_calibration += 1
+
+        self._prune_pending(stamps, counts)
+
+    def _prune_pending(self, stamps: Deque[int], counts: Dict[int, int]) -> None:
+        while stamps and stamps[0] not in counts:
+            stamps.popleft()
+
+    def _consume_pending_stamp(
+        self,
+        stamps: Deque[int],
+        counts: Dict[int, int],
+        t_ns: int,
+    ) -> None:
+        if t_ns in counts:
+            counts[t_ns] -= 1
+            if counts[t_ns] <= 0:
+                counts.pop(t_ns, None)
+
+        self._prune_pending(stamps, counts)
 
     def _handle_imu_raw_with_calibration(
         self, imu_msg: ImuMsg, cal_msg: ImuCalibrationMsg
     ) -> None:
-        # TODO
-        pass
+        t_imu_ns: int = _time_to_ns(imu_msg.header.stamp)
+        t_cal_ns: int = _time_to_ns(cal_msg.header.stamp)
+
+        slop_ns: int = abs(t_imu_ns - t_cal_ns)
+        if slop_ns > self._time_sync_slop_max_ns:
+            self._time_sync_slop_max_ns = slop_ns
+
+        self._consume_pending_stamp(
+            self._pending_raw_stamps,
+            self._pending_raw_counts,
+            t_imu_ns,
+        )
+        self._consume_pending_stamp(
+            self._pending_cal_stamps,
+            self._pending_cal_counts,
+            t_cal_ns,
+        )
+
+        imu_frame: str = imu_msg.header.frame_id
+        cal_frame: str = cal_msg.header.frame_id
+
+        if not cal_msg.valid:
+            self._imu_raw_dropped_no_calibration += 1
+            return
+        if not imu_frame or not cal_frame or cal_frame != imu_frame:
+            self._imu_raw_dropped_no_calibration += 1
+            return
+
+        try:
+            imu_packet: ImuPacket = _build_imu_packet(imu_msg, cal_msg)
+        except ValueError as exc:
+            self.get_logger().warn(f"Dropping IMU pair: {exc}")
+            self._imu_raw_dropped_no_calibration += 1
+            return
+
+        try:
+            self._pipeline.ingest_imu_pair(imu_packet=imu_packet)
+            outputs: PipelineOutputs = self._pipeline.step(t_now_ns=t_imu_ns)
+        except MountingPipelineError as exc:
+            self.get_logger().warn(f"Mounting pipeline error: {exc}")
+            return
+
+        self._publish_outputs(outputs)
 
     def _handle_mag(self, message: MagneticFieldMsg) -> None:
-        # TODO
-        pass
+        if not message.header.frame_id:
+            self._mag_dropped_bad_cov += 1
+            return
+
+        try:
+            mag_packet: MagPacket = _build_mag_packet(message)
+        except ValueError as exc:
+            self.get_logger().warn(f"Dropping magnetometer sample: {exc}")
+            self._mag_dropped_bad_cov += 1
+            return
+
+        if mag_packet.magnitude_T() < self._params.mag.s_min_T:
+            self._mag_dropped_bad_cov += 1
+            return
+
+        try:
+            self._pipeline.ingest_mag(mag_packet=mag_packet)
+        except MountingPipelineError as exc:
+            self.get_logger().warn(f"Mounting pipeline error: {exc}")
+
+    def _publish_outputs(self, outputs: PipelineOutputs) -> None:
+        snapshot: ResultSnapshot | None = outputs.snapshot
+        t_ns: int = outputs.t_ns
+        flags: FlagsYaml | None = self._pipeline.current_flags()
+        anchored: bool = bool(flags.anchored) if flags is not None else False
+        mag_reference_invalid: bool = (
+            bool(flags.mag_reference_invalid) if flags is not None else True
+        )
+        mag_disturbance_detected: bool = (
+            bool(flags.mag_disturbance_detected) if flags is not None else False
+        )
+        mag_dir_prior_from_driver_cov: bool = (
+            bool(flags.mag_dir_prior_from_driver_cov) if flags is not None else False
+        )
+
+        residual_rms: float = float(outputs.report.residual_rms or 0.0)
+        if snapshot is not None:
+            mount_msg: AhrsMountMsg = AhrsMountMsg()
+            mount_msg.header.stamp = _ns_to_time_msg(t_ns)
+            mount_msg.base_frame = snapshot.frame_base
+            mount_msg.imu_frame = snapshot.frame_imu
+            mount_msg.mag_frame = snapshot.frame_mag or ""
+            mount_msg.anchored = anchored
+            mount_msg.mag_reference_invalid = mag_reference_invalid
+            mount_msg.mag_disturbance_detected = mag_disturbance_detected
+            mount_msg.mag_dir_prior_from_driver_cov = mag_dir_prior_from_driver_cov
+
+            q_bi_wxyz: Sequence[float] = (
+                Quaternion.from_matrix(snapshot.R_BI).to_wxyz().tolist()
+            )
+
+            if snapshot.R_BM is not None:
+                q_bm_wxyz: Sequence[float] = (
+                    Quaternion.from_matrix(snapshot.R_BM).to_wxyz().tolist()
+                )
+            else:
+                q_bm_wxyz = [1.0, 0.0, 0.0, 0.0]
+
+            mount_msg.q_bi_wxyz = list(q_bi_wxyz)
+            mount_msg.q_bm_wxyz = list(q_bm_wxyz)
+
+            cov_r_bi: Sequence[float] = snapshot.cov_rot_BI.reshape(-1).tolist()
+            cov_r_bm: Sequence[float] = (
+                snapshot.cov_rot_BM.reshape(-1).tolist()
+                if snapshot.cov_rot_BM is not None
+                else [0.0] * 9
+            )
+            mount_msg.cov_r_bi_row_major_3x3 = list(cov_r_bi)
+            mount_msg.cov_r_bm_row_major_3x3 = list(cov_r_bm)
+
+            mount_msg.accel_bias_mps2 = snapshot.b_a_mps2.tolist()
+            mount_msg.accel_a_row_major_3x3 = snapshot.A_a.reshape(-1).tolist()
+            mount_msg.accel_param_cov_row_major_12x12 = [0.0] * 144
+            mount_msg.gyro_bias_rads = snapshot.b_g_rads.tolist()
+            mount_msg.gyro_bias_cov_row_major_3x3 = [0.0] * 9
+
+            if snapshot.b_m_T is not None:
+                mount_msg.mag_offset_t = snapshot.b_m_T.tolist()
+            else:
+                mount_msg.mag_offset_t = [0.0, 0.0, 0.0]
+
+            mount_msg.mag_offset_cov_row_major_3x3 = [0.0] * 9
+
+            if snapshot.R_m is not None:
+                mount_msg.mag_r_m_unitless2_row_major_3x3 = snapshot.R_m.reshape(
+                    -1
+                ).tolist()
+            else:
+                mount_msg.mag_r_m_unitless2_row_major_3x3 = [0.0] * 9
+
+            mount_msg.mag_r_m0_unitless2_row_major_3x3 = (
+                np.diag(self._params.mag.Rm_init_diag).reshape(-1).tolist()
+            )
+
+            mount_msg.raw_samples = int(self._pipeline.raw_sample_count())
+            mount_msg.steady_segments = int(snapshot.segment_count)
+            mount_msg.keyframes = int(snapshot.keyframe_count)
+            mount_msg.accel_residual_rms = residual_rms
+            mount_msg.mag_residual_rms = (
+                residual_rms if snapshot.R_BM is not None else 0.0
+            )
+            mount_msg.gravity_max_angle_deg = float(snapshot.diversity_tilt_deg or 0.0)
+            mount_msg.mag_proj_max_angle_deg = float(snapshot.diversity_yaw_deg or 0.0)
+
+            self._ahrs_mount_pub.publish(mount_msg)
+
+            transform_msg: TransformStampedMsg = TransformStampedMsg()
+            transform_msg.header.stamp = _ns_to_time_msg(t_ns)
+            transform_msg.header.frame_id = snapshot.frame_base
+            transform_msg.child_frame_id = snapshot.frame_imu
+            transform_msg.transform.translation.x = 0.0
+            transform_msg.transform.translation.y = 0.0
+            transform_msg.transform.translation.z = 0.0
+            transform_msg.transform.rotation = _quat_wxyz_to_msg(q_bi_wxyz)
+
+            self._ahrs_mount_tf_pub.publish(transform_msg)
+
+        published_transforms: Sequence[PublishedTransform] = (
+            outputs.published_transforms
+        )
+
+        for published in published_transforms:
+            tf_msg: TransformStampedMsg = _published_transform_to_msg(published)
+
+            if published.is_static:
+                self._tf_static_broadcaster.sendTransform(tf_msg)
+            else:
+                self._tf_broadcaster.sendTransform(tf_msg)
+
+        diag_msg: AhrsMountDiagnosticsMsg = AhrsMountDiagnosticsMsg()
+        diag_msg.header.stamp = _ns_to_time_msg(t_ns)
+        diag_msg.imu_raw_dropped_no_calibration = int(
+            self._imu_raw_dropped_no_calibration
+        )
+        diag_msg.mag_dropped_bad_cov = int(self._mag_dropped_bad_cov)
+        diag_msg.time_sync_slop_max_ns = int(self._time_sync_slop_max_ns)
+        diag_msg.bootstrap_active = bool(self._pipeline.is_bootstrapping())
+        diag_msg.bootstrap_remaining_sec = self._pipeline.bootstrap_remaining_sec(t_ns)
+        diag_msg.anchored = anchored
+        diag_msg.steady_detected = bool(self._pipeline.steady_window_is_steady())
+        diag_msg.steady_segments = int(self._pipeline.segment_count())
+        diag_msg.keyframes = int(self._pipeline.keyframe_count())
+        diag_msg.need_more_tilt = bool(outputs.report.need_more_tilt)
+        diag_msg.need_more_yaw = bool(outputs.report.need_more_yaw)
+        diag_msg.mag_reference_invalid = mag_reference_invalid
+        diag_msg.mag_disturbance_detected = mag_disturbance_detected
+        if snapshot is not None and snapshot.R_m is not None:
+            diag_msg.mag_r_m_trace = float(np.trace(snapshot.R_m))
+        else:
+            diag_msg.mag_r_m_trace = 0.0
+        diag_msg.mag_factors_dropped = 0
+        diag_msg.optimizer_iterations_last = int(outputs.report.iterations)
+        diag_msg.optimizer_step_norm_last = float(outputs.report.step_norm or 0.0)
+        diag_msg.accel_residual_rms = residual_rms
+        diag_msg.mag_residual_rms = (
+            residual_rms if snapshot and snapshot.R_BM is not None else 0.0
+        )
+        last_save_ns: int = int(self._pipeline.last_save_time_ns() or 0)
+        diag_msg.last_save_unix_ns = last_save_ns
+        diag_msg.save_period_sec = float(self._params.save.save_period_sec)
+        diag_msg.save_fail_count = int(self._pipeline.save_fail_count())
+
+        self._ahrs_mount_diag_pub.publish(diag_msg)
+
+
+def _time_to_ns(stamp: TimeMsg) -> int:
+    sec_ns: int = int(stamp.sec) * int(1e9)
+
+    return sec_ns + int(stamp.nanosec)
+
+
+def _ns_to_time_msg(t_ns: int) -> TimeMsg:
+    stamp: TimeMsg = TimeMsg()
+
+    stamp.sec = int(t_ns // int(1e9))
+    stamp.nanosec = int(t_ns % int(1e9))
+
+    return stamp
+
+
+def _quat_wxyz_to_msg(wxyz: Sequence[float]) -> QuaternionMsg:
+    quat: QuaternionMsg = QuaternionMsg()
+
+    quat.w = float(wxyz[0])
+    quat.x = float(wxyz[1])
+    quat.y = float(wxyz[2])
+    quat.z = float(wxyz[3])
+
+    return quat
+
+
+def _build_imu_packet(imu_msg: ImuMsg, cal_msg: ImuCalibrationMsg) -> ImuPacket:
+    imu_frame: str = imu_msg.header.frame_id
+    t_ns: int = _time_to_ns(imu_msg.header.stamp)
+
+    omega_raw: np.ndarray = np.array(
+        [
+            imu_msg.angular_velocity.x,
+            imu_msg.angular_velocity.y,
+            imu_msg.angular_velocity.z,
+        ],
+        dtype=np.float64,
+    )
+    accel_raw: np.ndarray = np.array(
+        [
+            imu_msg.linear_acceleration.x,
+            imu_msg.linear_acceleration.y,
+            imu_msg.linear_acceleration.z,
+        ],
+        dtype=np.float64,
+    )
+
+    cov_omega_raw: np.ndarray = _reshape_covariance(
+        imu_msg.angular_velocity_covariance, (3, 3), "angular_velocity_covariance"
+    )
+    cov_accel_raw: np.ndarray = _reshape_covariance(
+        imu_msg.linear_acceleration_covariance,
+        (3, 3),
+        "linear_acceleration_covariance",
+    )
+
+    b_a_mps2: np.ndarray = np.array(
+        [
+            cal_msg.accel_bias.x,
+            cal_msg.accel_bias.y,
+            cal_msg.accel_bias.z,
+        ],
+        dtype=np.float64,
+    )
+    A_a: np.ndarray = _reshape_covariance(
+        cal_msg.accel_a,
+        (3, 3),
+        "accel_a",
+    )
+    b_g_rads: np.ndarray = np.array(
+        [
+            cal_msg.gyro_bias.x,
+            cal_msg.gyro_bias.y,
+            cal_msg.gyro_bias.z,
+        ],
+        dtype=np.float64,
+    )
+
+    cov_a_params: np.ndarray = _reshape_covariance(
+        cal_msg.accel_param_cov,
+        (12, 12),
+        "accel_param_cov",
+    )
+    cov_b_g: np.ndarray = _reshape_covariance(
+        cal_msg.gyro_bias_cov,
+        (3, 3),
+        "gyro_bias_cov",
+    )
+
+    calibration: ImuCalibrationPrior = ImuCalibrationPrior(
+        valid=bool(cal_msg.valid),
+        frame_id=imu_frame,
+        b_a_mps2=b_a_mps2,
+        A_a=A_a,
+        b_g_rads=b_g_rads,
+        cov_a_params=cov_a_params,
+        cov_b_g=cov_b_g,
+    )
+
+    return ImuPacket(
+        t_meas_ns=t_ns,
+        frame_id=imu_frame,
+        omega_raw_rads=omega_raw,
+        cov_omega_raw=cov_omega_raw,
+        a_raw_mps2=accel_raw,
+        cov_a_raw=cov_accel_raw,
+        calibration=calibration,
+    )
+
+
+def _build_mag_packet(message: MagneticFieldMsg) -> MagPacket:
+    t_ns: int = _time_to_ns(message.header.stamp)
+    m_raw: np.ndarray = np.array(
+        [
+            message.magnetic_field.x,
+            message.magnetic_field.y,
+            message.magnetic_field.z,
+        ],
+        dtype=np.float64,
+    )
+    cov_m_raw: np.ndarray = _reshape_covariance(
+        message.magnetic_field_covariance,
+        (3, 3),
+        "magnetic_field_covariance",
+    )
+
+    return MagPacket(
+        t_meas_ns=t_ns,
+        frame_id=message.header.frame_id,
+        m_raw_T=m_raw,
+        cov_m_raw_T2=cov_m_raw,
+    )
+
+
+def _reshape_covariance(
+    values: Sequence[float],
+    shape: tuple[int, int],
+    name: str,
+) -> np.ndarray:
+    array: np.ndarray = np.asarray(values, dtype=np.float64)
+    if array.shape[0] != shape[0] * shape[1]:
+        raise ValueError(f"{name} must have {shape[0] * shape[1]} elements")
+
+    matrix: np.ndarray = array.reshape(shape)
+    if not np.all(np.isfinite(matrix)):
+        raise ValueError(f"{name} must be finite")
+    if np.any(np.diag(matrix) < 0.0):
+        raise ValueError(f"{name} diagonal must be non-negative")
+
+    return matrix
+
+
+def _published_transform_to_msg(transform: PublishedTransform) -> TransformStampedMsg:
+    tf_msg: TransformStampedMsg = TransformStampedMsg()
+
+    tf_msg.header.stamp = _ns_to_time_msg(transform.t_ns)
+    tf_msg.header.frame_id = transform.parent_frame
+    tf_msg.child_frame_id = transform.child_frame
+    tf_msg.transform.translation.x = 0.0
+    tf_msg.transform.translation.y = 0.0
+    tf_msg.transform.translation.z = 0.0
+    tf_msg.transform.rotation = _quat_wxyz_to_msg(transform.quaternion_wxyz.tolist())
+
+    return tf_msg

--- a/oasis_control/oasis_control/nodes/ahrs_mounting_node.py
+++ b/oasis_control/oasis_control/nodes/ahrs_mounting_node.py
@@ -7,3 +7,119 @@
 #  See DOCS/LICENSING.md for more information.
 #
 ################################################################################
+
+import math
+from typing import Protocol
+from typing import Sequence
+
+import message_filters
+import rclpy.node
+import rclpy.publisher
+import rclpy.qos
+import rclpy.subscription
+import tf2_ros
+from builtin_interfaces.msg import Time as TimeMsg
+from geometry_msgs.msg import Point as PointMsg
+from geometry_msgs.msg import Pose as PoseMsg
+from geometry_msgs.msg import Quaternion as QuaternionMsg
+from geometry_msgs.msg import TransformStamped as TransformStampedMsg
+from geometry_msgs.msg import Vector3 as Vector3Msg
+from sensor_msgs.msg import Imu as ImuMsg
+from sensor_msgs.msg import MagneticField as MagneticFieldMsg
+
+from oasis_msgs.msg import ImuCalibration as ImuCalibrationMsg
+
+
+################################################################################
+# ROS parameters
+################################################################################
+
+
+NODE_NAME: str = "ahrs_mounting"
+
+# ROS topics
+AHRS_MOUNT_TOPIC: str = "ahrs_mount"
+AHRS_MOUNT_DIAGNOSTICS_TOPIC: str = "ahrs_mount_diagnostics"
+AHRS_MOUNT_TRANSFORM_TOPIC: str = "ahrs_mount_transform"
+IMU_CAL_TOPIC: str = "imu_calibration"
+IMU_RAW_TOPIC: str = "imu_raw"
+MAG_TOPIC: str = "magnetic_field"
+
+# TF topics
+# TODO
+
+
+################################################################################
+# ROS node
+################################################################################
+
+
+class AhrsMountingNode(rclpy.node.Node):
+    def __init__(self) -> None:
+        """
+        Initialize resources
+        """
+
+        super().__init__(NODE_NAME)
+
+        # QoS profile
+        qos_profile: rclpy.qos.QoSProfile = (
+            rclpy.qos.QoSPresetProfiles.SENSOR_DATA.value
+        )
+
+        # ROS Publishers
+        # TODO
+
+        # AHRS filter
+        # TODO
+
+        # ROS Subscribers
+        # TODO: AHRS topics
+        self._imu_cal_filter_sub: message_filters.Subscriber = (
+            message_filters.Subscriber(
+                self,
+                ImuCalibrationMsg,
+                IMU_CAL_TOPIC,
+                qos_profile=qos_profile,
+            )
+        )
+        self._imu_raw_filter_sub: message_filters.Subscriber = (
+            message_filters.Subscriber(
+                self,
+                ImuMsg,
+                IMU_RAW_TOPIC,
+                qos_profile=qos_profile,
+            )
+        )
+        self._mag_sub: rclpy.subscription.Subscription = self.create_subscription(
+            msg_type=MagneticFieldMsg,
+            topic=MAG_TOPIC,
+            callback=self._handle_mag,
+            qos_profile=qos_profile,
+        )
+
+        # ROS message synchronizers
+        self._imu_sync: message_filters.TimeSynchronizer = (
+            message_filters.TimeSynchronizer(
+                [self._imu_raw_filter_sub, self._imu_cal_filter_sub],
+                queue_size=20,
+            )
+        )
+        self._imu_sync.registerCallback(self._handle_imu_raw_with_calibration)
+
+        self.get_logger().info("AHRS node initialized")
+
+    def stop(self) -> None:
+        self.get_logger().info("AHRS node deinitialized")
+
+        self.destroy_node()
+
+    def _handle_imu_raw_with_calibration(
+        self, imu_msg: ImuMsg, cal_msg: ImuCalibrationMsg
+    ) -> None:
+        # TODO
+        pass
+
+    def _handle_mag(self, message: MagneticFieldMsg) -> None:
+        # TODO
+        pass

--- a/oasis_control/setup.py
+++ b/oasis_control/setup.py
@@ -68,6 +68,7 @@ setuptools.setup(
     ],
     entry_points={
         "console_scripts": [
+            "ahrs_mounting = oasis_control.cli.ahrs_mounting_cli:main",
             "conductor_manager_firmata = oasis_control.cli.conductor_manager_firmata_cli:main",
             "conductor_manager_telemetrix = oasis_control.cli.conductor_manager_telemetrix_cli:main",
             "engine_manager = oasis_control.cli.engine_manager_cli:main",

--- a/oasis_control/test/nodes/test_ahrs_mounting_node.py
+++ b/oasis_control/test/nodes/test_ahrs_mounting_node.py
@@ -15,6 +15,12 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
+from oasis_control.localization.mounting.diagnostics.imu_pair_tracker import (
+    ImuPairTracker,
+)
+from oasis_control.localization.mounting.math_utils.validation import (
+    CovarianceValidationError,
+)
 from oasis_control.localization.mounting.math_utils.validation import (
     normalize_quaternion_wxyz,
 )
@@ -40,15 +46,21 @@ def test_reshape_matrix_accepts_negative_diagonal() -> None:
     assert matrix[0, 0] < 0.0
 
 
-def test_reshape_covariance_rejects_unknown_all_minus_one() -> None:
-    """Ensure all -1 covariances are rejected."""
+def test_reshape_covariance_accepts_unknown_all_minus_one() -> None:
+    """Ensure all -1 covariances are substituted."""
     values: list[float] = [-1.0] * 9
-    with pytest.raises(ValueError):
-        reshape_covariance(values, (3, 3), "covariance")
+    fallback: np.ndarray = np.diag([0.1, 0.2, 0.3])
+    matrix: np.ndarray = reshape_covariance(
+        values,
+        (3, 3),
+        "covariance",
+        fallback=fallback,
+    )
+    assert np.allclose(matrix, fallback)
 
 
-def test_reshape_covariance_rejects_unknown_diag_minus_one() -> None:
-    """Ensure -1 diagonal covariances are rejected."""
+def test_reshape_covariance_accepts_unknown_diag_minus_one() -> None:
+    """Ensure -1 diagonal covariances are substituted."""
     values: list[float] = [
         -1.0,
         0.0,
@@ -60,7 +72,20 @@ def test_reshape_covariance_rejects_unknown_diag_minus_one() -> None:
         0.0,
         -1.0,
     ]
-    with pytest.raises(ValueError):
+    fallback: np.ndarray = np.diag([0.4, 0.5, 0.6])
+    matrix: np.ndarray = reshape_covariance(
+        values,
+        (3, 3),
+        "covariance",
+        fallback=fallback,
+    )
+    assert np.allclose(matrix, fallback)
+
+
+def test_reshape_covariance_rejects_unknown_without_fallback() -> None:
+    """Ensure unknown covariances still raise without fallback."""
+    values: list[float] = [-1.0] * 9
+    with pytest.raises(CovarianceValidationError):
         reshape_covariance(values, (3, 3), "covariance")
 
 
@@ -79,6 +104,43 @@ def test_reshape_covariance_rejects_negative_diagonal() -> None:
     ]
     with pytest.raises(ValueError):
         reshape_covariance(values, (3, 3), "covariance")
+
+
+def test_reshape_covariance_rejects_nan_values() -> None:
+    """Ensure NaN covariances are rejected."""
+    values: list[float] = [
+        0.1,
+        0.0,
+        0.0,
+        0.0,
+        float("nan"),
+        0.0,
+        0.0,
+        0.0,
+        0.3,
+    ]
+    with pytest.raises(ValueError):
+        reshape_covariance(values, (3, 3), "covariance")
+
+
+def test_imu_pair_tracker_rejects_bad_cov_without_unpaired_drop() -> None:
+    """Ensure covariance rejection increments bad cov, not unpaired drops."""
+    tracker: ImuPairTracker = ImuPairTracker(warmup_sec=0.0)
+    t_ns: int = 1_000_000
+    tracker.record_raw(t_ns)
+    tracker.record_calibration(t_ns)
+    tracker.record_pair(t_ns)
+    tracker.reject_bad_cov()
+    assert tracker.imu_pairs_rejected_bad_cov == 1
+    assert tracker.unpaired_raw(t_ns) == 0
+
+
+def test_imu_pair_tracker_counts_unpaired_raw() -> None:
+    """Ensure unpaired raw messages are counted after warmup."""
+    tracker: ImuPairTracker = ImuPairTracker(warmup_sec=0.0)
+    t_ns: int = 2_000_000
+    tracker.record_raw(t_ns)
+    assert tracker.unpaired_raw(t_ns) == 1
 
 
 def test_quaternion_normalization() -> None:

--- a/oasis_control/test/nodes/test_ahrs_mounting_node.py
+++ b/oasis_control/test/nodes/test_ahrs_mounting_node.py
@@ -1,0 +1,91 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""Tests for AHRS mounting node helpers."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from oasis_control.localization.mounting.math_utils.validation import (
+    normalize_quaternion_wxyz,
+)
+from oasis_control.localization.mounting.math_utils.validation import reshape_covariance
+from oasis_control.localization.mounting.math_utils.validation import reshape_matrix
+
+
+def test_reshape_matrix_accepts_negative_diagonal() -> None:
+    """Ensure accel calibration matrices allow negative diagonals."""
+    values: list[float] = [
+        -1.0,
+        0.1,
+        0.2,
+        0.0,
+        -0.5,
+        0.3,
+        0.0,
+        0.0,
+        -0.2,
+    ]
+    matrix: np.ndarray = reshape_matrix(values, (3, 3), "accel_a")
+    assert matrix.shape == (3, 3)
+    assert matrix[0, 0] < 0.0
+
+
+def test_reshape_covariance_rejects_unknown_all_minus_one() -> None:
+    """Ensure all -1 covariances are rejected."""
+    values: list[float] = [-1.0] * 9
+    with pytest.raises(ValueError):
+        reshape_covariance(values, (3, 3), "covariance")
+
+
+def test_reshape_covariance_rejects_unknown_diag_minus_one() -> None:
+    """Ensure -1 diagonal covariances are rejected."""
+    values: list[float] = [
+        -1.0,
+        0.0,
+        0.0,
+        0.0,
+        -1.0,
+        0.0,
+        0.0,
+        0.0,
+        -1.0,
+    ]
+    with pytest.raises(ValueError):
+        reshape_covariance(values, (3, 3), "covariance")
+
+
+def test_reshape_covariance_rejects_negative_diagonal() -> None:
+    """Ensure negative diagonal entries are rejected."""
+    values: list[float] = [
+        -0.1,
+        0.0,
+        0.0,
+        0.0,
+        0.2,
+        0.0,
+        0.0,
+        0.0,
+        0.3,
+    ]
+    with pytest.raises(ValueError):
+        reshape_covariance(values, (3, 3), "covariance")
+
+
+def test_quaternion_normalization() -> None:
+    """Ensure quaternion inputs are normalized."""
+    wxyz: list[float] = [2.0, 0.0, 0.0, 0.0]
+    normalized: np.ndarray = normalize_quaternion_wxyz(wxyz)
+    assert np.isclose(normalized[0], 1.0)
+    assert np.isclose(normalized[1], 0.0)
+    assert np.isclose(normalized[2], 0.0)
+    assert np.isclose(normalized[3], 0.0)

--- a/oasis_control/test/nodes/test_ahrs_mounting_node.py
+++ b/oasis_control/test/nodes/test_ahrs_mounting_node.py
@@ -12,9 +12,13 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from dataclasses import replace
+
 import numpy as np
 import pytest
 
+from oasis_control.localization.mounting.config.mounting_params import MountingParams
 from oasis_control.localization.mounting.diagnostics.imu_pair_tracker import (
     ImuPairTracker,
 )
@@ -26,6 +30,59 @@ from oasis_control.localization.mounting.math_utils.validation import (
 )
 from oasis_control.localization.mounting.math_utils.validation import reshape_covariance
 from oasis_control.localization.mounting.math_utils.validation import reshape_matrix
+from oasis_control.localization.mounting.mounting_types import ImuPacket
+from oasis_control.localization.mounting.ros.imu_packet_builder import (
+    build_imu_packet as _build_imu_packet,
+)
+
+
+@dataclass
+class FakeStamp:
+    """Minimal timestamp container for IMU messages"""
+
+    sec: int
+    nanosec: int
+
+
+@dataclass
+class FakeHeader:
+    """Minimal header container for IMU messages"""
+
+    stamp: FakeStamp
+    frame_id: str
+
+
+@dataclass
+class FakeVector3:
+    """Minimal vector container for IMU messages"""
+
+    x: float
+    y: float
+    z: float
+
+
+@dataclass
+class FakeImuMsg:
+    """Minimal IMU message container for helper tests"""
+
+    header: FakeHeader
+    angular_velocity: FakeVector3
+    linear_acceleration: FakeVector3
+    angular_velocity_covariance: list[float]
+    linear_acceleration_covariance: list[float]
+
+
+@dataclass
+class FakeImuCalibrationMsg:
+    """Minimal IMU calibration container for helper tests"""
+
+    header: FakeHeader
+    valid: bool
+    accel_bias: FakeVector3
+    accel_a: list[float]
+    accel_param_cov: list[float]
+    gyro_bias: FakeVector3
+    gyro_bias_cov: list[float]
 
 
 def test_reshape_matrix_accepts_negative_diagonal() -> None:
@@ -151,3 +208,37 @@ def test_quaternion_normalization() -> None:
     assert np.isclose(normalized[1], 0.0)
     assert np.isclose(normalized[2], 0.0)
     assert np.isclose(normalized[3], 0.0)
+
+
+def test_build_imu_packet_uses_param_defaults_for_unknown_covariance() -> None:
+    """Ensure IMU covariance fallbacks ignore calibration parameters."""
+    omega_diag: np.ndarray = np.array([1.1e-05, 2.2e-05, 3.3e-05], dtype=np.float64)
+    accel_diag: np.ndarray = np.array([4.4e-03, 5.5e-03, 6.6e-03], dtype=np.float64)
+    params: MountingParams = MountingParams.defaults()
+    params = replace(
+        params,
+        imu=replace(params.imu, omega_cov_diag=omega_diag, accel_cov_diag=accel_diag),
+    )
+
+    imu_msg: FakeImuMsg = FakeImuMsg(
+        header=FakeHeader(stamp=FakeStamp(sec=1, nanosec=2), frame_id="imu"),
+        angular_velocity=FakeVector3(x=0.1, y=0.2, z=0.3),
+        linear_acceleration=FakeVector3(x=1.0, y=2.0, z=3.0),
+        angular_velocity_covariance=[-1.0] * 9,
+        linear_acceleration_covariance=[-1.0] * 9,
+    )
+
+    cal_msg: FakeImuCalibrationMsg = FakeImuCalibrationMsg(
+        header=FakeHeader(stamp=FakeStamp(sec=1, nanosec=2), frame_id="imu"),
+        valid=True,
+        accel_bias=FakeVector3(x=0.1, y=0.2, z=0.3),
+        accel_a=np.eye(3, dtype=np.float64).reshape(-1).tolist(),
+        accel_param_cov=np.eye(12, dtype=np.float64).reshape(-1).tolist(),
+        gyro_bias=FakeVector3(x=0.4, y=0.5, z=0.6),
+        gyro_bias_cov=np.eye(3, dtype=np.float64).reshape(-1).tolist(),
+    )
+
+    packet: ImuPacket = _build_imu_packet(imu_msg, cal_msg, params=params)
+
+    assert np.allclose(packet.cov_omega_raw, np.diag(omega_diag))
+    assert np.allclose(packet.cov_a_raw, np.diag(accel_diag))

--- a/oasis_msgs/CMakeLists.txt
+++ b/oasis_msgs/CMakeLists.txt
@@ -31,6 +31,8 @@ ament_export_dependencies(rosidl_default_runtime)
 rosidl_generate_interfaces(
   ${PROJECT_NAME}
     msg/Accelerometer.msg
+    msg/AhrsMount.msg
+    msg/AhrsMountDiagnostics.msg
     msg/AirQuality.msg
     msg/AnalogButton.msg
     msg/AnalogReading.msg

--- a/oasis_msgs/msg/AhrsMount.msg
+++ b/oasis_msgs/msg/AhrsMount.msg
@@ -1,0 +1,127 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See the file LICENSE.txt for more information.
+#
+################################################################################
+
+#
+# AHRS Mounting Calibration result snapshot.
+#
+# Publishes the current mounting-rotation estimates (IMU->body and Mag->body),
+# associated covariances, nuisance parameters, and status/quality metrics.
+#
+# Contract highlights:
+# - Rotations only: translations are NOT estimated and are NOT included here.
+# - Quaternions are explicitly stored in [w, x, y, z] order.
+# - Rotation covariances are 3x3 tangent-space covariances (rad^2), row-major.
+#
+
+std_msgs/Header header
+
+# -----------------------------
+# Frames (stable identifiers)
+# -----------------------------
+
+# Body frame (parent frame for TF), e.g. "base_link"
+string base_frame
+
+# IMU sensor frame, from imu_raw.header.frame_id, e.g. "imu_link"
+string imu_frame
+
+# Magnetometer sensor frame, from magnetic_field.header.frame_id, e.g. "mag_link"
+string mag_frame
+
+# -----------------------------
+# Flags / status
+# -----------------------------
+
+# True when the solution is anchored to base_link (reference pose captured)
+bool anchored
+
+# True when a valid magnetometer reference could not be established
+bool mag_reference_invalid
+
+# True when a magnetic disturbance is detected (or mag factors are being dropped)
+bool mag_disturbance_detected
+
+# True if the mag direction covariance prior was initialized from driver covariance
+bool mag_dir_prior_from_driver_cov
+
+# -----------------------------
+# Mount rotations (primary outputs)
+# -----------------------------
+
+# Quaternion for R_BI (IMU {I} -> body {B}), order [w,x,y,z]
+float64[4] q_bi_wxyz
+
+# Quaternion for R_BM (Mag {M} -> body {B}), order [w,x,y,z]
+float64[4] q_bm_wxyz
+
+# 3x3 tangent-space covariance for R_BI (rad^2), row-major
+float64[9] cov_r_bi_row_major_3x3
+
+# 3x3 tangent-space covariance for R_BM (rad^2), row-major
+float64[9] cov_r_bm_row_major_3x3
+
+# -----------------------------
+# Nuisance snapshot (refined online)
+# -----------------------------
+
+# Accel bias b_a (m/s^2), used in: a_corr = A_a (a_raw - b_a)
+float64[3] accel_bias_mps2
+
+# Accel scale/misalignment matrix A_a (row-major 3x3)
+float64[9] accel_a_row_major_3x3
+
+# Optional accel systematic covariance over [b_a (3), A_a (9)] => 12x12 row-major.
+# Leave all zeros if not tracked.
+float64[144] accel_param_cov_row_major_12x12
+
+# Gyro bias b_g (rad/s), used in: omega_corr = omega_raw - b_g
+float64[3] gyro_bias_rads
+
+# Gyro bias covariance 3x3 (rad^2/s^2), row-major. Zeros if not tracked.
+float64[9] gyro_bias_cov_row_major_3x3
+
+# Optional magnetometer offset b_m (tesla) used in: m_corr = m_raw - b_m.
+# Zeros if not estimated/used.
+float64[3] mag_offset_t
+
+# Optional mag offset covariance 3x3 (tesla^2), row-major. Zeros if not tracked.
+float64[9] mag_offset_cov_row_major_3x3
+
+# Current direction-residual noise model R_m (unitless^2 ~ rad^2), row-major 3x3.
+# This is the bounded/adaptive covariance used for direction residuals.
+float64[9] mag_r_m_unitless2_row_major_3x3
+
+# Initial direction-residual noise model R_m0 (unitless^2 ~ rad^2), row-major 3x3.
+float64[9] mag_r_m0_unitless2_row_major_3x3
+
+# -----------------------------
+# Quality / bookkeeping
+# -----------------------------
+
+# Total raw samples ingested (IMU pairs) since start/reset
+uint32 raw_samples
+
+# Number of steady segments emitted by gating
+uint32 steady_segments
+
+# Number of active keyframes in clustering
+uint32 keyframes
+
+# Direction-residual RMS for accel (unitless ~ radians)
+float64 accel_residual_rms
+
+# Direction-residual RMS for mag (unitless ~ radians). 0 when mag unused/invalid.
+float64 mag_residual_rms
+
+# Maximum angle between gravity directions across keyframes (deg)
+float64 gravity_max_angle_deg
+
+# Maximum angle between horizontal mag projections across keyframes (deg)
+float64 mag_proj_max_angle_deg

--- a/oasis_msgs/msg/AhrsMountDiagnostics.msg
+++ b/oasis_msgs/msg/AhrsMountDiagnostics.msg
@@ -22,7 +22,26 @@ std_msgs/Header header
 # -----------------------------
 
 # Count of imu_raw messages dropped because no ExactTime imu_calibration matched
+# (legacy alias for imu_raw_unpaired_dropped)
 uint32 imu_raw_dropped_no_calibration
+
+# Count of ExactTime imu_raw + imu_calibration pairs received
+uint32 imu_pairs_received
+
+# Count of pairs rejected because calibration msg.valid was false
+uint32 imu_pairs_rejected_invalid_cal
+
+# Count of pairs rejected due to missing/mismatched frame_ids
+uint32 imu_pairs_rejected_frame_mismatch
+
+# Count of pairs rejected due to invalid or unknown covariance
+uint32 imu_pairs_rejected_bad_cov
+
+# Count of pairs rejected due to other exceptions
+uint32 imu_pairs_rejected_other
+
+# Count of imu_raw messages that never matched a calibration
+uint32 imu_raw_unpaired_dropped
 
 # Count of magnetometer samples dropped due to invalid/NaN covariance or bad norm
 uint32 mag_dropped_bad_cov
@@ -49,6 +68,9 @@ bool anchored
 
 # True when current steady detector window satisfies STEADY criteria
 bool steady_detected
+
+# Count of raw IMU samples ingested
+uint32 raw_samples
 
 # Count of emitted steady segments
 uint32 steady_segments

--- a/oasis_msgs/msg/AhrsMountDiagnostics.msg
+++ b/oasis_msgs/msg/AhrsMountDiagnostics.msg
@@ -1,0 +1,108 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See the file LICENSE.txt for more information.
+#
+################################################################################
+
+#
+# Structured diagnostics for the AHRS mounting calibration node.
+#
+# This is a typed alternative to stuffing everything into DiagnosticArray.
+# It’s intended for logging, dashboards, and test assertions.
+#
+
+std_msgs/Header header
+
+# -----------------------------
+# Timing / drops
+# -----------------------------
+
+# Count of imu_raw messages dropped because no ExactTime imu_calibration matched
+uint32 imu_raw_dropped_no_calibration
+
+# Count of magnetometer samples dropped due to invalid/NaN covariance or bad norm
+uint32 mag_dropped_bad_cov
+
+# Maximum observed time-sync slop between streams (ns). 0 if not tracked.
+int64 time_sync_slop_max_ns
+
+# -----------------------------
+# Bootstrap / state
+# -----------------------------
+
+# True while in startup bootstrap phase
+bool bootstrap_active
+
+# Remaining bootstrap time (sec). 0 when inactive.
+float64 bootstrap_remaining_sec
+
+# True when anchored to base_link (reference pose captured)
+bool anchored
+
+# -----------------------------
+# Steady / keyframe pipeline
+# -----------------------------
+
+# True when current steady detector window satisfies STEADY criteria
+bool steady_detected
+
+# Count of emitted steady segments
+uint32 steady_segments
+
+# Count of active keyframes
+uint32 keyframes
+
+# True when solver indicates insufficient tilt diversity
+bool need_more_tilt
+
+# True when solver indicates insufficient yaw diversity (when mag used)
+bool need_more_yaw
+
+# -----------------------------
+# Magnetometer health
+# -----------------------------
+
+# True if mag reference is invalid / unavailable
+bool mag_reference_invalid
+
+# True if mag disturbance is detected (or mag constraints dropped)
+bool mag_disturbance_detected
+
+# Trace of current mag direction noise model R_m (unitless^2)
+float64 mag_r_m_trace
+
+# Count of mag factors dropped/ignored due to gating/disturbance
+uint32 mag_factors_dropped
+
+# -----------------------------
+# Solver health
+# -----------------------------
+
+# Iterations used in the last optimizer update
+int32 optimizer_iterations_last
+
+# Step norm from the last optimizer update (rad)
+float64 optimizer_step_norm_last
+
+# Accel direction residual RMS (unitless ~ rad)
+float64 accel_residual_rms
+
+# Mag direction residual RMS (unitless ~ rad)
+float64 mag_residual_rms
+
+# -----------------------------
+# Persistence
+# -----------------------------
+
+# Last successful save time (unix ns). 0 if never saved.
+int64 last_save_unix_ns
+
+# Save period configured (sec)
+float64 save_period_sec
+
+# Count of save failures since start/reset
+uint32 save_fail_count


### PR DESCRIPTION
### Motivation
- Calibration-parameter covariances were being used as per-sample measurement-noise fallbacks, which conflates systematic parameter uncertainty with per-sample sensor noise.
- Use parameter-configured measurement-noise defaults for driver-unknown covariances to make the measurement model predictable and tunable.

### Description
- Replace driver-covariance fallback policy so `_build_imu_packet` always uses parameter defaults computed as `np.diag(params.imu.omega_cov_diag)` and `np.diag(params.imu.accel_cov_diag)` when the driver reports unknown covariances.
- Move IMU/mag packet construction into a small ROS helper `oasis_control.localization.mounting.ros.imu_packet_builder` and wire the node to use `build_imu_packet`/`build_mag_packet` for cleaner separation of ROS glue from core logic.
- Update default diagonals in `mounting_params.py` to conservative values informed by an observed sample (gyro ~2.3e-06–3.6e-06 (rad/s)^2 → set to ~5e-06; accel ~1.2e-03–2.7e-03 (m/s^2)^2 → set to ~3.5e-03) and document the observed values in comments.
- Add a unit test `test_build_imu_packet_uses_param_defaults_for_unknown_covariance` that asserts unknown driver covariances (`-1`) fall back to the `MountingParams` defaults even when `imu_calibration.valid == True`, and keep existing covariance validation semantics intact.

### Testing
- Ran full `tox` including `black`/`isort`/`flake8`/`mypy` and the test suite via `pytest` as part of the tox run; all checks passed.
- Test results: `166 passed` (unit tests) during the `tox` run.
- Formatting and import-order issues were fixed (`black`/`isort`) as part of the change so CI linters remain green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978c3f5c1b083269a5ce93f65bc706a)