### PR TITLE
localization: add ZUPT detector core

### DIFF
--- a/docs/AHRS_Speedometer.md
+++ b/docs/AHRS_Speedometer.md
@@ -1,0 +1,414 @@
+# AHRS_Speedometer.md
+
+> **Goal:** Estimate **forward (longitudinal) speed** for Falcon/train from IMU signals, with **bounded drift** via **ZUPT (Zero-Velocity Updates)** detected from a trusted _tilt_ signal + motor command (duty cycle).
+> **Non-goals (v1):** full 3D pose, global heading, map frame, absolute position, or full IMU mounting calibration.
+
+---
+
+## 1. Overview
+
+This module provides a **1D inertial speedometer**:
+
+- Estimates **forward speed** `v_f` (m/s) along **body x-forward**.
+- Learns the **forward accelerometer bias component** `b_f` robustly during stops (ZUPT).
+- Uses a trusted **tilt** signal for:
+  - stationary detection (low angular rate + stable roll/pitch)
+  - estimating the **gravity projection** onto the forward axis (to remove gravity from raw accel)
+- Optionally uses **6DOF accel calibration** as _priors_ (not as ground truth) to initialize scale/bias uncertainty.
+
+Two ROS nodes are defined:
+
+1. `zupt_sensor_node`
+   Detects stops; publishes a zero-velocity “measurement” with covariance.
+2. `speedometer_node`
+   Runs a 1D Kalman filter to estimate forward speed (and forward bias, and optionally gravity magnitude).
+
+---
+
+## 2. Frames and sign conventions
+
+- **body frame:** `base_link`
+  - `+x` = **forward** (longitudinal direction)
+  - `+y` = left
+  - `+z` = up
+- **IMU raw frame:** `imu_raw` (conceptual; represented by `/imu_raw` message frame_id)
+- **Tilt frame:** `/tilt` is published with `frame_id: imu_link` (derived estimate in IMU frame)
+
+For v1, you may treat:
+
+- `base_link ≈ imu_link` rotation (identity) if you only care about 1D speed and accept some scale/bias error.
+- The _gravity compensation_ uses tilt’s roll/pitch (yaw irrelevant for gravity).
+
+---
+
+## 3. ROS Interfaces
+
+### 3.1 Inputs
+
+#### `/oasis/<system>/tilt` _(trusted)_
+
+**Type:** `sensor_msgs/Imu`
+Used for:
+
+- `orientation` (roll/pitch only; yaw may be unobservable / high covariance)
+- `angular_velocity` (used for stationary detection)
+- `orientation_covariance`, `angular_velocity_covariance` (used for adaptive thresholds / confidence)
+
+#### `/oasis/<system>/conductor_state`
+
+**Type:** `oasis_msgs/msg/ConductorState`
+Used for:
+
+- `duty_cycle` in `[-1, 1]`
+  Used as a discrete “intent” signal: `== 0` means commanded stop (controller deadzone already applied).
+
+#### `/oasis/<system>/imu_raw`
+
+**Type:** `sensor_msgs/Imu`
+Used for:
+
+- `linear_acceleration` (raw, biased, includes gravity)
+- (optionally) `angular_velocity` if tilt angular velocity is unavailable
+
+> **Note:** `imu_raw` acceleration magnitude may be wrong (e.g., ~10.17 m/s² at rest). This design does **not** require that `|a|≈9.81`.
+
+#### `/oasis/<system>/imu_calibration` _(optional priors)_
+
+**Type:** `oasis_msgs/msg/ImuCalibration`
+Used as priors only:
+
+- accel scale/misalignment matrix `A` and bias `b_a`
+- parameter covariances (if provided)
+- gyro bias prior (optional)
+
+---
+
+### 3.2 Outputs
+
+#### `/oasis/<system>/zupt`
+
+**Type:** `geometry_msgs/TwistWithCovarianceStamped`
+Represents a **measurement** that forward velocity is zero:
+
+- `twist.twist.linear.x = 0.0`
+- `twist.covariance[0,0] = σ²_zupt_v` (tunable / annealed)
+- All other covariance entries may be large or left as-is.
+
+`header.frame_id`: `base_link` (preferred) or `imu_link` if base_link is not meaningful yet.
+
+#### `/oasis/<system>/zupt_flag`
+
+**Type:** `std_msgs/Bool`
+Convenience boolean: `true` while stationary is asserted.
+
+#### `/oasis/<system>/forward_twist`
+
+**Type:** `geometry_msgs/TwistWithCovarianceStamped`
+Speedometer output:
+
+- `twist.twist.linear.x = v_f`
+- `twist.covariance[0,0] = P_vv`
+
+Frame: `base_link`.
+
+#### `/oasis/<system>/speedometer_diagnostics` _(recommended)_
+
+**Type:** `diagnostic_msgs/DiagnosticArray` (or a custom msg)
+Suggested fields:
+
+- stationary flag, dwell time
+- thresholds (omega_enter/exit, tilt stability)
+- v_f, P_vv
+- b_f, P_bb
+- gravity estimate (if enabled) + covariance
+- innovation stats for ZUPT updates
+- gating reasons (why ZUPT rejected)
+
+---
+
+## 4. ZUPT Sensor Node (`zupt_sensor_node`)
+
+### 4.1 Stationary detection logic (tilt + duty)
+
+Stationary should mean:
+
+- robot is not commanded to move **and**
+- robot is not rotating significantly **and**
+- roll/pitch are stable (optional but helpful against vibration false positives)
+
+**Inputs used:**
+
+- `duty_cycle` from `/conductor_state`
+- `ω = tilt.angular_velocity` (or imu_raw gyro)
+- `q = tilt.orientation` (roll/pitch stability)
+
+**Gating rules (typical):**
+
+1. `duty_cycle == 0` (exact zero due to deadzoning)
+2. Angular rate magnitude below threshold:
+   - `||ω|| < omega_enter` to enter stationary
+   - `||ω|| > omega_exit` to exit stationary (hysteresis)
+3. Optional: tilt stability (roll/pitch change rate small)
+   - e.g., `angle( q(t), q(t-Δt) ) < tilt_delta_max`
+
+### 4.2 Adaptive threshold “annealing”
+
+Because vibration and sensor conditions vary, thresholds can be adaptive:
+
+- Maintain running estimates during recent motion/stops:
+  - gyro noise floor `σ_ω` from covariance or from a short window variance estimate
+  - optionally gyro bias estimate `b_g` (see §4.4)
+
+Then set:
+
+- `omega_enter = k_enter * σ_ω + omega_min`
+- `omega_exit  = k_exit  * σ_ω + omega_min`, with `k_exit > k_enter`
+
+### 4.3 ZUPT measurement covariance annealing (confidence grows with stillness)
+
+When stationary persists for longer, the ZUPT velocity measurement can be trusted more:
+
+- Let `t_s` = time continuously stationary.
+- Define a decreasing function:
+  - `σ_zupt_v(t_s) = max(σ_min, σ0 * exp(-t_s / τ))`
+
+So the ZUPT “pull to zero” is gentle initially, then becomes strong if the robot stays still.
+
+This avoids instantly “snapping” velocity to zero on a brief pause.
+
+### 4.4 Gyro bias estimate (optional, but helps stability)
+
+Even if speedometer is 1D, you may want a gyro bias estimate in ZUPT sensor to avoid false motion detection:
+
+- During stationary, treat true angular rate as ~0:
+  - measurement: `ω_meas = b_g + noise`
+- Run a 3D bias estimator:
+  - `b_g` as a slowly-updated mean with covariance
+  - or a tiny Kalman filter per axis
+
+This bias does **not** have to be perfect; it’s mainly to keep `||ω||` gating stable.
+
+**Publish?**
+
+- If useful elsewhere, publish `b_g` as part of diagnostics (or a custom msg).
+
+---
+
+## 5. Speedometer Node (`speedometer_node`)
+
+### 5.1 State, units, and covariance
+
+A minimal 1D Kalman filter:
+
+**State**
+
+- `x = [ v_f, b_f ]ᵀ`
+  - `v_f` = forward speed (m/s)
+  - `b_f` = forward accel bias component (m/s²)
+
+**Covariance**
+
+- `P = cov(x)` (2×2)
+
+**Optional extension**
+
+- Add gravity magnitude `g` as a third state:
+  - `x = [ v_f, b_f, g ]ᵀ`
+  - Useful if `|a|` at rest is not trustworthy and you want the filter to learn a consistent gravity magnitude during ZUPT.
+
+### 5.2 Inputs used by the propagation step
+
+At each IMU raw sample:
+
+1. Get raw acceleration vector from `/imu_raw`:
+   - `a_raw_I` (m/s²) in IMU raw frame
+
+2. Compute forward axis unit vector `e_f` in the same frame:
+   - v1: assume `e_f = [1,0,0]` in imu frame if `base_link≈imu_link`
+   - if you later add mounting, compute `e_f` via `R_BI`
+
+3. Remove gravity using tilt:
+   - From `tilt.orientation` (roll/pitch), compute gravity direction in IMU frame:
+     - `ĝ_I = R(q_tilt)ᵀ * [0,0,1]` (or `[0,0,-1]` depending on convention)
+   - Use a gravity magnitude:
+     - either fixed parameter `imu_gravity_mps2`
+     - or learned `g` (state), or
+     - or a prior from tilt (see §5.6)
+
+4. Form forward specific force estimate:
+   - `a_f = e_fᵀ * a_raw_I  -  g * (e_fᵀ * ĝ_I)`
+     This estimates “horizontal/forward acceleration” excluding gravity projection.
+
+> You are **not** depending on the accelerometer being well-calibrated; `b_f` absorbs a large part of the error along forward.
+
+### 5.3 Process model (prediction)
+
+Discrete time step `Δt`:
+
+- `v_{k+1} = v_k + (a_f - b_f) * Δt`
+- `b_{k+1} = b_k` (random walk)
+
+Process noise:
+
+- `q_v` from accel noise / model mismatch
+- `q_b` sets how fast bias is allowed to wander (tunable)
+
+This can be implemented as standard linear Kalman predict with:
+
+- `F = [[1, -Δt], [0, 1]]`
+- `u = a_f * Δt`
+- `Q` based on `q_v`, `q_b`
+
+### 5.4 ZUPT measurement update
+
+When `/zupt` arrives (or when `zupt_flag==true` and you choose to update every N ms):
+
+Measurement:
+
+- `z = 0` (forward velocity is zero)
+
+Model:
+
+- `z = H x + noise`, with `H = [1, 0]`
+
+Innovation covariance:
+
+- `S = HPHᵀ + R_zupt`, where `R_zupt = σ²_zupt_v`
+
+Update pulls:
+
+- `v_f → 0`
+- and indirectly learns `b_f` (because persistent ZUPTs constrain drift, causing bias to be corrected).
+
+### 5.5 Learning forward accel bias robustly
+
+**Key claim:** ZUPT lets you learn **only what’s observable** in 1D:
+
+- The forward component of accelerometer bias (and scale, if you model it) is the most robust learnable term.
+- Cross-axis calibration and full 3D bias are not observable without richer motion/tilt excitation.
+
+If you want a **scale factor** too, extend the model:
+
+- Add `s_f` (unitless) such that:
+  - `v_{k+1} = v_k + (s_f * a_f - b_f)Δt`
+- But be careful: `s_f` and `b_f` can be weakly identifiable without varied acceleration profiles. Use strong priors.
+
+### 5.6 Using `imu_calibration` as priors (optional)
+
+You want priors (that’s the point of your 6DOF calibration), but you **don’t** want to trust them blindly.
+
+Recommended pattern:
+
+- Use `imu_calibration` to initialize:
+  - `b_f` prior mean and covariance (weak prior)
+  - optionally a scale prior `s_f` if you add it
+  - optionally gyro bias prior for ZUPT gating
+
+But keep priors **wide**:
+
+- If the calibration is stale/wrong, the ZUPT-driven updates should override it quickly.
+
+If you include gravity magnitude `g` as a state:
+
+- Initialize `g` from:
+  - a parameter or a prior derived from tilt history
+- Then refine `g` slowly during ZUPT windows using the measured accel magnitude statistics.
+
+---
+
+## 6. Why magnetometer is not required for speedometer v1
+
+For **forward speed only**, magnetometer is usually unnecessary:
+
+- Yaw is not needed if you define the forward axis in the body/IMU frame and only integrate along that axis.
+- Magnetometer is more relevant for:
+  - heading / yaw drift correction
+  - mapping accel into a world frame
+  - coupling speed to global velocity
+
+You can add mag later if you decide to estimate world-frame velocity or fuse odometry.
+
+---
+
+## 7. Parameters
+
+Suggested ROS parameters (names are illustrative):
+
+### ZUPT sensor
+
+- `duty_zero_epsilon` (default: `0.0` if deadzoning guarantees exact zero)
+- `omega_enter` / `omega_exit` (or adaptive gains `k_enter`, `k_exit`)
+- `tilt_delta_max_rad` (optional)
+- `min_stationary_sec` (debounce, e.g. `0.2`)
+- `zupt_sigma_v0` (initial σ)
+- `zupt_sigma_v_min`
+- `zupt_sigma_tau_sec` (annealing time constant)
+
+### Speedometer
+
+- `process_noise_v` (q_v)
+- `process_noise_b` (q_b)
+- `initial_speed_sigma`
+- `initial_bias_sigma`
+- `imu_gravity_mps2` (if fixed)
+- `use_gravity_state` (bool)
+- `publish_rate_hz`
+- `frame_id` (`base_link`)
+
+---
+
+## 8. Expected behavior and limitations
+
+### Works well when:
+
+- Train does frequent stops (station platforms / pauses / manual stops)
+- Duty command provides a reliable “intent” signal
+- Tilt angular velocity is reasonably clean for stationary gating
+
+### Drift sources:
+
+- forward accel bias changes with temperature/vibration
+- scale error (if not modeled)
+- imperfect gravity projection from tilt under vibration
+- coasting / creep when duty=0 (train not truly stationary)
+
+### What you cannot get from yaw-only motion:
+
+- Full IMU mounting (`R_BI`) is not observable without tilt diversity.
+- But for 1D speed, you can proceed with approximate alignment and learn bias.
+
+---
+
+## 9. Testing plan
+
+### Offline bag tests
+
+- Log `/tilt`, `/imu_raw`, `/conductor_state`, `/zupt`, `/forward_twist`
+- Check:
+  - ZUPT triggers only when expected
+  - velocity returns to ~0 during stops
+  - covariance grows during motion and shrinks during long stops
+
+### Bench tests
+
+- Hold train still, duty=0:
+  - verify ZUPT assert after debounce
+  - verify velocity covariance anneals down
+
+### Track tests
+
+- Run laps with periodic stops:
+  - verify drift between stops is bounded
+  - verify speed sign matches direction
+
+---
+
+## 10. Future extensions
+
+- Add `s_f` scale factor learning with priors from `imu_calibration.accel_a`
+- Add coasting detector (if duty=0 but vibration signature indicates motion)
+- Add wheel encoder / hall sensor for absolute speed correction
+- Add mounting calibration later (AHRS Mounting) to unify frames robustly
+- Publish `nav_msgs/Odometry` if you later want a standard interface (twist only)
+
+---

--- a/oasis_control/oasis_control/localization/zupt_detector.py
+++ b/oasis_control/oasis_control/localization/zupt_detector.py
@@ -1,0 +1,420 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""Zero-velocity update (ZUPT) detector for tilt gyro data."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Optional
+from typing import cast
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+_FLOAT_ARRAY = NDArray[np.float64]
+
+
+@dataclass
+class ZuptDetectorConfig:
+    """Configuration values for the ZUPT detector."""
+
+    # Minimum quiet time to enter stationary, in seconds
+    min_stationary_sec: float = 0.7
+
+    # Minimum loud time to exit stationary, in seconds
+    min_exit_sec: float = 0.15
+
+    # Chi-square gate to enter stationary for df=3
+    gate_enter_chi2: float = 7.8147279
+
+    # Chi-square gate to exit stationary for df=3
+    gate_exit_chi2: float = 11.3448667
+
+    # Norm gate to enter stationary when covariance inversion fails, rad/s
+    omega_norm_enter: float = 0.05
+
+    # Norm gate to exit stationary when covariance inversion fails, rad/s
+    omega_norm_exit: float = 0.10
+
+    # Require duty cycle to be exactly zero to gate stationary
+    duty_requires_exact_zero: bool = True
+
+    # Tolerance for duty cycle to be treated as zero
+    duty_zero_epsilon: float = 0.0
+
+    # Enable adaptive gates based on EWMA of quietness
+    use_adaptive_gates: bool = False
+
+    # EWMA smoothing factor for adaptive gate updates
+    adaptive_ewma_alpha: float = 0.02
+
+    # Minimum adaptive gate scale relative to nominal
+    adaptive_gate_scale_min: float = 0.75
+
+    # Maximum adaptive gate scale relative to nominal
+    adaptive_gate_scale_max: float = 2.0
+
+    # ZUPT velocity sigma at entry, meters per second
+    zupt_sigma_start_mps: float = 0.10
+
+    # ZUPT velocity sigma after long dwell, meters per second
+    zupt_sigma_min_mps: float = 0.01
+
+    # ZUPT variance annealing time constant, seconds
+    zupt_anneal_tau_sec: float = 0.7
+
+    # Regularization epsilon added to covariance for inversion
+    covariance_regularization_eps: float = 1e-9
+
+
+@dataclass
+class ZuptDetectorState:
+    """Mutable state for the ZUPT detector."""
+
+    # Last update timestamp in seconds, or None before the first update
+    last_t: Optional[float] = None
+
+    # Last duty cycle value, unitless
+    duty_cycle: float = 0.0
+
+    # True when the detector believes the platform is stationary
+    stationary: bool = False
+
+    # Accumulated quiet time while seeking stationary, seconds
+    candidate_quiet_time: float = 0.0
+
+    # Accumulated loud time while seeking exit, seconds
+    candidate_loud_time: float = 0.0
+
+    # Dwell time in the stationary state, seconds
+    stationary_dwell_time: float = 0.0
+
+    # Current adaptive scaling factor for gate thresholds
+    adaptive_gate_scale: float = 1.0
+
+    # Last Mahalanobis distance squared value
+    last_d2: float = 0.0
+
+    # Last raw omega norm, rad/s
+    last_omega_norm: float = 0.0
+
+    # Last bias-corrected omega norm, rad/s
+    last_omega_c_norm: float = 0.0
+
+    # Last enter gate value
+    last_gate_enter: float = 0.0
+
+    # Last exit gate value
+    last_gate_exit: float = 0.0
+
+    # Reason string for the last decision
+    last_reason: str = "init"
+
+
+class ZuptDetector:
+    """Detects zero-velocity intervals using duty gating and gyro quietness."""
+
+    def __init__(self, config: ZuptDetectorConfig) -> None:
+        self._config: ZuptDetectorConfig = config
+        self._state: ZuptDetectorState = ZuptDetectorState()
+        self._gyro_bias: _FLOAT_ARRAY = np.zeros(3, dtype=np.float64)
+        self._gyro_bias_cov: _FLOAT_ARRAY = np.zeros((3, 3), dtype=np.float64)
+        self._adaptive_d2_ewma: Optional[float] = None
+
+    @property
+    def state(self) -> ZuptDetectorState:
+        """Return the mutable detector state."""
+
+        return self._state
+
+    def reset(self) -> None:
+        """Reset the detector state and cached adaptive statistics."""
+
+        self._state = ZuptDetectorState()
+        self._adaptive_d2_ewma = None
+
+    def set_gyro_bias(self, bias: _FLOAT_ARRAY, cov: _FLOAT_ARRAY) -> None:
+        """Set gyro bias mean and covariance.
+
+        Args:
+            bias: Gyro bias vector in rad/s
+            cov: Gyro bias covariance matrix in (rad/s)^2
+        """
+
+        self._gyro_bias = _as_vector(bias, "gyro_bias")
+        self._gyro_bias_cov = _as_matrix(cov, "gyro_bias_cov")
+
+    def set_duty_cycle(self, duty: float) -> None:
+        """Update the duty cycle used for commanded-stop gating."""
+
+        self._state.duty_cycle = float(duty)
+
+    def update(
+        self,
+        timestamp_sec: float,
+        omega: _FLOAT_ARRAY,
+        omega_cov: _FLOAT_ARRAY,
+    ) -> dict[str, object]:
+        """Update the detector and return the current decision.
+
+        Args:
+            timestamp_sec: Timestamp in seconds
+            omega: Angular velocity vector in rad/s
+            omega_cov: Angular velocity covariance in (rad/s)^2
+        """
+
+        timestamp: float = float(timestamp_sec)
+        dt: float = 0.0
+        dt_clamped: bool = False
+        if self._state.last_t is not None:
+            dt = timestamp - self._state.last_t
+            if dt < 0.0:
+                dt = 0.0
+                dt_clamped = True
+            if dt > 0.2:
+                dt = 0.0
+                dt_clamped = True
+        self._state.last_t = timestamp
+
+        omega_vec: _FLOAT_ARRAY = _as_vector(omega, "omega")
+        omega_cov_mat: _FLOAT_ARRAY = _as_matrix(omega_cov, "omega_cov")
+
+        omega_norm: float = float(np.linalg.norm(omega_vec))
+        omega_c: _FLOAT_ARRAY = omega_vec - self._gyro_bias
+        omega_c_norm: float = float(np.linalg.norm(omega_c))
+
+        d2, inversion_ok, used_fallback = self._compute_mahalanobis(
+            omega_c,
+            omega_cov_mat,
+            omega_c_norm,
+        )
+
+        duty_zero: bool = _is_duty_zero(
+            self._state.duty_cycle,
+            self._config.duty_requires_exact_zero,
+            self._config.duty_zero_epsilon,
+        )
+
+        if self._config.use_adaptive_gates and duty_zero:
+            self._adaptive_d2_ewma = _update_ewma(
+                self._adaptive_d2_ewma,
+                d2,
+                self._config.adaptive_ewma_alpha,
+            )
+            scale: float = _clamp(
+                (self._adaptive_d2_ewma or d2) / self._config.gate_enter_chi2,
+                self._config.adaptive_gate_scale_min,
+                self._config.adaptive_gate_scale_max,
+            )
+            self._state.adaptive_gate_scale = scale
+        elif not self._config.use_adaptive_gates:
+            self._state.adaptive_gate_scale = 1.0
+
+        gate_enter: float = (
+            self._config.gate_enter_chi2 * self._state.adaptive_gate_scale
+        )
+        gate_exit: float = self._config.gate_exit_chi2 * self._state.adaptive_gate_scale
+
+        if used_fallback:
+            quiet: bool = duty_zero and (omega_c_norm < self._config.omega_norm_enter)
+            loud: bool = (not duty_zero) or (
+                omega_c_norm > self._config.omega_norm_exit
+            )
+            reason: str = "norm_gate"
+        else:
+            quiet = duty_zero and (d2 < gate_enter)
+            loud = (not duty_zero) or (d2 > gate_exit)
+            reason = "mahalanobis_gate" if inversion_ok else "regularized_gate"
+
+        stationary: bool = self._state.stationary
+        candidate_quiet_time: float = self._state.candidate_quiet_time
+        candidate_loud_time: float = self._state.candidate_loud_time
+        stationary_dwell: float = self._state.stationary_dwell_time
+
+        if stationary:
+            if loud:
+                candidate_loud_time += dt
+            else:
+                candidate_loud_time = 0.0
+            if candidate_loud_time >= self._config.min_exit_sec:
+                stationary = False
+                stationary_dwell = 0.0
+                candidate_loud_time = 0.0
+                candidate_quiet_time = 0.0
+                reason = "exit_stationary"
+        else:
+            if quiet:
+                candidate_quiet_time += dt
+            else:
+                candidate_quiet_time = 0.0
+            if candidate_quiet_time >= self._config.min_stationary_sec:
+                stationary = True
+                stationary_dwell = 0.0
+                candidate_quiet_time = 0.0
+                candidate_loud_time = 0.0
+                reason = "enter_stationary"
+
+        if stationary:
+            stationary_dwell += dt
+        else:
+            stationary_dwell = 0.0
+
+        self._state.stationary = stationary
+        self._state.candidate_quiet_time = candidate_quiet_time
+        self._state.candidate_loud_time = candidate_loud_time
+        self._state.stationary_dwell_time = stationary_dwell
+        self._state.last_d2 = d2
+        self._state.last_omega_norm = omega_norm
+        self._state.last_omega_c_norm = omega_c_norm
+        self._state.last_gate_enter = gate_enter
+        self._state.last_gate_exit = gate_exit
+        self._state.last_reason = reason
+
+        zupt_vx_variance: Optional[float]
+        if stationary:
+            zupt_vx_variance = _anneal_variance(
+                stationary_dwell,
+                self._config.zupt_sigma_start_mps,
+                self._config.zupt_sigma_min_mps,
+                self._config.zupt_anneal_tau_sec,
+            )
+        else:
+            zupt_vx_variance = None
+
+        diagnostics: dict[str, object] = {
+            "dt_sec": dt,
+            "dt_clamped": dt_clamped,
+            "duty_zero": duty_zero,
+            "omega_norm": omega_norm,
+            "omega_c_norm": omega_c_norm,
+            "d2": d2,
+            "gate_enter": gate_enter,
+            "gate_exit": gate_exit,
+            "adaptive_gate_scale": self._state.adaptive_gate_scale,
+            "used_fallback": used_fallback,
+            "reason": reason,
+        }
+
+        return {
+            "stationary": stationary,
+            "should_publish_zupt": stationary,
+            "stationary_dwell_sec": stationary_dwell,
+            "zupt_vx_variance": zupt_vx_variance,
+            "diagnostics": diagnostics,
+        }
+
+    def _compute_mahalanobis(
+        self,
+        omega_c: _FLOAT_ARRAY,
+        omega_cov: _FLOAT_ARRAY,
+        omega_c_norm: float,
+    ) -> tuple[float, bool, bool]:
+        """Compute Mahalanobis distance squared with regularization.
+
+        Returns:
+            Tuple of (d2, inversion_ok, used_fallback)
+        """
+
+        if not np.isfinite(omega_c_norm):
+            return float("inf"), False, True
+
+        cov_sum: _FLOAT_ARRAY = omega_cov + self._gyro_bias_cov
+        cov_sum = 0.5 * (cov_sum + cov_sum.T)
+        diag: _FLOAT_ARRAY = np.diag(cov_sum)
+        diag = np.maximum(diag, 0.0)
+        cov_sum = cov_sum.copy()
+        cov_sum[np.diag_indices_from(cov_sum)] = diag
+
+        eps: float = self._config.covariance_regularization_eps
+
+        # (rad/s)^2 regularization on the diagonal to ensure invertibility
+        cov_reg: _FLOAT_ARRAY = cov_sum + (eps * np.eye(3, dtype=np.float64))
+
+        try:
+            solve = np.linalg.solve(cov_reg, omega_c)
+        except np.linalg.LinAlgError:
+            return float("inf"), False, True
+
+        d2: float = float(omega_c.T @ solve)
+        if not np.isfinite(d2):
+            return float("inf"), False, True
+
+        return d2, True, False
+
+
+def _as_vector(vec: _FLOAT_ARRAY, name: str) -> _FLOAT_ARRAY:
+    """Convert input to a finite 3-vector."""
+
+    array: _FLOAT_ARRAY = np.asarray(vec, dtype=np.float64).reshape(-1)
+    if array.shape != (3,):
+        raise ValueError(f"{name} must have shape (3,), got {array.shape}")
+    if not np.all(np.isfinite(array)):
+        raise ValueError(f"{name} must be finite")
+    return cast(_FLOAT_ARRAY, array)
+
+
+def _as_matrix(mat: _FLOAT_ARRAY, name: str) -> _FLOAT_ARRAY:
+    """Convert input to a finite 3x3 matrix."""
+
+    array: _FLOAT_ARRAY = np.asarray(mat, dtype=np.float64)
+    if array.shape != (3, 3):
+        raise ValueError(f"{name} must have shape (3, 3), got {array.shape}")
+    if not np.all(np.isfinite(array)):
+        raise ValueError(f"{name} must be finite")
+    return cast(_FLOAT_ARRAY, array)
+
+
+def _is_duty_zero(duty: float, exact: bool, epsilon: float) -> bool:
+    """Return True when the duty cycle should be treated as zero."""
+
+    if exact and epsilon <= 0.0:
+        return duty == 0.0
+    return abs(duty) <= epsilon
+
+
+def _update_ewma(
+    prev: Optional[float],
+    value: float,
+    alpha: float,
+) -> float:
+    """Update an EWMA value."""
+
+    if prev is None:
+        return value
+    return (alpha * value) + ((1.0 - alpha) * prev)
+
+
+def _clamp(value: float, min_value: float, max_value: float) -> float:
+    """Clamp a value between bounds."""
+
+    return max(min_value, min(value, max_value))
+
+
+def _anneal_variance(
+    dwell_sec: float,
+    sigma_start_mps: float,
+    sigma_min_mps: float,
+    tau_sec: float,
+) -> float:
+    """Compute annealed ZUPT measurement variance."""
+
+    if tau_sec <= 0.0:
+        return sigma_min_mps * sigma_min_mps
+
+    # (m/s)^2 initial ZUPT variance based on start sigma
+    sigma2_start: float = sigma_start_mps * sigma_start_mps
+
+    # (m/s)^2 minimum ZUPT variance based on minimum sigma
+    sigma2_min: float = sigma_min_mps * sigma_min_mps
+
+    return sigma2_min + (sigma2_start - sigma2_min) * math.exp(-dwell_sec / tau_sec)

--- a/oasis_control/test/test_zupt_detector.py
+++ b/oasis_control/test/test_zupt_detector.py
@@ -1,0 +1,133 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""Tests for the ZUPT detector."""
+
+from __future__ import annotations
+
+import math
+from typing import cast
+
+import numpy as np
+
+from oasis_control.localization.zupt_detector import ZuptDetector
+from oasis_control.localization.zupt_detector import ZuptDetectorConfig
+
+
+def _make_detector() -> ZuptDetector:
+    config = ZuptDetectorConfig(
+        min_stationary_sec=0.2,
+        min_exit_sec=0.05,
+        zupt_anneal_tau_sec=0.2,
+    )
+    return ZuptDetector(config)
+
+
+def test_enters_stationary_with_quiet_gyro() -> None:
+    detector = _make_detector()
+    detector.set_duty_cycle(0.0)
+
+    omega = np.zeros(3)
+    cov = np.eye(3) * 0.01
+
+    detector.update(0.0, omega, cov)
+    result = detector.update(0.2, omega, cov)
+
+    assert result["stationary"] is True
+    assert result["should_publish_zupt"] is True
+
+
+def test_does_not_enter_stationary_when_duty_nonzero() -> None:
+    detector = _make_detector()
+    detector.set_duty_cycle(0.2)
+
+    omega = np.zeros(3)
+    cov = np.eye(3) * 0.01
+
+    detector.update(0.0, omega, cov)
+    result = detector.update(0.2, omega, cov)
+
+    assert result["stationary"] is False
+
+
+def test_exits_stationary_when_duty_nonzero() -> None:
+    detector = _make_detector()
+    detector.set_duty_cycle(0.0)
+
+    omega = np.zeros(3)
+    cov = np.eye(3) * 0.01
+
+    detector.update(0.0, omega, cov)
+    detector.update(0.2, omega, cov)
+    detector.set_duty_cycle(0.5)
+    result = detector.update(0.26, omega, cov)
+
+    assert result["stationary"] is False
+
+
+def test_exits_stationary_when_gyro_loud() -> None:
+    detector = _make_detector()
+    detector.set_duty_cycle(0.0)
+
+    quiet_omega = np.zeros(3)
+    loud_omega = np.array([1.0, 0.0, 0.0])
+    cov = np.eye(3) * 0.01
+
+    detector.update(0.0, quiet_omega, cov)
+    detector.update(0.2, quiet_omega, cov)
+    result = detector.update(0.26, loud_omega, cov)
+
+    assert result["stationary"] is False
+
+
+def test_mahalanobis_gate_responds_to_tiny_covariance() -> None:
+    detector = _make_detector()
+    detector.set_duty_cycle(0.0)
+
+    omega = np.array([0.2, 0.0, 0.0])
+    cov = np.eye(3) * 1e-6
+
+    result = detector.update(0.0, omega, cov)
+    diagnostics = cast(dict[str, float], result["diagnostics"])
+
+    assert diagnostics["d2"] > detector.state.last_gate_exit
+
+
+def test_regularization_handles_singular_covariance() -> None:
+    detector = _make_detector()
+    detector.set_duty_cycle(0.0)
+
+    omega = np.zeros(3)
+    cov = np.zeros((3, 3))
+
+    result = detector.update(0.0, omega, cov)
+    diagnostics = cast(dict[str, float], result["diagnostics"])
+
+    assert math.isfinite(diagnostics["d2"])
+
+
+def test_annealing_decreases_variance_with_dwell() -> None:
+    detector = _make_detector()
+    detector.set_duty_cycle(0.0)
+
+    omega = np.zeros(3)
+    cov = np.eye(3) * 0.01
+
+    detector.update(0.0, omega, cov)
+    detector.update(0.2, omega, cov)
+    result_start = detector.update(0.25, omega, cov)
+    result_later = detector.update(0.45, omega, cov)
+
+    var_start = cast(float, result_start["zupt_vx_variance"])
+    var_later = cast(float, result_later["zupt_vx_variance"])
+
+    assert isinstance(var_start, float)
+    assert isinstance(var_later, float)
+    assert var_later < var_start


### PR DESCRIPTION
### Motivation
- Provide a pure-Python, reusable ZUPT core for tilt-based localization that can be used by ROS nodes without pulling ROS types into the algorithmic layer. 
- Detect commanded stops using motor duty (exact-zero gate) and assess motion using bias-corrected gyro rates and their covariances so the detector is covariance-aware. 
- Produce publishing-quality outputs including an annealed velocity variance that tightens with stationary dwell time and support robust behavior (hysteresis, debounce, adaptive thresholds, and covariance regularization). 

### Description
- Add `ZuptDetectorConfig` and `ZuptDetectorState` dataclasses and a `ZuptDetector` class implementing a public API (`__init__`, `reset()`, `set_gyro_bias()`, `set_duty_cycle()`, `update()`) in `oasis_control/oasis_control/localization/zupt_detector.py` using only `numpy` and typed Python. 
- Implement Mahalanobis quietness test using `omega_c = omega - gyro_bias` with `Sigma = omega_cov + gyro_bias_cov`, including regularized inversion (`eps * I`) and a norm-based fallback gate (`omega_c_norm`), plus chi-square-based default gates and configurable overrides. 
- Support hysteresis (separate enter/exit gates), debounce (`min_stationary_sec`, `min_exit_sec`), optional adaptive gating via an EWMA of quietness to scale gates, and annealed ZUPT variance computed with `sigma2(t) = sigma2_min + (sigma2_start - sigma2_min) * exp(-t / tau)`. 
- Keep the core ROS-free and well-documented with shape/finite-value validation, dt clamping for irregular timestamps, and detailed diagnostics returned from `update()`; added concise unit tests in `oasis_control/test/test_zupt_detector.py`. 

### Testing
- Ran full project checks via `tox`, which executed formatting, `isort`, `flake8`, `mypy` and the test suite. 
- All automated checks passed and the test suite succeeded: `pytest` ran and reported all tests passing (181 passed), including unit tests covering entry/exit behavior, duty gating, Mahalanobis gating with tiny covariances, singular covariance regularization, and variance annealing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a7901b22083269512feffe367b61e)