### PR TITLE
Add forward velocity estimator core module

### DIFF
--- a/docs/AHRS_Speedometer.md
+++ b/docs/AHRS_Speedometer.md
@@ -1,0 +1,372 @@
+# AHRS_Speedometer.md
+
+> **Goal:** Estimate **forward (longitudinal) speed** for Falcon/train from IMU signals, with **bounded drift** via **ZUPT (Zero-Velocity Updates)** detected from **raw gyro quietness** + motor command (duty cycle).
+> **Non-goals (v1):** full 3D pose, global heading, map frame, absolute position, or full IMU mounting calibration.
+
+---
+
+## 1. Overview
+
+This module provides a **1D inertial speedometer**:
+
+- Estimates **forward speed** `v_f` (m/s) along **body x-forward**.
+- Learns the **forward accelerometer bias component** `b_f` robustly during stops (ZUPT).
+- Uses **raw IMU gyro** for stationary detection (quiet angular rate + duty-cycle gating).
+- Treats gravity projection onto the forward axis as negligible on level track (v1); any residual coupling is absorbed into the learned bias during frequent ZUPTs.
+- Optionally uses **6DOF accel/gyro calibration** as _priors_ (not as ground truth) to initialize bias uncertainty.
+
+Two ROS nodes are defined:
+
+1. `zupt_detector_node`
+   Detects stops; publishes a zero-velocity “measurement” with covariance.
+2. `speedometer_node`
+   Runs a 1D Kalman filter to estimate forward speed (and forward bias).
+
+---
+
+## 2. Frames and sign conventions
+
+- **body frame:** `base_link`
+  - `+x` = **forward** (longitudinal direction)
+  - `+y` = left
+  - `+z` = up
+- **IMU frame:** `imu_link` (from `/imu_raw.header.frame_id`)
+
+For v1, you may treat:
+
+- `base_link ≈ imu_link` rotation (identity) if you only care about 1D speed and accept some alignment error.
+- The speedometer integrates acceleration along the assumed forward axis; ZUPT bounds drift and learns the effective forward bias.
+
+---
+
+## 3. ROS Interfaces
+
+### 3.1 Inputs
+
+#### `/oasis/<system>/conductor_state`
+
+**Type:** `oasis_msgs/msg/ConductorState`
+Used for:
+
+- `duty_cycle` in `[-1, 1]`
+  Used as a discrete “intent” signal: `== 0` means commanded stop (controller deadzone already applied).
+
+#### `/oasis/<system>/imu_raw`
+
+**Type:** `sensor_msgs/Imu`
+Used for:
+
+- `linear_acceleration` (raw, biased, includes gravity)
+- `angular_velocity` (used for stationary detection)
+- `angular_velocity_covariance` (used for gating / confidence)
+
+> **Note:** `imu_raw` acceleration magnitude may be wrong (e.g., not exactly 9.81 m/s² at rest). This design does **not** require `|a|≈9.81`.
+
+#### `/oasis/<system>/imu_calibration` _(optional priors)_
+
+**Type:** `oasis_msgs/msg/ImuCalibration`
+Used as priors only:
+
+- accel bias prior (optional) and related covariance if provided
+- gyro bias prior and covariance (recommended for ZUPT gating stability)
+
+> **QoS note:** `imu_raw` should use SensorData QoS. `conductor_state` should be Reliable + Transient Local (late-joiners get the most recent duty state).
+
+---
+
+### 3.2 Outputs
+
+#### `/oasis/<system>/zupt`
+
+**Type:** `geometry_msgs/TwistWithCovarianceStamped`
+Represents a **measurement** that forward velocity is zero:
+
+- `twist.twist.linear.x = 0.0`
+- `twist.covariance[0,0] = σ²_zupt_v` (tunable / annealed)
+- All other covariance entries may be large or left as-is.
+
+`header.frame_id`: `base_link` (preferred) or `imu_link` if base_link is not meaningful yet.
+
+#### `/oasis/<system>/zupt_flag`
+
+**Type:** `std_msgs/Bool`
+Convenience boolean: `true` while stationary is asserted.
+
+#### `/oasis/<system>/forward_twist`
+
+**Type:** `geometry_msgs/TwistWithCovarianceStamped`
+Speedometer output:
+
+- `twist.twist.linear.x = v_f`
+- `twist.covariance[0,0] = P_vv`
+
+Frame: `base_link`.
+
+#### `/oasis/<system>/speedometer_diagnostics` _(recommended)_
+
+**Type:** `diagnostic_msgs/DiagnosticArray` (or a custom msg)
+
+Suggested fields:
+
+- stationary flag, dwell time
+- thresholds (gate_enter/exit, duty gating, debounce timers)
+- v_f, P_vv
+- b_f, P_bb
+- (optional) gravity estimate (if enabled) + covariance
+- innovation stats for ZUPT updates
+- gating reasons (why ZUPT rejected)
+
+---
+
+## 4. ZUPT Detector Node (`zupt_detector_node`)
+
+### 4.1 Stationary detection logic (imu_raw gyro + duty)
+
+Stationary should mean:
+
+- robot is not commanded to move **and**
+- robot is not rotating significantly
+
+**Inputs used:**
+
+- `duty_cycle` from `/conductor_state`
+- `ω = imu_raw.angular_velocity`
+- optionally: gyro bias prior from `/imu_calibration`
+
+**Gating rules (typical):**
+
+1. `duty_cycle == 0` (exact zero due to deadzoning; optionally allow epsilon)
+2. Angular rate quietness gate (with hysteresis):
+   - enter stationary when `d2(ω - b_g) < gate_enter`
+   - exit stationary when `d2(ω - b_g) > gate_exit`
+   where `d2(·)` is a Mahalanobis distance using `angular_velocity_covariance + gyro_bias_cov`.
+3. Debounce (time-in-state):
+   - require `min_stationary_sec` quiet time to enter
+   - require `min_exit_sec` loud time to exit
+
+### 4.2 Adaptive threshold scaling (optional)
+
+If sensor conditions vary, thresholds can adapt:
+
+- Maintain an EWMA of recent `d2` while duty is zero
+- Scale `gate_enter/gate_exit` within bounds `[scale_min, scale_max]`
+
+This helps avoid false positives from vibration changes without hardcoding a single gate.
+
+### 4.3 ZUPT measurement covariance annealing (confidence grows with stillness)
+
+When stationary persists longer, the ZUPT velocity measurement can be trusted more:
+
+- Let `t_s` = time continuously stationary.
+- Use a decreasing function:
+  - `σ_zupt_v(t_s) = max(σ_min, σ0 * exp(-t_s / τ))`
+
+So ZUPT “pull to zero” is gentle initially, then becomes strong during a long stop.
+
+### 4.4 Gyro bias handling
+
+ZUPT gating is much more stable if you account for gyro bias:
+
+- Prefer a prior bias + covariance from `/imu_calibration` when available.
+- If calibration is unavailable, treat bias as zero and rely on covariance + conservative gates.
+- (Optional future) estimate a slow bias online only during stationary windows.
+
+The node publishes:
+
+- `/zupt_flag` boolean
+- `/zupt` zero-velocity measurement with annealed variance
+
+---
+
+## 5. Speedometer Node (`speedometer_node`)
+
+### 5.1 State, units, and covariance
+
+A minimal 1D Kalman filter:
+
+**State**
+
+- `x = [ v_f, b_f ]ᵀ`
+  - `v_f` = forward speed (m/s)
+  - `b_f` = forward accel bias component (m/s²)
+
+**Covariance**
+
+- `P = cov(x)` (2×2)
+
+**Optional extension**
+
+- Add gravity magnitude `g` as a third state:
+  - `x = [ v_f, b_f, g ]ᵀ`
+  - Useful if `|a|` at rest is not trustworthy and you want the filter to learn a consistent gravity magnitude during ZUPT.
+
+### 5.2 Inputs used by the propagation step
+
+At each `/imu_raw` sample:
+
+1. Get raw acceleration vector from `/imu_raw`:
+   - `a_raw_I` (m/s²) in IMU frame.
+
+2. Compute the forward axis unit vector `e_f` in the same frame:
+   - v1: assume `e_f = [1,0,0]` in IMU frame if `base_link≈imu_link`
+   - later: if you add mounting, compute `e_f` via `R_BI`.
+
+3. Form forward acceleration used for integration:
+   - `a_f = e_fᵀ * a_raw_I`
+
+**Gravity note (v1):**
+
+- Full IMU mounting (`R_BI`) is not observable without richer excitation / independent references (e.g., varied orientations, external heading/velocity cues).
+- On level track, gravity projects mostly into IMU `z`, so the forward (`x`) projection is small. But note that track may not be level.
+- Any residual gravity coupling into the forward axis (e.g., slight pitch) is treated as part of the learned forward bias `b_f`, and is bounded by frequent ZUPTs.
+- If the vehicle runs sustained grades/pitch changes between ZUPTs, gravity leakage into `x` will appear as an acceleration bias and can induce speed drift between stops.
+
+### 5.3 Process model (prediction)
+
+Discrete time step `Δt`:
+
+- `v_{k+1} = v_k + (a_f - b_f) * Δt`
+- `b_{k+1} = b_k` (random walk)
+
+Process noise:
+
+- `q_v` from accel noise / model mismatch
+- `q_b` sets how fast bias is allowed to wander (tunable)
+
+This can be implemented as standard linear Kalman predict with:
+
+- `F = [[1, -Δt], [0, 1]]`
+- `u = a_f * Δt`
+- `Q` based on `q_v`, `q_b`
+
+### 5.4 ZUPT measurement update
+
+When `/zupt` arrives (or when `zupt_flag==true` and you choose to update every N ms):
+
+Measurement:
+
+- `z = 0` (forward velocity is zero)
+
+Model:
+
+- `z = H x + noise`, with `H = [1, 0]`
+
+Innovation covariance:
+
+- `S = HPHᵀ + R_zupt`, where `R_zupt = σ²_zupt_v`
+
+Update pulls:
+
+- `v_f → 0`
+- and indirectly learns `b_f` (because persistent ZUPTs constrain drift, causing bias to be corrected).
+
+### 5.5 Learning forward accel bias robustly
+
+**Key claim:** ZUPT lets you learn **only what’s observable** in 1D:
+
+- The forward component of accelerometer bias (and scale, if you model it) is the most robust learnable term.
+- Cross-axis calibration and full 3D bias are not observable without richer motion/tilt excitation.
+
+If you want a **scale factor** too, extend the model:
+
+- Add `s_f` (unitless) such that:
+  - `v_{k+1} = v_k + (s_f * a_f - b_f)Δt`
+- But be careful: `s_f` and `b_f` can be weakly identifiable without varied acceleration profiles. Use strong priors.
+
+### 5.6 Using `imu_calibration` as priors (optional)
+
+You want priors (that’s the point of your 6DOF calibration), but you **don’t** want to trust them blindly.
+
+Recommended pattern:
+
+- Use `imu_calibration` to initialize:
+  - `b_f` prior mean and covariance (weak prior)
+  - optionally a scale prior `s_f` if you add it
+  - optionally gyro bias prior for ZUPT gating
+
+But keep priors **wide**:
+
+- If the calibration is stale/wrong, the ZUPT-driven updates should override it quickly.
+
+If you include gravity magnitude `g` as a state:
+
+- Initialize `g` from a parameter (default ~9.80665), with a wide prior.
+- Optionally refine `g` slowly during long ZUPT windows using statistics of `|a_raw|` (but only if your sensor/model makes that meaningful).
+
+---
+
+## 6. Why magnetometer is not required for speedometer v1
+
+For **forward speed only**, magnetometer is usually unnecessary:
+
+- Yaw is not needed if you define the forward axis in the body/IMU frame and only integrate along that axis.
+- Magnetometer is more relevant for:
+  - heading / yaw drift correction
+  - mapping accel into a world frame
+  - coupling speed to global velocity
+
+You can add mag later if you decide to estimate world-frame velocity or fuse odometry.
+
+---
+
+## 7. Parameters
+
+Suggested ROS parameters (names are illustrative):
+
+### ZUPT sensor
+
+- `duty_zero_epsilon` (default: `0.0` if deadzoning guarantees exact zero)
+- `omega_enter` / `omega_exit` (or adaptive gains `k_enter`, `k_exit`)
+- `min_stationary_sec` (debounce, e.g. `0.2`)
+- `min_exit_sec` (debounce, e.g. `0.05`)
+- `use_mahalanobis_gate` (bool, optional)
+- `gate_enter_chi2` / `gate_exit_chi2` (if using Mahalanobis)
+- `omega_norm_enter` / `omega_norm_exit` (if using norm gate)
+- `zupt_sigma_v0` (initial σ)
+- `zupt_sigma_v_min`
+- `zupt_sigma_tau_sec` (annealing time constant)
+
+### Speedometer
+
+- `process_noise_v` (q_v)
+- `process_noise_b` (q_b)
+- `initial_speed_sigma`
+- `initial_bias_sigma`
+- `imu_gravity_mps2` (if fixed)
+- `use_gravity_state` (bool)
+- `publish_rate_hz`
+- `frame_id` (`base_link`)
+
+---
+
+## 8. Expected behavior and limitations
+
+### Works well when:
+
+- Train does frequent stops (station platforms / pauses / manual stops)
+- Duty command provides a reliable “intent” signal
+- Raw gyro is reasonably clean for stationary gating
+
+### Drift sources:
+
+- forward accel bias changes with temperature/vibration
+- gravity leakage into forward axis due to pitch/grade (v1 treats this as bias; frequent ZUPTs bound it)
+- imperfect axis alignment between `base_link` and `imu_link`
+- coasting / creep when duty=0 (train not truly stationary)
+
+### What you cannot get from yaw-only motion:
+
+- Full IMU mounting (`R_BI`) is not observable without tilt diversity.
+- But for 1D speed, you can proceed with approximate alignment and learn bias.
+
+---
+
+## 9. Future extensions
+
+- Add `s_f` scale factor learning with priors from `imu_calibration.accel_a`
+- Add coasting detector (if duty=0 but vibration signature indicates motion)
+- Add wheel encoder / hall sensor for absolute speed correction
+- Add mounting calibration later (AHRS Mounting) to unify frames robustly
+- Publish `nav_msgs/Odometry` if you later want a standard interface (twist only)
+
+---

--- a/oasis_control/launch/control_launch.py
+++ b/oasis_control/launch/control_launch.py
@@ -69,6 +69,7 @@ def generate_launch_description() -> LaunchDescription:
     # Navigation
     if HOST_ID == "falcon":
         ControlDescriptions.add_tilt_sensor(ld, HOST_ID)
+        ControlDescriptions.add_zupt_detector(ld, HOST_ID, "station")
 
     # Microcontroller nodes
     if HOST_ID == "station":

--- a/oasis_control/oasis_control/cli/zupt_detector_cli.py
+++ b/oasis_control/oasis_control/cli/zupt_detector_cli.py
@@ -1,0 +1,38 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""
+ROS entry point for the ZUPT detector node
+"""
+
+from typing import Optional
+
+import rclpy
+
+from oasis_control.nodes.zupt_detector_node import ZuptDetectorNode
+
+
+################################################################################
+# ROS entry point
+################################################################################
+
+
+def main(args: Optional[list[str]] = None) -> None:
+    rclpy.init(args=args)
+
+    node: ZuptDetectorNode = ZuptDetectorNode()
+
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.stop()
+        rclpy.shutdown()

--- a/oasis_control/oasis_control/launch/control_descriptions.py
+++ b/oasis_control/oasis_control/launch/control_descriptions.py
@@ -231,3 +231,27 @@ class ControlDescriptions:
             ],
         )
         ld.add_action(localization_node)
+
+    #
+    # ZUPT detector
+    #
+
+    @staticmethod
+    def add_zupt_detector(
+        ld: LaunchDescription, host_id: str, conductor_host: str
+    ) -> None:
+        zupt_detector_node: Node = Node(
+            namespace=ROS_NAMESPACE,
+            package=CONTROL_PACKAGE_NAME,
+            executable="zupt_detector",
+            name=f"zupt_detector_{host_id}",
+            output="screen",
+            remappings=[
+                ("conductor_state", f"{conductor_host}/conductor_state"),
+                ("imu_calibration", f"{host_id}/imu_calibration"),
+                ("imu_raw", f"{host_id}/imu_raw"),
+                ("zupt_flag", f"{host_id}/zupt_flag"),
+                ("zupt", f"{host_id}/zupt"),
+            ],
+        )
+        ld.add_action(zupt_detector_node)

--- a/oasis_control/oasis_control/localization/velocity_estimator.py
+++ b/oasis_control/oasis_control/localization/velocity_estimator.py
@@ -1,0 +1,428 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""Forward velocity estimator for 1D IMU propagation with ZUPT updates."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from dataclasses import field
+from typing import Optional
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+_FLOAT_ARRAY = NDArray[np.float64]
+
+
+@dataclass
+class VelocityEstimatorConfig:
+    """Configuration values for the velocity estimator."""
+
+    # Forward speed process noise in (m/s)^2 per second
+    process_noise_v: float = 0.4
+
+    # Bias process noise in (m/s^2)^2 per second
+    process_noise_b: float = 0.04
+
+    # Initial forward speed sigma in m/s
+    initial_speed_sigma: float = 0.5
+
+    # Initial acceleration bias sigma in m/s^2
+    initial_bias_sigma: float = 0.2
+
+    # Optional initial bias mean in m/s^2
+    initial_bias_mean: Optional[float] = None
+
+    # Optional initial bias variance in (m/s^2)^2
+    initial_bias_var: Optional[float] = None
+
+    # Maximum allowed dt in seconds before clamping to zero
+    max_dt_sec: float = 0.2
+
+    # Minimum allowed dt in seconds before clamping to zero
+    min_dt_sec: float = 0.0
+
+    # Minimum ZUPT variance to avoid divide-by-zero
+    zupt_var_floor: float = 1e-12
+
+
+@dataclass
+class VelocityEstimatorCounters:
+    """Counters tracking how many updates have been applied."""
+
+    # Count of IMU prediction calls
+    imu_updates: int = 0
+
+    # Count of ZUPT measurement updates
+    zupt_updates: int = 0
+
+
+@dataclass
+class VelocityEstimatorState:
+    """Mutable state for the velocity estimator."""
+
+    # Last IMU timestamp in seconds, or None before the first predict
+    last_t: Optional[float] = None
+
+    # Estimated forward speed in m/s
+    v: float = 0.0
+
+    # Estimated forward acceleration bias in m/s^2
+    b: float = 0.0
+
+    # State covariance matrix for [v, b] in (m/s)^2 and (m/s^2)^2
+    P: _FLOAT_ARRAY = field(default_factory=lambda: np.zeros((2, 2), dtype=np.float64))
+
+    # Reason string describing the last update decision
+    last_reason: str = "init"
+
+    # Last dt in seconds used by predict
+    last_dt_sec: float = 0.0
+
+    # True when dt was clamped to zero
+    dt_clamped: bool = False
+
+    # Last ZUPT innovation value in m/s
+    last_innovation: float = 0.0
+
+    # Last ZUPT innovation variance
+    last_S: float = 0.0
+
+    # Last ZUPT Kalman gain vector
+    last_K: _FLOAT_ARRAY = field(default_factory=lambda: np.zeros(2, dtype=np.float64))
+
+    # Counters for predict and update calls
+    counters: VelocityEstimatorCounters = field(
+        default_factory=VelocityEstimatorCounters
+    )
+
+
+class VelocityEstimator:
+    """Kalman-based forward velocity estimator with ZUPT corrections."""
+
+    def __init__(self, config: VelocityEstimatorConfig) -> None:
+        self._config: VelocityEstimatorConfig = config
+        self._state: VelocityEstimatorState = VelocityEstimatorState()
+        self.reset()
+
+    @property
+    def state(self) -> VelocityEstimatorState:
+        """Return the mutable estimator state."""
+
+        return self._state
+
+    def reset(self) -> None:
+        """Reset the estimator state to configured priors."""
+
+        initial_speed_var: float = self._config.initial_speed_sigma**2
+        initial_bias_var: float = self._config.initial_bias_sigma**2
+        P: _FLOAT_ARRAY = np.diag([initial_speed_var, initial_bias_var]).astype(
+            np.float64
+        )
+
+        v_init: float = 0.0
+        b_init: float = 0.0
+
+        if self._config.initial_bias_mean is not None:
+            bias_mean: float = float(self._config.initial_bias_mean)
+            if _is_finite(bias_mean):
+                b_init = bias_mean
+        if self._config.initial_bias_var is not None:
+            bias_var: float = float(self._config.initial_bias_var)
+            if _is_finite(bias_var) and bias_var > 0.0:
+                P[1, 1] = bias_var
+
+        self._state = VelocityEstimatorState(
+            last_t=None,
+            v=v_init,
+            b=b_init,
+            P=P,
+            last_reason="reset",
+            last_dt_sec=0.0,
+            dt_clamped=False,
+            last_innovation=0.0,
+            last_S=0.0,
+            last_K=np.zeros(2, dtype=np.float64),
+            counters=VelocityEstimatorCounters(),
+        )
+
+    def set_priors(self, bias_mean: float, bias_var: float) -> None:
+        """Set the bias prior mean and variance.
+
+        Args:
+            bias_mean: Bias mean in m/s^2
+            bias_var: Bias variance in (m/s^2)^2
+        """
+
+        bias_mean_val: float = float(bias_mean)
+        bias_var_val: float = float(bias_var)
+        if not _is_finite(bias_mean_val) or not _is_finite(bias_var_val):
+            self._state.last_reason = "priors_non_finite"
+            return
+        if bias_var_val <= 0.0:
+            self._state.last_reason = "priors_non_positive"
+            return
+
+        self._state.b = bias_mean_val
+        self._state.P[1, 1] = bias_var_val
+        self._state.P = _symmetrize(self._state.P)
+        self._state.last_reason = "priors_updated"
+
+    def predict(
+        self,
+        timestamp_sec: float,
+        a_f_mps2: float,
+        a_f_var: Optional[float] = None,
+    ) -> dict[str, object]:
+        """Propagate the state using forward acceleration.
+
+        Args:
+            timestamp_sec: Timestamp in seconds
+            a_f_mps2: Forward acceleration measurement in m/s^2
+            a_f_var: Optional acceleration variance in (m/s^2)^2
+        """
+
+        timestamp: float = float(timestamp_sec)
+        accel: float = float(a_f_mps2)
+        if not _is_finite(timestamp) or not _is_finite(accel):
+            self._state.last_reason = "predict_non_finite"
+            return self._predict_diagnostics(0.0, False, accel, a_f_var)
+
+        dt: float = 0.0
+        dt_clamped: bool = False
+        if self._state.last_t is None:
+            self._state.last_t = timestamp
+            self._state.last_reason = "predict_init"
+            self._state.last_dt_sec = 0.0
+            self._state.dt_clamped = False
+            return self._predict_diagnostics(0.0, False, accel, a_f_var)
+
+        dt = timestamp - self._state.last_t
+        dt, dt_clamped = _clamp_dt(
+            dt,
+            self._config.min_dt_sec,
+            self._config.max_dt_sec,
+        )
+        self._state.last_t = timestamp
+
+        F: _FLOAT_ARRAY = np.array(
+            [
+                [1.0, -dt],
+                [0.0, 1.0],
+            ],
+            dtype=np.float64,
+        )
+        x: _FLOAT_ARRAY = np.array([self._state.v, self._state.b], dtype=np.float64)
+
+        x = F @ x + np.array([accel * dt, 0.0], dtype=np.float64)
+
+        # Process noise uses continuous-time spectral densities scaled by dt
+        q_v: float = float(self._config.process_noise_v)
+        q_b: float = float(self._config.process_noise_b)
+        Q: _FLOAT_ARRAY = np.array(
+            [
+                [q_v * dt, 0.0],
+                [0.0, q_b * dt],
+            ],
+            dtype=np.float64,
+        )
+
+        P: _FLOAT_ARRAY = F @ self._state.P @ F.T + Q
+
+        self._state.v = float(x[0])
+        self._state.b = float(x[1])
+        self._state.P = _symmetrize(P)
+        self._state.last_reason = "predict"
+        self._state.last_dt_sec = dt
+        self._state.dt_clamped = dt_clamped
+        self._state.counters.imu_updates += 1
+
+        return self._predict_diagnostics(dt, dt_clamped, accel, a_f_var)
+
+    def update_zupt(self, timestamp_sec: float, zupt_var: float) -> dict[str, object]:
+        """Apply a zero-velocity measurement update.
+
+        Args:
+            timestamp_sec: Timestamp in seconds
+            zupt_var: ZUPT variance in (m/s)^2
+        """
+
+        timestamp: float = float(timestamp_sec)
+        if not _is_finite(timestamp):
+            self._state.last_reason = "zupt_non_finite_time"
+            return self._zupt_diagnostics(
+                0.0,
+                0.0,
+                np.zeros(2, dtype=np.float64),
+                self._config.zupt_var_floor,
+            )
+
+        zupt_var_val: float = float(zupt_var)
+        if not _is_finite(zupt_var_val):
+            self._state.last_reason = "zupt_non_finite_var"
+            return self._zupt_diagnostics(
+                0.0,
+                0.0,
+                np.zeros(2, dtype=np.float64),
+                self._config.zupt_var_floor,
+            )
+
+        zupt_var_val = max(zupt_var_val, self._config.zupt_var_floor)
+
+        y: float = -self._state.v
+        S: float = float(self._state.P[0, 0] + zupt_var_val)
+
+        if not _is_finite(S) or S <= 0.0:
+            self._state.last_reason = "zupt_bad_innovation"
+            return self._zupt_diagnostics(
+                y,
+                S,
+                np.zeros(2, dtype=np.float64),
+                zupt_var_val,
+            )
+
+        K: _FLOAT_ARRAY = (self._state.P[:, 0] / S).astype(np.float64)
+
+        x: _FLOAT_ARRAY = np.array([self._state.v, self._state.b], dtype=np.float64)
+        x = x + K * y
+
+        H: _FLOAT_ARRAY = np.array([[1.0, 0.0]], dtype=np.float64)
+        I: _FLOAT_ARRAY = np.eye(2, dtype=np.float64)
+        KH: _FLOAT_ARRAY = K[:, None] @ H
+        P: _FLOAT_ARRAY = (I - KH) @ self._state.P @ (I - KH).T
+        P = P + np.outer(K, K) * zupt_var_val
+
+        self._state.v = float(x[0])
+        self._state.b = float(x[1])
+        self._state.P = _symmetrize(P)
+        self._state.last_reason = "zupt_update"
+        self._state.last_innovation = y
+        self._state.last_S = S
+        self._state.last_K = K
+        self._state.counters.zupt_updates += 1
+
+        return self._zupt_diagnostics(y, S, K, zupt_var_val)
+
+    def get_velocity_mps(self) -> float:
+        """Return the estimated forward speed in m/s."""
+
+        return float(self._state.v)
+
+    def get_bias_mps2(self) -> float:
+        """Return the estimated acceleration bias in m/s^2."""
+
+        return float(self._state.b)
+
+    def get_covariance(self) -> _FLOAT_ARRAY:
+        """Return a copy of the 2x2 state covariance matrix."""
+
+        return np.array(self._state.P, dtype=np.float64)
+
+    def get_diagnostics_snapshot(self) -> dict[str, object]:
+        """Return a snapshot of recent diagnostic values."""
+
+        return {
+            "last_t": self._state.last_t,
+            "v_mps": self._state.v,
+            "b_mps2": self._state.b,
+            "P_vv": float(self._state.P[0, 0]),
+            "P_bb": float(self._state.P[1, 1]),
+            "last_reason": self._state.last_reason,
+            "last_dt_sec": self._state.last_dt_sec,
+            "dt_clamped": self._state.dt_clamped,
+            "last_innovation": self._state.last_innovation,
+            "last_S": self._state.last_S,
+            "last_K": np.array(self._state.last_K, dtype=np.float64),
+            "imu_updates": self._state.counters.imu_updates,
+            "zupt_updates": self._state.counters.zupt_updates,
+        }
+
+    def _predict_diagnostics(
+        self,
+        dt: float,
+        dt_clamped: bool,
+        accel: float,
+        a_f_var: Optional[float],
+    ) -> dict[str, object]:
+        a_f_var_used: Optional[float] = None
+        if a_f_var is not None:
+            a_f_var_val: float = float(a_f_var)
+            if _is_finite(a_f_var_val):
+                a_f_var_used = a_f_var_val
+        return {
+            "dt_sec": dt,
+            "dt_clamped": dt_clamped,
+            "v_mps": self._state.v,
+            "b_mps2": self._state.b,
+            "P_vv": float(self._state.P[0, 0]),
+            "P_bb": float(self._state.P[1, 1]),
+            "a_f_mps2": accel,
+            "a_f_var": a_f_var_used,
+        }
+
+    def _zupt_diagnostics(
+        self,
+        innovation: float,
+        S: float,
+        K: _FLOAT_ARRAY,
+        zupt_var: float,
+    ) -> dict[str, object]:
+        return {
+            "innovation": innovation,
+            "S": S,
+            "K": np.array(K, dtype=np.float64),
+            "zupt_var": zupt_var,
+            "v_mps": self._state.v,
+            "b_mps2": self._state.b,
+            "P_vv": float(self._state.P[0, 0]),
+            "P_bb": float(self._state.P[1, 1]),
+        }
+
+
+def run_velocity_estimator_self_test() -> dict[str, object]:
+    """Run a minimal self-test sequence and return diagnostics."""
+
+    config: VelocityEstimatorConfig = VelocityEstimatorConfig(
+        process_noise_v=0.0,
+        process_noise_b=0.0,
+        initial_speed_sigma=0.1,
+        initial_bias_sigma=0.1,
+    )
+    estimator: VelocityEstimator = VelocityEstimator(config)
+
+    estimator.predict(0.0, 0.0)
+    estimator.predict(0.1, 1.0)
+    zupt_diag: dict[str, object] = estimator.update_zupt(0.1, 0.01)
+
+    snapshot: dict[str, object] = estimator.get_diagnostics_snapshot()
+
+    return {
+        "zupt": zupt_diag,
+        "snapshot": snapshot,
+    }
+
+
+def _clamp_dt(dt: float, min_dt: float, max_dt: float) -> tuple[float, bool]:
+    if dt < min_dt:
+        return 0.0, True
+    if dt > max_dt:
+        return 0.0, True
+    return dt, False
+
+
+def _is_finite(value: float) -> bool:
+    return math.isfinite(value)
+
+
+def _symmetrize(matrix: _FLOAT_ARRAY) -> _FLOAT_ARRAY:
+    return 0.5 * (matrix + matrix.T)

--- a/oasis_control/oasis_control/localization/zupt_detector.py
+++ b/oasis_control/oasis_control/localization/zupt_detector.py
@@ -1,0 +1,420 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""Zero-velocity update (ZUPT) detector for tilt gyro data."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Optional
+from typing import cast
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+_FLOAT_ARRAY = NDArray[np.float64]
+
+
+@dataclass
+class ZuptDetectorConfig:
+    """Configuration values for the ZUPT detector."""
+
+    # Minimum quiet time to enter stationary, in seconds
+    min_stationary_sec: float = 0.7
+
+    # Minimum loud time to exit stationary, in seconds
+    min_exit_sec: float = 0.15
+
+    # Chi-square gate to enter stationary for df=3
+    gate_enter_chi2: float = 7.8147279
+
+    # Chi-square gate to exit stationary for df=3
+    gate_exit_chi2: float = 11.3448667
+
+    # Norm gate to enter stationary when covariance inversion fails, rad/s
+    omega_norm_enter: float = 0.05
+
+    # Norm gate to exit stationary when covariance inversion fails, rad/s
+    omega_norm_exit: float = 0.10
+
+    # Require duty cycle to be exactly zero to gate stationary
+    duty_requires_exact_zero: bool = True
+
+    # Tolerance for duty cycle to be treated as zero
+    duty_zero_epsilon: float = 0.0
+
+    # Enable adaptive gates based on EWMA of quietness
+    use_adaptive_gates: bool = False
+
+    # EWMA smoothing factor for adaptive gate updates
+    adaptive_ewma_alpha: float = 0.02
+
+    # Minimum adaptive gate scale relative to nominal
+    adaptive_gate_scale_min: float = 0.75
+
+    # Maximum adaptive gate scale relative to nominal
+    adaptive_gate_scale_max: float = 2.0
+
+    # ZUPT velocity sigma at entry, meters per second
+    zupt_sigma_start_mps: float = 0.10
+
+    # ZUPT velocity sigma after long dwell, meters per second
+    zupt_sigma_min_mps: float = 0.01
+
+    # ZUPT variance annealing time constant, seconds
+    zupt_anneal_tau_sec: float = 0.7
+
+    # Regularization epsilon added to covariance for inversion
+    covariance_regularization_eps: float = 1e-9
+
+
+@dataclass
+class ZuptDetectorState:
+    """Mutable state for the ZUPT detector."""
+
+    # Last update timestamp in seconds, or None before the first update
+    last_t: Optional[float] = None
+
+    # Last duty cycle value, unitless
+    duty_cycle: float = 0.0
+
+    # True when the detector believes the platform is stationary
+    stationary: bool = False
+
+    # Accumulated quiet time while seeking stationary, seconds
+    candidate_quiet_time: float = 0.0
+
+    # Accumulated loud time while seeking exit, seconds
+    candidate_loud_time: float = 0.0
+
+    # Dwell time in the stationary state, seconds
+    stationary_dwell_time: float = 0.0
+
+    # Current adaptive scaling factor for gate thresholds
+    adaptive_gate_scale: float = 1.0
+
+    # Last Mahalanobis distance squared value
+    last_d2: float = 0.0
+
+    # Last raw omega norm, rad/s
+    last_omega_norm: float = 0.0
+
+    # Last bias-corrected omega norm, rad/s
+    last_omega_c_norm: float = 0.0
+
+    # Last enter gate value
+    last_gate_enter: float = 0.0
+
+    # Last exit gate value
+    last_gate_exit: float = 0.0
+
+    # Reason string for the last decision
+    last_reason: str = "init"
+
+
+class ZuptDetector:
+    """Detects zero-velocity intervals using duty gating and gyro quietness."""
+
+    def __init__(self, config: ZuptDetectorConfig) -> None:
+        self._config: ZuptDetectorConfig = config
+        self._state: ZuptDetectorState = ZuptDetectorState()
+        self._gyro_bias: _FLOAT_ARRAY = np.zeros(3, dtype=np.float64)
+        self._gyro_bias_cov: _FLOAT_ARRAY = np.zeros((3, 3), dtype=np.float64)
+        self._adaptive_d2_ewma: Optional[float] = None
+
+    @property
+    def state(self) -> ZuptDetectorState:
+        """Return the mutable detector state."""
+
+        return self._state
+
+    def reset(self) -> None:
+        """Reset the detector state and cached adaptive statistics."""
+
+        self._state = ZuptDetectorState()
+        self._adaptive_d2_ewma = None
+
+    def set_gyro_bias(self, bias: _FLOAT_ARRAY, cov: _FLOAT_ARRAY) -> None:
+        """Set gyro bias mean and covariance.
+
+        Args:
+            bias: Gyro bias vector in rad/s
+            cov: Gyro bias covariance matrix in (rad/s)^2
+        """
+
+        self._gyro_bias = _as_vector(bias, "gyro_bias")
+        self._gyro_bias_cov = _as_matrix(cov, "gyro_bias_cov")
+
+    def set_duty_cycle(self, duty: float) -> None:
+        """Update the duty cycle used for commanded-stop gating."""
+
+        self._state.duty_cycle = float(duty)
+
+    def update(
+        self,
+        timestamp_sec: float,
+        omega: _FLOAT_ARRAY,
+        omega_cov: _FLOAT_ARRAY,
+    ) -> dict[str, object]:
+        """Update the detector and return the current decision.
+
+        Args:
+            timestamp_sec: Timestamp in seconds
+            omega: Angular velocity vector in rad/s
+            omega_cov: Angular velocity covariance in (rad/s)^2
+        """
+
+        timestamp: float = float(timestamp_sec)
+        dt: float = 0.0
+        dt_clamped: bool = False
+        if self._state.last_t is not None:
+            dt = timestamp - self._state.last_t
+            if dt < 0.0:
+                dt = 0.0
+                dt_clamped = True
+            if dt > 0.2:
+                dt = 0.0
+                dt_clamped = True
+        self._state.last_t = timestamp
+
+        omega_vec: _FLOAT_ARRAY = _as_vector(omega, "omega")
+        omega_cov_mat: _FLOAT_ARRAY = _as_matrix(omega_cov, "omega_cov")
+
+        omega_norm: float = float(np.linalg.norm(omega_vec))
+        omega_c: _FLOAT_ARRAY = omega_vec - self._gyro_bias
+        omega_c_norm: float = float(np.linalg.norm(omega_c))
+
+        d2, inversion_ok, used_fallback = self._compute_mahalanobis(
+            omega_c,
+            omega_cov_mat,
+            omega_c_norm,
+        )
+
+        duty_zero: bool = _is_duty_zero(
+            self._state.duty_cycle,
+            self._config.duty_requires_exact_zero,
+            self._config.duty_zero_epsilon,
+        )
+
+        if self._config.use_adaptive_gates and duty_zero:
+            self._adaptive_d2_ewma = _update_ewma(
+                self._adaptive_d2_ewma,
+                d2,
+                self._config.adaptive_ewma_alpha,
+            )
+            scale: float = _clamp(
+                (self._adaptive_d2_ewma or d2) / self._config.gate_enter_chi2,
+                self._config.adaptive_gate_scale_min,
+                self._config.adaptive_gate_scale_max,
+            )
+            self._state.adaptive_gate_scale = scale
+        elif not self._config.use_adaptive_gates:
+            self._state.adaptive_gate_scale = 1.0
+
+        gate_enter: float = (
+            self._config.gate_enter_chi2 * self._state.adaptive_gate_scale
+        )
+        gate_exit: float = self._config.gate_exit_chi2 * self._state.adaptive_gate_scale
+
+        if used_fallback:
+            quiet: bool = duty_zero and (omega_c_norm < self._config.omega_norm_enter)
+            loud: bool = (not duty_zero) or (
+                omega_c_norm > self._config.omega_norm_exit
+            )
+            reason: str = "norm_gate"
+        else:
+            quiet = duty_zero and (d2 < gate_enter)
+            loud = (not duty_zero) or (d2 > gate_exit)
+            reason = "mahalanobis_gate" if inversion_ok else "regularized_gate"
+
+        stationary: bool = self._state.stationary
+        candidate_quiet_time: float = self._state.candidate_quiet_time
+        candidate_loud_time: float = self._state.candidate_loud_time
+        stationary_dwell: float = self._state.stationary_dwell_time
+
+        if stationary:
+            if loud:
+                candidate_loud_time += dt
+            else:
+                candidate_loud_time = 0.0
+            if candidate_loud_time >= self._config.min_exit_sec:
+                stationary = False
+                stationary_dwell = 0.0
+                candidate_loud_time = 0.0
+                candidate_quiet_time = 0.0
+                reason = "exit_stationary"
+        else:
+            if quiet:
+                candidate_quiet_time += dt
+            else:
+                candidate_quiet_time = 0.0
+            if candidate_quiet_time >= self._config.min_stationary_sec:
+                stationary = True
+                stationary_dwell = 0.0
+                candidate_quiet_time = 0.0
+                candidate_loud_time = 0.0
+                reason = "enter_stationary"
+
+        if stationary:
+            stationary_dwell += dt
+        else:
+            stationary_dwell = 0.0
+
+        self._state.stationary = stationary
+        self._state.candidate_quiet_time = candidate_quiet_time
+        self._state.candidate_loud_time = candidate_loud_time
+        self._state.stationary_dwell_time = stationary_dwell
+        self._state.last_d2 = d2
+        self._state.last_omega_norm = omega_norm
+        self._state.last_omega_c_norm = omega_c_norm
+        self._state.last_gate_enter = gate_enter
+        self._state.last_gate_exit = gate_exit
+        self._state.last_reason = reason
+
+        zupt_vx_variance: Optional[float]
+        if stationary:
+            zupt_vx_variance = _anneal_variance(
+                stationary_dwell,
+                self._config.zupt_sigma_start_mps,
+                self._config.zupt_sigma_min_mps,
+                self._config.zupt_anneal_tau_sec,
+            )
+        else:
+            zupt_vx_variance = None
+
+        diagnostics: dict[str, object] = {
+            "dt_sec": dt,
+            "dt_clamped": dt_clamped,
+            "duty_zero": duty_zero,
+            "omega_norm": omega_norm,
+            "omega_c_norm": omega_c_norm,
+            "d2": d2,
+            "gate_enter": gate_enter,
+            "gate_exit": gate_exit,
+            "adaptive_gate_scale": self._state.adaptive_gate_scale,
+            "used_fallback": used_fallback,
+            "reason": reason,
+        }
+
+        return {
+            "stationary": stationary,
+            "should_publish_zupt": stationary,
+            "stationary_dwell_sec": stationary_dwell,
+            "zupt_vx_variance": zupt_vx_variance,
+            "diagnostics": diagnostics,
+        }
+
+    def _compute_mahalanobis(
+        self,
+        omega_c: _FLOAT_ARRAY,
+        omega_cov: _FLOAT_ARRAY,
+        omega_c_norm: float,
+    ) -> tuple[float, bool, bool]:
+        """Compute Mahalanobis distance squared with regularization.
+
+        Returns:
+            Tuple of (d2, inversion_ok, used_fallback)
+        """
+
+        if not np.isfinite(omega_c_norm):
+            return float("inf"), False, True
+
+        cov_sum: _FLOAT_ARRAY = omega_cov + self._gyro_bias_cov
+        cov_sum = 0.5 * (cov_sum + cov_sum.T)
+        diag: _FLOAT_ARRAY = np.diag(cov_sum)
+        diag = np.maximum(diag, 0.0)
+        cov_sum = cov_sum.copy()
+        cov_sum[np.diag_indices_from(cov_sum)] = diag
+
+        eps: float = self._config.covariance_regularization_eps
+
+        # (rad/s)^2 regularization on the diagonal to ensure invertibility
+        cov_reg: _FLOAT_ARRAY = cov_sum + (eps * np.eye(3, dtype=np.float64))
+
+        try:
+            solve = np.linalg.solve(cov_reg, omega_c)
+        except np.linalg.LinAlgError:
+            return float("inf"), False, True
+
+        d2: float = float(omega_c.T @ solve)
+        if not np.isfinite(d2):
+            return float("inf"), False, True
+
+        return d2, True, False
+
+
+def _as_vector(vec: _FLOAT_ARRAY, name: str) -> _FLOAT_ARRAY:
+    """Convert input to a finite 3-vector."""
+
+    array: _FLOAT_ARRAY = np.asarray(vec, dtype=np.float64).reshape(-1)
+    if array.shape != (3,):
+        raise ValueError(f"{name} must have shape (3,), got {array.shape}")
+    if not np.all(np.isfinite(array)):
+        raise ValueError(f"{name} must be finite")
+    return cast(_FLOAT_ARRAY, array)
+
+
+def _as_matrix(mat: _FLOAT_ARRAY, name: str) -> _FLOAT_ARRAY:
+    """Convert input to a finite 3x3 matrix."""
+
+    array: _FLOAT_ARRAY = np.asarray(mat, dtype=np.float64)
+    if array.shape != (3, 3):
+        raise ValueError(f"{name} must have shape (3, 3), got {array.shape}")
+    if not np.all(np.isfinite(array)):
+        raise ValueError(f"{name} must be finite")
+    return cast(_FLOAT_ARRAY, array)
+
+
+def _is_duty_zero(duty: float, exact: bool, epsilon: float) -> bool:
+    """Return True when the duty cycle should be treated as zero."""
+
+    if exact and epsilon <= 0.0:
+        return duty == 0.0
+    return abs(duty) <= epsilon
+
+
+def _update_ewma(
+    prev: Optional[float],
+    value: float,
+    alpha: float,
+) -> float:
+    """Update an EWMA value."""
+
+    if prev is None:
+        return value
+    return (alpha * value) + ((1.0 - alpha) * prev)
+
+
+def _clamp(value: float, min_value: float, max_value: float) -> float:
+    """Clamp a value between bounds."""
+
+    return max(min_value, min(value, max_value))
+
+
+def _anneal_variance(
+    dwell_sec: float,
+    sigma_start_mps: float,
+    sigma_min_mps: float,
+    tau_sec: float,
+) -> float:
+    """Compute annealed ZUPT measurement variance."""
+
+    if tau_sec <= 0.0:
+        return sigma_min_mps * sigma_min_mps
+
+    # (m/s)^2 initial ZUPT variance based on start sigma
+    sigma2_start: float = sigma_start_mps * sigma_start_mps
+
+    # (m/s)^2 minimum ZUPT variance based on minimum sigma
+    sigma2_min: float = sigma_min_mps * sigma_min_mps
+
+    return sigma2_min + (sigma2_start - sigma2_min) * math.exp(-dwell_sec / tau_sec)

--- a/oasis_control/oasis_control/nodes/zupt_detector_node.py
+++ b/oasis_control/oasis_control/nodes/zupt_detector_node.py
@@ -1,0 +1,356 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+from typing import Optional
+from typing import cast
+
+import numpy as np
+import rclpy.node
+import rclpy.publisher
+import rclpy.qos
+import rclpy.subscription
+from builtin_interfaces.msg import Time as TimeMsg
+from geometry_msgs.msg import TwistWithCovarianceStamped
+from rclpy.qos import DurabilityPolicy
+from rclpy.qos import HistoryPolicy
+from rclpy.qos import ReliabilityPolicy
+from sensor_msgs.msg import Imu as ImuMsg
+from std_msgs.msg import Bool as BoolMsg
+
+from oasis_control.localization.zupt_detector import ZuptDetector
+from oasis_control.localization.zupt_detector import ZuptDetectorConfig
+from oasis_msgs.msg import ConductorState as ConductorStateMsg
+from oasis_msgs.msg import ImuCalibration as ImuCalibrationMsg
+
+
+################################################################################
+# ROS parameters
+################################################################################
+
+
+NODE_NAME: str = "zupt_detector"
+
+# ROS topics
+CONDUCTOR_STATE_TOPIC: str = "conductor_state"
+IMU_CAL_TOPIC: str = "imu_calibration"
+IMU_RAW_TOPIC: str = "imu_raw"
+ZUPT_FLAG_TOPIC: str = "zupt_flag"
+ZUPT_TOPIC: str = "zupt"
+
+# Default base frame identifier
+DEFAULT_BASE_FRAME: str = "base_link"
+
+# (rad/s)^2 large covariance used when IMU covariance is invalid
+DEFAULT_LARGE_COVARIANCE: float = 1e6
+
+# Transition logging throttle in seconds
+TRANSITION_LOG_THROTTLE_SEC: float = 1.0
+
+# Debug logging throttle
+DEBUG_LOG_THROTTLE_SEC: float = 1.0
+
+
+################################################################################
+# Helper functions
+################################################################################
+
+
+def _time_to_float_sec(stamp: TimeMsg) -> float:
+    """Convert a ROS time message to seconds"""
+
+    return float(stamp.sec) + 1e-9 * float(stamp.nanosec)
+
+
+def _cov9_to_mat3(cov: Sequence[float]) -> np.ndarray:
+    """Convert a row-major 3x3 covariance array to a matrix"""
+
+    if len(cov) != 9:
+        raise ValueError("Expected 9 covariance entries")
+
+    cov_array: np.ndarray = np.array(cov, dtype=np.float64)
+    if not np.isfinite(cov_array).all():
+        raise ValueError("Covariance contains NaN or Inf")
+
+    return cov_array.reshape((3, 3))
+
+
+def _make_twist_cov(vx_var: float, *, large: float = 1e6) -> list[float]:
+    """Create a TwistWithCovariance row-major 6x6 covariance array"""
+
+    # Layout: [x y z roll pitch yaw] in row-major 6x6 order
+    cov: list[float] = [large] * 36
+    cov[0] = float(vx_var)
+    return cov
+
+
+################################################################################
+# ROS node
+################################################################################
+
+
+class ZuptDetectorNode(rclpy.node.Node):
+    def __init__(self) -> None:
+        """
+        Initialize resources
+        """
+
+        super().__init__(NODE_NAME)
+
+        self.declare_parameter("base_frame", DEFAULT_BASE_FRAME)
+
+        base_frame: str = str(self.get_parameter("base_frame").value)
+        if not base_frame:
+            self.get_logger().error("base_frame parameter is empty")
+            raise RuntimeError("Missing base_frame parameter")
+
+        self._base_frame: str = base_frame
+
+        # ZUPT detector
+        config: ZuptDetectorConfig = ZuptDetectorConfig(
+            min_stationary_sec=0.1,
+            min_exit_sec=0.05,
+            gate_enter_chi2=50.0,
+            gate_exit_chi2=80.0,
+        )
+        self._detector: ZuptDetector = ZuptDetector(config)
+
+        # Cached inputs
+        self._duty_cycle: float = 0.0
+        self._gyro_bias: np.ndarray = np.zeros(3, dtype=np.float64)
+        self._gyro_bias_cov: np.ndarray = np.zeros((3, 3), dtype=np.float64)
+        self._cal_valid: bool = False
+        self._last_stationary: bool = False
+        self._last_transition_log_ns: int | None = None
+        self._last_debug_log_ns: int | None = None
+
+        # QoS profiles
+        sensor_qos_profile: rclpy.qos.QoSProfile = (
+            rclpy.qos.QoSPresetProfiles.SENSOR_DATA.value
+        )
+        conductor_qos_profile: rclpy.qos.QoSProfile = rclpy.qos.QoSProfile(
+            reliability=ReliabilityPolicy.RELIABLE,
+            durability=DurabilityPolicy.TRANSIENT_LOCAL,
+            history=HistoryPolicy.KEEP_LAST,
+            depth=1,
+        )
+
+        # ROS Publishers
+        self._zupt_flag_pub: rclpy.publisher.Publisher = self.create_publisher(
+            msg_type=BoolMsg,
+            topic=ZUPT_FLAG_TOPIC,
+            qos_profile=sensor_qos_profile,
+        )
+        self._zupt_pub: rclpy.publisher.Publisher = self.create_publisher(
+            msg_type=TwistWithCovarianceStamped,
+            topic=ZUPT_TOPIC,
+            qos_profile=sensor_qos_profile,
+        )
+
+        # ROS Subscribers
+        self._conductor_state_sub: rclpy.subscription.Subscription = (
+            self.create_subscription(
+                msg_type=ConductorStateMsg,
+                topic=CONDUCTOR_STATE_TOPIC,
+                callback=self._handle_conductor_state,
+                qos_profile=conductor_qos_profile,
+            )
+        )
+        self._imu_calibration_sub: rclpy.subscription.Subscription = (
+            self.create_subscription(
+                msg_type=ImuCalibrationMsg,
+                topic=IMU_CAL_TOPIC,
+                callback=self._handle_imu_calibration,
+                qos_profile=sensor_qos_profile,
+            )
+        )
+        self._imu_raw_sub: rclpy.subscription.Subscription = self.create_subscription(
+            msg_type=ImuMsg,
+            topic=IMU_RAW_TOPIC,
+            callback=self._handle_imu_raw,
+            qos_profile=sensor_qos_profile,
+        )
+
+        self.get_logger().info("ZUPT detector node initialized")
+
+    def stop(self) -> None:
+        self.get_logger().info("ZUPT detector node deinitialized")
+
+        self.destroy_node()
+
+    def _handle_conductor_state(self, message: ConductorStateMsg) -> None:
+        duty_cycle: float = float(message.duty_cycle)
+        self._duty_cycle = duty_cycle
+        self._detector.set_duty_cycle(duty_cycle)
+
+    def _handle_imu_calibration(self, message: ImuCalibrationMsg) -> None:
+        if message.valid:
+            bias: np.ndarray = np.array(
+                [
+                    message.gyro_bias.x,
+                    message.gyro_bias.y,
+                    message.gyro_bias.z,
+                ],
+                dtype=np.float64,
+            )
+            try:
+                bias_cov: np.ndarray = _cov9_to_mat3(message.gyro_bias_cov)
+            except ValueError as exc:
+                self.get_logger().warn(
+                    f"Gyro bias covariance invalid, using zeros: {exc}"
+                )
+                bias_cov = np.zeros((3, 3), dtype=np.float64)
+            cal_valid: bool = True
+        else:
+            bias = np.zeros(3, dtype=np.float64)
+            bias_cov = np.zeros((3, 3), dtype=np.float64)
+            cal_valid = False
+
+        self._gyro_bias = bias
+        self._gyro_bias_cov = bias_cov
+        self._cal_valid = cal_valid
+
+        self._detector.set_gyro_bias(bias, bias_cov)
+
+    def _handle_imu_raw(self, message: ImuMsg) -> None:
+        omega: np.ndarray = np.array(
+            [
+                message.angular_velocity.x,
+                message.angular_velocity.y,
+                message.angular_velocity.z,
+            ],
+            dtype=np.float64,
+        )
+
+        try:
+            omega_cov: np.ndarray = _cov9_to_mat3(message.angular_velocity_covariance)
+        except ValueError as exc:
+            self.get_logger().warn(
+                f"Angular velocity covariance invalid, using large diag: {exc}"
+            )
+            omega_cov = np.eye(3, dtype=np.float64) * DEFAULT_LARGE_COVARIANCE
+
+        stamp_sec: float = _time_to_float_sec(message.header.stamp)
+        result: dict[str, object] = self._detector.update(
+            timestamp_sec=stamp_sec,
+            omega=omega,
+            omega_cov=omega_cov,
+        )
+
+        stationary: bool = bool(result.get("stationary", False))
+        stationary_dwell: object = result.get("stationary_dwell_sec", 0.0)
+        stationary_dwell_sec: float = float(cast(float, stationary_dwell))
+        diagnostics_raw: object = result.get("diagnostics", {})
+        diagnostics: dict[str, Any] = cast(dict[str, Any], diagnostics_raw)
+        reason: str = str(diagnostics.get("reason", "unknown"))
+
+        # --- Throttled debug log -------------------------------------------------
+
+        now_ns: int = int(self.get_clock().now().nanoseconds)
+        throttle_ns: int = int(DEBUG_LOG_THROTTLE_SEC * 1e9)
+
+        dt_sec: float = float(diagnostics.get("dt_sec", 0.0))
+        dt_clamped: bool = bool(diagnostics.get("dt_clamped", False))
+        duty_zero: bool = bool(diagnostics.get("duty_zero", False))
+        omega_norm: float = float(diagnostics.get("omega_norm", 0.0))
+        omega_c_norm: float = float(diagnostics.get("omega_c_norm", 0.0))
+        d2: float = float(diagnostics.get("d2", 0.0))
+        gate_enter: float = float(diagnostics.get("gate_enter", 0.0))
+        gate_exit: float = float(diagnostics.get("gate_exit", 0.0))
+        used_fallback: bool = bool(diagnostics.get("used_fallback", False))
+
+        # Optional: expose internal detector state (super useful)
+        cand_quiet: float = float(self._detector.state.candidate_quiet_time)
+        cand_loud: float = float(self._detector.state.candidate_loud_time)
+        dwell: float = float(self._detector.state.stationary_dwell_time)
+
+        # Log immediately on transitions, otherwise throttle
+        should_log: bool = False
+        if stationary != self._last_stationary:
+            should_log = True
+        else:
+            last_ns: int | None = self._last_debug_log_ns
+            if last_ns is None or (now_ns - last_ns) >= throttle_ns:
+                should_log = True
+
+        if should_log:
+            self.get_logger().debug(
+                (
+                    "ZUPT dbg: st=%s duty=%.3f duty0=%s dt=%.4f clamp=%s "
+                    "w=%.5f wc=%.5f d2=%.3f gate=(%.3f,%.3f) fb=%s "
+                    "quiet_t=%.3f loud_t=%.3f dwell=%.3f reason=%s"
+                )
+                % (
+                    "T" if stationary else "F",
+                    float(self._duty_cycle),
+                    "T" if duty_zero else "F",
+                    dt_sec,
+                    "T" if dt_clamped else "F",
+                    omega_norm,
+                    omega_c_norm,
+                    d2,
+                    gate_enter,
+                    gate_exit,
+                    "T" if used_fallback else "F",
+                    cand_quiet,
+                    cand_loud,
+                    dwell,
+                    reason,
+                )
+            )
+            self._last_debug_log_ns = now_ns
+
+        # -------------------------------------------------------------------------
+
+        if stationary != self._last_stationary:
+            state_name: str = "enter" if stationary else "exit"
+            now_ns: int = int(self.get_clock().now().nanoseconds)
+            throttle_ns: int = int(TRANSITION_LOG_THROTTLE_SEC * 1e9)
+            last_log_ns: int | None = self._last_transition_log_ns
+            if last_log_ns is None or now_ns - last_log_ns >= throttle_ns:
+                self.get_logger().debug(
+                    "ZUPT %s stationary (dwell=%.3f sec, reason=%s)"
+                    % (state_name, stationary_dwell_sec, reason)
+                )
+                self._last_transition_log_ns = now_ns
+            self._last_stationary = stationary
+
+        self._zupt_flag_pub.publish(BoolMsg(data=stationary))
+
+        zupt_vx_variance: Optional[float] = cast(
+            Optional[float], result.get("zupt_vx_variance")
+        )
+        if zupt_vx_variance is None:
+            return
+
+        zupt_msg: TwistWithCovarianceStamped = TwistWithCovarianceStamped()
+        if message.header.stamp.sec == 0 and message.header.stamp.nanosec == 0:
+            zupt_msg.header.stamp = self.get_clock().now().to_msg()
+        else:
+            zupt_msg.header.stamp = message.header.stamp
+        zupt_msg.header.frame_id = self._base_frame
+
+        zupt_msg.twist.twist.linear.x = 0.0
+        zupt_msg.twist.twist.linear.y = 0.0
+        zupt_msg.twist.twist.linear.z = 0.0
+
+        zupt_msg.twist.twist.angular.x = 0.0
+        zupt_msg.twist.twist.angular.y = 0.0
+        zupt_msg.twist.twist.angular.z = 0.0
+
+        zupt_msg.twist.covariance = _make_twist_cov(
+            float(zupt_vx_variance),
+            large=DEFAULT_LARGE_COVARIANCE,
+        )
+
+        self._zupt_pub.publish(zupt_msg)

--- a/oasis_control/setup.py
+++ b/oasis_control/setup.py
@@ -79,6 +79,7 @@ setuptools.setup(
             "lab_manager_telemetrix = oasis_control.cli.lab_manager_telemetrix_cli:main",
             "leonardo_manager = oasis_control.cli.leonardo_manager_cli:main",
             "tilt_sensor = oasis_control.cli.tilt_sensor_cli:main",
+            "zupt_detector = oasis_control.cli.zupt_detector_cli:main",
         ],
     },
 )

--- a/oasis_control/test/test_velocity_estimator.py
+++ b/oasis_control/test/test_velocity_estimator.py
@@ -1,0 +1,83 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""Tests for the velocity estimator."""
+
+from __future__ import annotations
+
+import math
+from typing import cast
+
+from oasis_control.localization.velocity_estimator import VelocityEstimator
+from oasis_control.localization.velocity_estimator import VelocityEstimatorConfig
+
+
+def _make_estimator() -> VelocityEstimator:
+    config: VelocityEstimatorConfig = VelocityEstimatorConfig(
+        process_noise_v=0.0,
+        process_noise_b=0.0,
+        initial_speed_sigma=0.1,
+        initial_bias_sigma=0.1,
+        max_dt_sec=0.2,
+        min_dt_sec=0.0,
+    )
+    return VelocityEstimator(config)
+
+
+def test_predict_integrates_forward_accel() -> None:
+    estimator: VelocityEstimator = _make_estimator()
+
+    estimator.predict(0.0, 1.0)
+    estimator.predict(0.1, 1.0)
+
+    v: float = estimator.get_velocity_mps()
+
+    assert math.isclose(v, 0.1, rel_tol=1e-6, abs_tol=1e-9)
+
+
+def test_predict_clamps_large_dt() -> None:
+    estimator: VelocityEstimator = _make_estimator()
+
+    estimator.predict(0.0, 1.0)
+    diagnostics: dict[str, object] = estimator.predict(1.0, 1.0)
+
+    dt_clamped: bool = cast(bool, diagnostics["dt_clamped"])
+    v: float = estimator.get_velocity_mps()
+
+    assert dt_clamped is True
+    assert math.isclose(v, 0.0, rel_tol=1e-6, abs_tol=1e-9)
+
+
+def test_zupt_update_reduces_speed() -> None:
+    estimator: VelocityEstimator = _make_estimator()
+
+    estimator.predict(0.0, 1.0)
+    estimator.predict(0.1, 1.0)
+
+    v_before: float = estimator.get_velocity_mps()
+    estimator.update_zupt(0.1, 0.01)
+    v_after: float = estimator.get_velocity_mps()
+
+    assert abs(v_after) < abs(v_before)
+
+
+def test_non_finite_predict_is_ignored() -> None:
+    estimator: VelocityEstimator = _make_estimator()
+
+    estimator.predict(0.0, 1.0)
+    v_before: float = estimator.get_velocity_mps()
+
+    estimator.predict(0.1, math.nan)
+    v_after: float = estimator.get_velocity_mps()
+    snapshot: dict[str, object] = estimator.get_diagnostics_snapshot()
+    last_reason: str = cast(str, snapshot["last_reason"])
+
+    assert math.isclose(v_before, v_after, rel_tol=1e-6, abs_tol=1e-9)
+    assert last_reason == "predict_non_finite"

--- a/oasis_control/test/test_zupt_detector.py
+++ b/oasis_control/test/test_zupt_detector.py
@@ -1,0 +1,133 @@
+################################################################################
+#
+#  Copyright (C) 2026 Garrett Brown
+#  This file is part of OASIS - https://github.com/eigendude/OASIS
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  See DOCS/LICENSING.md for more information.
+#
+################################################################################
+
+"""Tests for the ZUPT detector."""
+
+from __future__ import annotations
+
+import math
+from typing import cast
+
+import numpy as np
+
+from oasis_control.localization.zupt_detector import ZuptDetector
+from oasis_control.localization.zupt_detector import ZuptDetectorConfig
+
+
+def _make_detector() -> ZuptDetector:
+    config = ZuptDetectorConfig(
+        min_stationary_sec=0.2,
+        min_exit_sec=0.05,
+        zupt_anneal_tau_sec=0.2,
+    )
+    return ZuptDetector(config)
+
+
+def test_enters_stationary_with_quiet_gyro() -> None:
+    detector = _make_detector()
+    detector.set_duty_cycle(0.0)
+
+    omega = np.zeros(3)
+    cov = np.eye(3) * 0.01
+
+    detector.update(0.0, omega, cov)
+    result = detector.update(0.2, omega, cov)
+
+    assert result["stationary"] is True
+    assert result["should_publish_zupt"] is True
+
+
+def test_does_not_enter_stationary_when_duty_nonzero() -> None:
+    detector = _make_detector()
+    detector.set_duty_cycle(0.2)
+
+    omega = np.zeros(3)
+    cov = np.eye(3) * 0.01
+
+    detector.update(0.0, omega, cov)
+    result = detector.update(0.2, omega, cov)
+
+    assert result["stationary"] is False
+
+
+def test_exits_stationary_when_duty_nonzero() -> None:
+    detector = _make_detector()
+    detector.set_duty_cycle(0.0)
+
+    omega = np.zeros(3)
+    cov = np.eye(3) * 0.01
+
+    detector.update(0.0, omega, cov)
+    detector.update(0.2, omega, cov)
+    detector.set_duty_cycle(0.5)
+    result = detector.update(0.26, omega, cov)
+
+    assert result["stationary"] is False
+
+
+def test_exits_stationary_when_gyro_loud() -> None:
+    detector = _make_detector()
+    detector.set_duty_cycle(0.0)
+
+    quiet_omega = np.zeros(3)
+    loud_omega = np.array([1.0, 0.0, 0.0])
+    cov = np.eye(3) * 0.01
+
+    detector.update(0.0, quiet_omega, cov)
+    detector.update(0.2, quiet_omega, cov)
+    result = detector.update(0.26, loud_omega, cov)
+
+    assert result["stationary"] is False
+
+
+def test_mahalanobis_gate_responds_to_tiny_covariance() -> None:
+    detector = _make_detector()
+    detector.set_duty_cycle(0.0)
+
+    omega = np.array([0.2, 0.0, 0.0])
+    cov = np.eye(3) * 1e-6
+
+    result = detector.update(0.0, omega, cov)
+    diagnostics = cast(dict[str, float], result["diagnostics"])
+
+    assert diagnostics["d2"] > detector.state.last_gate_exit
+
+
+def test_regularization_handles_singular_covariance() -> None:
+    detector = _make_detector()
+    detector.set_duty_cycle(0.0)
+
+    omega = np.zeros(3)
+    cov = np.zeros((3, 3))
+
+    result = detector.update(0.0, omega, cov)
+    diagnostics = cast(dict[str, float], result["diagnostics"])
+
+    assert math.isfinite(diagnostics["d2"])
+
+
+def test_annealing_decreases_variance_with_dwell() -> None:
+    detector = _make_detector()
+    detector.set_duty_cycle(0.0)
+
+    omega = np.zeros(3)
+    cov = np.eye(3) * 0.01
+
+    detector.update(0.0, omega, cov)
+    detector.update(0.2, omega, cov)
+    result_start = detector.update(0.25, omega, cov)
+    result_later = detector.update(0.45, omega, cov)
+
+    var_start = cast(float, result_start["zupt_vx_variance"])
+    var_later = cast(float, result_later["zupt_vx_variance"])
+
+    assert isinstance(var_start, float)
+    assert isinstance(var_later, float)
+    assert var_later < var_start


### PR DESCRIPTION
### Motivation

- Provide a small, ROS-agnostic 1D forward velocity estimator (pure algorithm module) for later wrapping by a ROS node.
- Use a minimal 2-state Kalman filter (state [v_f, b_f]) with IMU-forward acceleration propagation and ZUPT corrections to bound drift and learn bias.

### Description

- Added `oasis_control/localization/velocity_estimator.py` implementing `VelocityEstimatorConfig`, `VelocityEstimatorState`, `VelocityEstimatorCounters`, and `VelocityEstimator` dataclasses and class. 
- Implemented `predict(...)` using the discrete model v_{k+1}=v_k+(a_f-b_f)*dt and F/Q construction (Q = diag(q_v*dt, q_b*dt)); documented that process noise are continuous-time spectral-density-ish and scaled by `dt`.
- Implemented `update_zupt(...)` applying a ZUPT measurement z=0 with Joseph-form covariance update and safe handling of small/non-finite variances; stored diagnostics (`innovation`, `S`, `K`, `zupt_var`, etc.).
- Added robustness: numpy float64 everywhere, finiteness checks to ignore NaN/Inf inputs, dt clamping to `min_dt_sec`/`max_dt_sec` with `dt_clamped` flag, covariance symmetrization (`P = 0.5*(P+P.T)`), and a floor for ZUPT variance to avoid divide-by-zero.
- Exposed getters and a `get_diagnostics_snapshot()` helper plus a minimal `run_velocity_estimator_self_test()` helper to facilitate unit testing and quick local checks.
- Added unit tests at `oasis_control/test/test_velocity_estimator.py` covering integration of forward acceleration, dt clamping behavior, ZUPT correction reducing speed, and handling of non-finite predict inputs.

### Testing

- Ran the project sanity and static checks via `tox`; formatting and lint steps passed (black/isort/flake8 checks executed). 
- `mypy` step failed in the existing `oasis_control` package (`mypy oasis_control` reported pre-existing `no-redef` errors in `oasis_control/nodes/zupt_detector_node.py`), preventing the full test phase from running inside `tox`.
- The new unit tests were added (`oasis_control/test/test_velocity_estimator.py`) and are ready to run once the existing mypy issues are resolved in the repo; the estimator includes a self-test helper (`run_velocity_estimator_self_test()`) for local validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e62fc105483269f4ae7471dbc1805)